### PR TITLE
Changing the duration to long (int64) as accepted by zipkin API

### DIFF
--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -118,7 +118,7 @@ public class ZipkinService {
         span.setRemoteEndpoint(remoteEndpoint);
       }
       span.setTimestamp(convertToMicroSeconds(message.getTimestamp()));
-      span.setDuration(Math.toIntExact(duration));
+      span.setDuration(duration);
       span.setTags(messageTags);
       traces.add(span);
     }

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinSpanResponse.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinSpanResponse.java
@@ -23,8 +23,8 @@ public class ZipkinSpanResponse {
   private ZipkinEndpointResponse remoteEndpoint = null;
 
   @JsonProperty("duration")
-  // Zipkin spec defines this is integer, even though a long seems like it would be more appropriate
-  private int durationMicros;
+  // Zipkin spec defines this is integer64, so long seems to be more appropriate
+  private long durationMicros;
 
   private String kind;
 
@@ -48,7 +48,7 @@ public class ZipkinSpanResponse {
     this.timestampMicros = timestampMicros;
   }
 
-  public void setDuration(int durationMicros) {
+  public void setDuration(long durationMicros) {
     this.durationMicros = durationMicros;
   }
 
@@ -96,7 +96,7 @@ public class ZipkinSpanResponse {
     return timestampMicros;
   }
 
-  public int getDuration() {
+  public long getDuration() {
     return durationMicros;
   }
 


### PR DESCRIPTION
###  Summary
Changing the duration to long (int64) as accepted by zipkin API. Currently, spans of duration > 2^31 do not load anything via zipkin API. The actual zipkin api supports duration of type integer (int64)

Swagger doc of Zipkin API: https://zipkin.io/zipkin-api/#/

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
