### PR TITLE
Add nesting depth limit to SpanFormatter

### DIFF
--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -158,6 +158,9 @@ public class SpanFormatter {
     List<Trace.KeyValue> tags = new ArrayList<>();
     if (value instanceof Map) {
       if (depthLimit <= 0) {
+        // We could encode the value with json instead of toString to make it more friendly to API consumers.
+        // NB: Using BINARY here to ensure it is not indexed.
+        tags.add(makeTraceKV(key, value.toString(), Schema.SchemaFieldType.BINARY));
         return tags;
       }
 

--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -21,7 +21,7 @@ public class SpanFormatter {
 
   public static final String DEFAULT_LOG_MESSAGE_TYPE = "INFO";
   public static final String DEFAULT_INDEX_NAME = "unknown";
-  public static final int DEPTH_LIMIT = 3;
+  public static final int DEPTH_LIMIT = 1;
 
   public static Timestamp parseDate(String dateStr, Schema.SchemaFieldType type) {
     Instant instant;

--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -21,7 +21,7 @@ public class SpanFormatter {
 
   public static final String DEFAULT_LOG_MESSAGE_TYPE = "INFO";
   public static final String DEFAULT_INDEX_NAME = "unknown";
-  public static final int DEPTH_LIMIT = 1;
+  public static final int DEPTH_LIMIT = 3;
 
   public static Timestamp parseDate(String dateStr, Schema.SchemaFieldType type) {
     Instant instant;

--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -158,7 +158,8 @@ public class SpanFormatter {
     List<Trace.KeyValue> tags = new ArrayList<>();
     if (value instanceof Map) {
       if (depthLimit <= 0) {
-        // We could encode the value with json instead of toString to make it more friendly to API consumers.
+        // We could encode the value with json instead of toString to make it more friendly to API
+        // consumers.
         // NB: Using BINARY here to ensure it is not indexed.
         tags.add(makeTraceKV(key, value.toString(), Schema.SchemaFieldType.BINARY));
         return tags;

--- a/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
+++ b/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
@@ -173,13 +173,22 @@ public class SpanFormatterWithSchemaTest {
     Map<String, Object> head = nestedMap.apply(List.of("a", "b", "c", "d", "e", "f"));
     List<Trace.KeyValue> list;
     list = SpanFormatter.convertKVtoProtoDefault("init", head, schema);
-    assertThat(list.size()).isEqualTo(0);
+    assertThat(list.size()).isEqualTo(1);
+    assertThat(list.getFirst().getKey()).isEqualTo("init.a.b");
+    assertThat(list.getFirst().getVBinary().toString(StandardCharsets.UTF_8))
+        .isEqualTo("{c={d={e={f=value}}}}");
+
+    list = SpanFormatter.convertKVtoProtoDefault("init", head, schema, 0);
+    assertThat(list.size()).isEqualTo(1);
+    assertThat(list.getFirst().getKey()).isEqualTo("init");
 
     list = SpanFormatter.convertKVtoProtoDefault("init", head, schema, 1);
-    assertThat(list.size()).isEqualTo(0);
+    assertThat(list.size()).isEqualTo(1);
+    assertThat(list.getFirst().getKey()).isEqualTo("init.a");
 
     list = SpanFormatter.convertKVtoProtoDefault("init", head, schema, 2);
-    assertThat(list.size()).isEqualTo(0);
+    assertThat(list.size()).isEqualTo(1);
+    assertThat(list.getFirst().getKey()).isEqualTo("init.a.b");
 
     list = SpanFormatter.convertKVtoProtoDefault("init", head, schema, 6);
     assertThat(list.size()).isEqualTo(1);
@@ -193,7 +202,8 @@ public class SpanFormatterWithSchemaTest {
     list =
         SpanFormatter.convertKVtoProtoDefault(
             "init", nestedMap.apply(List.of("a", "b", "c")), schema);
-    assertThat(list.size()).isEqualTo(0);
+    assertThat(list.size()).isEqualTo(1);
+    assertThat(list.getFirst().getKey()).isEqualTo("init.a.b");
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
+++ b/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
@@ -175,8 +175,7 @@ public class SpanFormatterWithSchemaTest {
     list = SpanFormatter.convertKVtoProtoDefault("init", head, schema);
     assertThat(list.size()).isEqualTo(1);
     assertThat(list.getFirst().getKey()).isEqualTo("init.a.b");
-    assertThat(list.getFirst().getVBinary().toString(StandardCharsets.UTF_8))
-        .isEqualTo("{c={d={e={f=value}}}}");
+    assertThat(list.getFirst().getVBinary().toStringUtf8()).isEqualTo("{c={d={e={f=value}}}}");
 
     list = SpanFormatter.convertKVtoProtoDefault("init", head, schema, 0);
     assertThat(list.size()).isEqualTo(1);


### PR DESCRIPTION
###  Summary

Currently the preprocessor will generate fields for all the nested keys in a given document even if they are highly nested. This can cause problems if there are many keys or keys that represent ids with a large cardinality. The index node's equivalent code has a limit on how deep to nest, but the preprocessor's code path just had a TODO.

This patch adds a depth limit so that fields that are too deeply nested are handled differently.

Currently it just ignores them, but it could do something else.

Rather than deciding on a place to put the depth limit in config, I hard coded it in a constant, but I'm thinking it'd make sense to add it to the schema config.

### Requirements

* [ ] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
