### PR TITLE
Cache node ignores fields that start with `.` rather than failing to load the segment

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
+++ b/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
@@ -345,10 +345,8 @@ public class OpenSearchAdapter {
       XContentBuilder builder =
           XContentFactory.jsonBuilder().startObject().startObject("_doc").startObject("properties");
       // Filter out fields that start with a dot (.), e.g. ".ipv4". This is a temporary fix until we
-      // sanitize
-      // elsewhere in the pipeline. It is currently possible for index nodes to publish a
-      // segment/snapshot
-      // with this data, which causes cache nodes to fail to load the segment.
+      // sanitize elsewhere in the pipeline. It is currently possible for index nodes to publish a
+      // segment/snapshot with this data, which causes cache nodes to fail to load the segment.
       rootNode
           .fields()
           .forEachRemaining(

--- a/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
+++ b/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
@@ -344,19 +344,16 @@ public class OpenSearchAdapter {
     try {
       XContentBuilder builder =
           XContentFactory.jsonBuilder().startObject().startObject("_doc").startObject("properties");
-      // Filter out fields that start with a dot (.). This is a hack. Probably want to sanitize
-      // elsewhere, potentially in the index node. Maybe the indexing library has a bug? Or we
-      // should sanitize before
-      // sending to preprocessor or in preprocessor.
-      //
-      // I don't love this, but given the opensearch library implementation, I think this would be
-      // the way to handle
-      // this issue in the cache node.
+      // Filter out fields that start with a dot (.), e.g. ".ipv4". This is a temporary fix until we
+      // sanitize
+      // elsewhere in the pipeline. It is currently possible for index nodes to publish a
+      // segment/snapshot
+      // with this data, which causes cache nodes to fail to load the segment.
       rootNode
           .fields()
           .forEachRemaining(
               (entry) -> {
-                // if the root node includes a field that is empty, we need to skip it
+                // if the root node includes a field that is empty, we need to skip it.
                 if (!entry.getKey().equals("")) {
                   buildObject(builder, entry);
                 } else {

--- a/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
+++ b/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
@@ -360,7 +360,8 @@ public class OpenSearchAdapter {
                 if (!entry.getKey().equals("")) {
                   buildObject(builder, entry);
                 } else {
-                  LOG.warn("Skipping invalid field name '{}'", entry.getValue().toString());
+                  LOG.warn(
+                      "Skipping empty field name with value '{}'", entry.getValue().toString());
                 }
               });
 

--- a/astra/src/test/java/com/slack/astra/logstore/opensearch/OpenSearchAdapterTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/opensearch/OpenSearchAdapterTest.java
@@ -200,4 +200,24 @@ public class OpenSearchAdapterTest {
       org.junit.jupiter.api.Assertions.fail("Unexpected exception thrown: " + e.getMessage());
     }
   }
+
+  @Test
+  public void shouldHandleFieldsWithDotInMiddle() throws IOException {
+    // Define a schema with a field name starting with a dot
+    ImmutableMap<String, LuceneFieldDef> chunkSchema =
+        ImmutableMap.of(
+            "something.ipv4",
+            new LuceneFieldDef("something.ipv4", FieldType.IP.name, false, true, true));
+
+    // Create a new OpenSearchAdapter instance with this schema
+    OpenSearchAdapter adapter = new OpenSearchAdapter(chunkSchema);
+
+    // Run loadSchema and assert it passes (does not throw an exception)
+    try {
+      adapter.loadSchema(); // This should pass
+    } catch (RuntimeException e) {
+      // The test fails if there is any exception
+      org.junit.jupiter.api.Assertions.fail("Unexpected exception thrown: " + e.getMessage());
+    }
+  }
 }

--- a/astra/src/test/java/com/slack/astra/logstore/opensearch/OpenSearchAdapterTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/opensearch/OpenSearchAdapterTest.java
@@ -181,4 +181,23 @@ public class OpenSearchAdapterTest {
     assertThat(filterNullEndQuery.get().toString()).contains(String.valueOf(100L));
     assertThat(filterNullEndQuery.get().toString()).contains(String.valueOf(Long.MAX_VALUE));
   }
+
+  @Test
+  public void shouldHandleFieldsStartingWithDot() throws IOException {
+    // Define a schema with a field name starting with a dot
+    ImmutableMap<String, LuceneFieldDef> chunkSchema =
+        ImmutableMap.of(".ipv4", new LuceneFieldDef(".ipv4", FieldType.IP.name, false, true, true));
+
+    // Create a new OpenSearchAdapter instance with this schema
+    OpenSearchAdapter adapter = new OpenSearchAdapter(chunkSchema);
+
+    // Run loadSchema and assert it passes (does not throw an exception)
+    try {
+      adapter.loadSchema(); // This should pass
+    } catch (RuntimeException e) {
+      // The test fails if the exception message contains "name cannot be empty string"
+      assertThat(e.getMessage()).doesNotContain("name cannot be empty string");
+      org.junit.jupiter.api.Assertions.fail("Unexpected exception thrown: " + e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
###  Summary
The index nodes are uploading field names that start with a `.`. This is unsupported in the opensearch library deserialization logic that the cache nodes use to load a segment. There is probably a better fix in the pipeline, but until this is fixed on the pipeline, cache nodes cannot load data. Futhermore, old segments wouldn't be able to load even when this is fixed on ingestion.

Lets put this in until ingestion is sanitized and all new segments in the cache nodes have the sanitized data.

Error we're encountering in cache nodes:
**exception.error_root_cause_stack_trace**
```
java.lang.IllegalArgumentException: name cannot be empty string
	at org.opensearch.index.mapper.FieldMapper.<init>(FieldMapper.java:218)
	at org.opensearch.index.mapper.ParametrizedFieldMapper.<init>(ParametrizedFieldMapper.java:84)
	at org.opensearch.index.mapper.BinaryFieldMapper.<init>(BinaryFieldMapper.java:187)
	at org.opensearch.index.mapper.BinaryFieldMapper$Builder.build(BinaryFieldMapper.java:108)
	at org.opensearch.index.mapper.BinaryFieldMapper$Builder.build(BinaryFieldMapper.java:82)
	at org.opensearch.index.mapper.ObjectMapper$Builder.build(ObjectMapper.java:216)
	at org.opensearch.index.mapper.RootObjectMapper$Builder.build(RootObjectMapper.java:111)
	at org.opensearch.index.mapper.DocumentMapper$Builder.<init>(DocumentMapper.java:91)
	at org.opensearch.index.mapper.DocumentMapperParser.parse(DocumentMapperParser.java:144)
	at org.opensearch.index.mapper.DocumentMapperParser.parse(DocumentMapperParser.java:133)
	at org.opensearch.index.mapper.MapperService.internalMerge(MapperService.java:438)
	at org.opensearch.index.mapper.MapperService.merge(MapperService.java:416)
	at com.slack.astra.logstore.opensearch.OpenSearchAdapter.loadSchema(OpenSearchAdapter.java:350)
	at com.slack.astra.logstore.search.LogIndexSearcherImpl.<init>(LogIndexSearcherImpl.java:93)
	at com.slack.astra.chunk.ReadOnlyChunkImpl.handleChunkAssignment(ReadOnlyChunkImpl.java:417)
	at com.slack.astra.chunk.ReadOnlyChunkImpl.lambda$cacheNodeListener$0(ReadOnlyChunkImpl.java:341)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
```

**exception.error_stack_trace**
```
java.lang.RuntimeException: MapperParsingException[Failed to parse mapping [_doc]: name cannot be empty string]; nested: IllegalArgumentException[name cannot be empty string];
	at com.slack.astra.logstore.opensearch.OpenSearchAdapter.loadSchema(OpenSearchAdapter.java:355)
	at com.slack.astra.logstore.search.LogIndexSearcherImpl.<init>(LogIndexSearcherImpl.java:93)
	at com.slack.astra.chunk.ReadOnlyChunkImpl.handleChunkAssignment(ReadOnlyChunkImpl.java:417)
	at com.slack.astra.chunk.ReadOnlyChunkImpl.lambda$cacheNodeListener$0(ReadOnlyChunkImpl.java:341)
	at java.base/java.lang.VirtualThread.run(VirtualThread.java:329)
Caused by: MapperParsingException[Failed to parse mapping [_doc]: name cannot be empty string]; nested: IllegalArgumentException[name cannot be empty string];
	at org.opensearch.index.mapper.MapperService.internalMerge(MapperService.java:440)
	at org.opensearch.index.mapper.MapperService.merge(MapperService.java:416)
	at com.slack.astra.logstore.opensearch.OpenSearchAdapter.loadSchema(OpenSearchAdapter.java:350)
	... 4 more
Caused by: java.lang.IllegalArgumentException: name cannot be empty string
	at org.opensearch.index.mapper.FieldMapper.<init>(FieldMapper.java:218)
	at org.opensearch.index.mapper.ParametrizedFieldMapper.<init>(ParametrizedFieldMapper.java:84)
	at org.opensearch.index.mapper.BinaryFieldMapper.<init>(BinaryFieldMapper.java:187)
	at org.opensearch.index.mapper.BinaryFieldMapper$Builder.build(BinaryFieldMapper.java:108)
	at org.opensearch.index.mapper.BinaryFieldMapper$Builder.build(BinaryFieldMapper.java:82)
	at org.opensearch.index.mapper.ObjectMapper$Builder.build(ObjectMapper.java:216)
	at org.opensearch.index.mapper.RootObjectMapper$Builder.build(RootObjectMapper.java:111)
	at org.opensearch.index.mapper.DocumentMapper$Builder.<init>(DocumentMapper.java:91)
	at org.opensearch.index.mapper.DocumentMapperParser.parse(DocumentMapperParser.java:144)
	at org.opensearch.index.mapper.DocumentMapperParser.parse(DocumentMapperParser.java:1...
```

### Requirements

* [ ] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
