### PR TITLE
If a chunk fails to load when assigned, run the eviction logic

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
@@ -341,9 +341,8 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
           Thread.ofVirtual().start(() -> handleChunkAssignment(cacheSlotMetadata));
         } else if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.EVICT)) {
           LOG.info("Chunk - EVICT received - {}", cacheSlotMetadata);
-          if (!cacheSlotLastKnownState.equals(Metadata.CacheSlotMetadata.CacheSlotState.LIVE)
-              && !cacheSlotLastKnownState.equals(
-                  Metadata.CacheSlotMetadata.CacheSlotState.LOADING)) {
+          if (!
+          EnumSet.of(Metadata.CacheSlotMetadata.CacheSlotState.LIVE, Metadata.CacheSlotMetadata.CacheSlotState.LOADING).contains(cacheSlotLastKnownState)) {
             LOG.warn(
                 "Unexpected state transition from {} to {} - {}",
                 cacheSlotLastKnownState,

--- a/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;

--- a/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
@@ -341,7 +341,9 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
           Thread.ofVirtual().start(() -> handleChunkAssignment(cacheSlotMetadata));
         } else if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.EVICT)) {
           LOG.info("Chunk - EVICT received - {}", cacheSlotMetadata);
-          if (!cacheSlotLastKnownState.equals(Metadata.CacheSlotMetadata.CacheSlotState.LIVE)) {
+          if (!cacheSlotLastKnownState.equals(Metadata.CacheSlotMetadata.CacheSlotState.LIVE)
+              && !cacheSlotLastKnownState.equals(
+                  Metadata.CacheSlotMetadata.CacheSlotState.LOADING)) {
             LOG.warn(
                 "Unexpected state transition from {} to {} - {}",
                 cacheSlotLastKnownState,
@@ -433,11 +435,11 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
           TimeUnit.SECONDS.convert(durationNanos, TimeUnit.NANOSECONDS),
           FileUtils.byteCountToDisplaySize(FileUtils.sizeOfDirectory(dataDirectory.toFile())));
     } catch (Exception e) {
-      // if any error occurs during the chunk assignment, try to release the slot for re-assignment,
-      // disregarding any errors
-      setChunkMetadataState(cacheSlotMetadata, Metadata.CacheSlotMetadata.CacheSlotState.FREE);
-      LOG.error("Error handling chunk assignment", e);
+      LOG.error("Error handling chunk assignment: {}\n{}", e, cacheSlotMetadata);
       assignmentTimer.stop(chunkAssignmentTimerFailure);
+      // If any error occurs during the chunk assignment, evict the chunk so eviction code cleans up
+      // the files.
+      setChunkMetadataState(cacheSlotMetadata, Metadata.CacheSlotMetadata.CacheSlotState.EVICT);
     } finally {
       chunkAssignmentLock.unlock();
     }

--- a/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
@@ -434,7 +434,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
           TimeUnit.SECONDS.convert(durationNanos, TimeUnit.NANOSECONDS),
           FileUtils.byteCountToDisplaySize(FileUtils.sizeOfDirectory(dataDirectory.toFile())));
     } catch (Exception e) {
-      LOG.error("Error handling chunk assignment: {}\n{}", e, cacheSlotMetadata);
+      LOG.error("Error handling chunk assignment for cache slot {}:", cacheSlotMetadata, e);
       assignmentTimer.stop(chunkAssignmentTimerFailure);
       // If any error occurs during the chunk assignment, evict the chunk so eviction code cleans up
       // the files.

--- a/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
@@ -341,8 +341,10 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
           Thread.ofVirtual().start(() -> handleChunkAssignment(cacheSlotMetadata));
         } else if (newSlotState.equals(Metadata.CacheSlotMetadata.CacheSlotState.EVICT)) {
           LOG.info("Chunk - EVICT received - {}", cacheSlotMetadata);
-          if (!
-          EnumSet.of(Metadata.CacheSlotMetadata.CacheSlotState.LIVE, Metadata.CacheSlotMetadata.CacheSlotState.LOADING).contains(cacheSlotLastKnownState)) {
+          if (!EnumSet.of(
+                  Metadata.CacheSlotMetadata.CacheSlotState.LIVE,
+                  Metadata.CacheSlotMetadata.CacheSlotState.LOADING)
+              .contains(cacheSlotLastKnownState)) {
             LOG.warn(
                 "Unexpected state transition from {} to {} - {}",
                 cacheSlotLastKnownState,

--- a/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
@@ -631,13 +631,7 @@ public class ReadOnlyChunkImplTest {
     assignReplicaToChunk(cacheSlotMetadataStore, replicaId, readOnlyChunk);
 
     // The expected state transitions are from FREE -> ASSIGNED -> LOADING (encounters some error)
-    // -> EVICT -> EVICTING -> FREE
-    await()
-        .until(
-            () ->
-                readOnlyChunk.getChunkMetadataState()
-                    == Metadata.CacheSlotMetadata.CacheSlotState.LOADING);
-
+    // -> EVICT -> EVICTING -> FREE, the final state being FREE
     await()
         .until(
             () ->


### PR DESCRIPTION
###  Summary
When a chunk is assigned, while in loading state, the following happens:
- files downloaded from s3 (can partially or completely download. can fail). This can fail at partial download when S3 is a bit overloaded.
- the files are parsed
- the schema is loaded and data loaded for serving (can fail). This failure is what sparked this PR

If any of the above steps fail, we want the slot available. The old code marks the slot as `FREE` but this misses cleanup. This change marks the slot as `EVICT` which a listener listens for to do cleanup work. Now the necessary cleanup steps happen. See test confirm the failed assignment but successful eviction.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
