### PR TITLE
makes a zipkin lookback configurable instead of hardcoded

### DIFF
--- a/astra/pom.xml
+++ b/astra/pom.xml
@@ -549,7 +549,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <compilerVersion>${javac.target}</compilerVersion>
+                    <release>${javac.target}</release>
                     <source>${javac.target}</source>
                     <testSource>${javac.target}</testSource>
                     <target>${javac.target}</target>

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -226,7 +226,8 @@ public class Astra {
               .withAnnotatedService(
                   new ZipkinService(
                       astraDistributedQueryService,
-                      astraConfig.getQueryConfig().getZipkinDefaultMaxSpans()))
+                      astraConfig.getQueryConfig().getZipkinDefaultMaxSpans(),
+                      astraConfig.getQueryConfig().getZipkinDefaultLookbackMins()))
               .withGrpcService(astraDistributedQueryService)
               .build();
       services.add(armeriaService);

--- a/astra/src/main/java/com/slack/astra/server/ValidateAstraConfig.java
+++ b/astra/src/main/java/com/slack/astra/server/ValidateAstraConfig.java
@@ -53,6 +53,10 @@ public class ValidateAstraConfig {
     checkArgument(
         queryConfig.getZipkinDefaultMaxSpans() >= 1000,
         "QueryConfig zipkinDefaultMaxSpans cannot less than 1000");
+
+    checkArgument(
+        queryConfig.getZipkinDefaultLookbackMins() >= 1440,
+        "QueryConfig zipkinDefaultLookbackMins cannot less than 1440");
   }
 
   private static void validateCacheConfig(AstraConfigs.CacheConfig cacheConfig) {

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -146,9 +146,8 @@ public class ZipkinService {
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(ZipkinService.class);
-  private static long LOOKBACK_MINS = 60 * 24 * 7;
-
   private final int defaultMaxSpans;
+  private final int defaultLookbackMins;
 
   private final AstraQueryServiceBase searcher;
 
@@ -160,9 +159,11 @@ public class ZipkinService {
           .serializationInclusion(JsonInclude.Include.NON_EMPTY)
           .build();
 
-  public ZipkinService(AstraQueryServiceBase searcher, int defaultMaxSpans) {
+  public ZipkinService(
+      AstraQueryServiceBase searcher, int defaultMaxSpans, int defaultLookbackMins) {
     this.searcher = searcher;
     this.defaultMaxSpans = defaultMaxSpans;
+    this.defaultLookbackMins = defaultLookbackMins;
   }
 
   @Get
@@ -210,13 +211,13 @@ public class ZipkinService {
     String queryString = queryJson.toString();
     long startTime =
         startTimeEpochMs.orElseGet(
-            () -> Instant.now().minus(LOOKBACK_MINS, ChronoUnit.MINUTES).toEpochMilli());
+            () -> Instant.now().minus(this.defaultLookbackMins, ChronoUnit.MINUTES).toEpochMilli());
     // we are adding a buffer to end time also because some machines clock may be ahead of current
     // system clock and those spans would be stored but can't be queried
 
     long endTime =
         endTimeEpochMs.orElseGet(
-            () -> Instant.now().plus(LOOKBACK_MINS, ChronoUnit.MINUTES).toEpochMilli());
+            () -> Instant.now().plus(this.defaultLookbackMins, ChronoUnit.MINUTES).toEpochMilli());
     int howMany = maxSpans.orElse(this.defaultMaxSpans);
 
     brave.Span span = Tracing.currentTracer().currentSpan();

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -222,7 +222,7 @@ public class ZipkinService {
 
     brave.Span span = Tracing.currentTracer().currentSpan();
     span.tag("startTimeEpochMs", String.valueOf(startTime));
-    span.tag("endTimeEpochMs", String.valueOf(endTimeEpochMs));
+    span.tag("endTimeEpochMs", String.valueOf(endTime));
     span.tag("howMany", String.valueOf(howMany));
 
     // TODO: when MAX_SPANS is hit the results will look weird because the index is sorted in

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -86,6 +86,7 @@ message QueryServiceConfig {
   int32 default_query_timeout_ms = 2;
   string managerConnectString = 3;
   int32 zipkin_default_max_spans = 4;
+  int32 zipkin_default_lookback_mins = 5;
 }
 
 enum KafkaOffsetLocation {

--- a/astra/src/test/java/com/slack/astra/server/AstraConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraConfigTest.java
@@ -200,6 +200,8 @@ public class AstraConfigTest {
     assertThat(queryServiceConfig.getServerConfig().getServerPort()).isEqualTo(8081);
     assertThat(queryServiceConfig.getServerConfig().getServerAddress()).isEqualTo("1.2.3.4");
     assertThat(queryServiceConfig.getManagerConnectString()).isEqualTo("localhost:8083");
+    assertThat(queryServiceConfig.getZipkinDefaultLookbackMins())
+        .isEqualTo(10080); // 7 days in minutes
 
     final AstraConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final AstraConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();
@@ -366,6 +368,7 @@ public class AstraConfigTest {
     assertThat(readConfig.getServerConfig().getServerPort()).isEqualTo(8081);
     assertThat(readConfig.getServerConfig().getServerAddress()).isEqualTo("1.2.3.4");
     assertThat(readConfig.getManagerConnectString()).isEqualTo("localhost:8083");
+    assertThat(readConfig.getZipkinDefaultLookbackMins()).isEqualTo(10080); // 7 days in minutes
 
     final AstraConfigs.MetadataStoreConfig metadataStoreConfig = config.getMetadataStoreConfig();
     final AstraConfigs.ZookeeperConfig zookeeperConfig = metadataStoreConfig.getZookeeperConfig();

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
@@ -33,11 +33,12 @@ public class ZipkinServiceTest {
   private AstraSearch.SearchResult mockSearchResult;
 
   private static final int defaultMaxSpans = 2000;
+  private static final int defaultLookbackMins = 60 * 24 * 7;
 
   @BeforeEach
   public void setup() throws IOException {
     MockitoAnnotations.openMocks(this);
-    zipkinService = spy(new ZipkinService(searcher, defaultMaxSpans));
+    zipkinService = spy(new ZipkinService(searcher, defaultMaxSpans, defaultLookbackMins));
     // Build mockSearchResult
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode jsonNode =

--- a/astra/src/test/resources/test_config.json
+++ b/astra/src/test/resources/test_config.json
@@ -58,6 +58,7 @@
     },
     "defaultQueryTimeoutMs": 1500,
     "zipkinDefaultMaxSpans": 20000,
+    "zipkinDefaultLookbackMins": 10080,
     "managerConnectString": "localhost:8083"
   },
   "metadataStoreConfig": {

--- a/astra/src/test/resources/test_config.yaml
+++ b/astra/src/test/resources/test_config.yaml
@@ -34,6 +34,7 @@ queryConfig:
     requestTimeoutMs: 3000
   defaultQueryTimeoutMs: 2500
   zipkinDefaultMaxSpans: 20000
+  zipkinDefaultLookbackMins: 10080
   managerConnectString: localhost:8083
 
 s3Config:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -51,6 +51,7 @@ queryConfig:
     requestTimeoutMs: ${ASTRA_QUERY_REQUEST_TIMEOUT_MS:-5000}
   defaultQueryTimeoutMs: ${ASTRA_QUERY_DEFAULT_QUERY_TIMEOUT_MS:-3000}
   zipkinDefaultMaxSpans: ${ASTRA_QUERY_ZIPKIN_DEFAULT_MAX_SPANS:-20000}
+  zipkinDefaultLookbackMins: ${ASTRA_QUERY_ZIPKIN_DEFAULT_LOOKBACK_MINS:-10080}
   managerConnectString: ${ASTRA_MANAGER_CONNECTION_STRING:-localhost:8083}
 
 metadataStoreConfig:


### PR DESCRIPTION
###  Summary
Makes the zipkin lookback configurable. the default value is the current value which is 1 week of minutes.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
