### PR TITLE
Dynamic indexing with max fields protection that always indexes fields explicitly defined in the schema

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.lucene.document.Document;
@@ -46,6 +47,9 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
 
   // TODO: In future, make this value configurable.
   private static final int MAX_NESTING_DEPTH = 3;
+
+  private static final int MAX_DYNAMIC_FIELDS =
+      Integer.parseInt(System.getProperty("astra.mapping.dynamicFieldsLimit", "1500"));
 
   /**
    * This enum tracks the field conflict policy for a chunk.
@@ -72,10 +76,18 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
       final Object value,
       final Schema.SchemaFieldType schemaFieldType,
       final String keyPrefix,
+      final Trace.IndexStrategy indexStrategy,
       int nestingDepth) {
     // If value is a list, convert the value to a String and index the field.
     if (value instanceof List) {
-      addField(doc, key, Strings.join((List) value, ','), schemaFieldType, keyPrefix, nestingDepth);
+      addField(
+          doc,
+          key,
+          Strings.join((List) value, ','),
+          schemaFieldType,
+          keyPrefix,
+          indexStrategy,
+          nestingDepth);
       return;
     }
 
@@ -84,13 +96,26 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
     if (value instanceof Map) {
       if (nestingDepth >= MAX_NESTING_DEPTH) {
         // Once max nesting depth is reached, index the field as a string.
-        addField(doc, key, value.toString(), schemaFieldType, keyPrefix, nestingDepth + 1);
+        addField(
+            doc,
+            key,
+            value.toString(),
+            schemaFieldType,
+            keyPrefix,
+            indexStrategy,
+            nestingDepth + 1);
       } else {
         Map<Object, Object> mapValue = (Map<Object, Object>) value;
         for (Object k : mapValue.keySet()) {
           if (k instanceof String) {
             addField(
-                doc, (String) k, mapValue.get(k), schemaFieldType, fieldName, nestingDepth + 1);
+                doc,
+                (String) k,
+                mapValue.get(k),
+                schemaFieldType,
+                fieldName,
+                indexStrategy,
+                nestingDepth + 1);
           } else {
             throw new FieldDefMismatchException(
                 String.format(
@@ -103,7 +128,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
 
     FieldType valueType = FieldType.valueOf(schemaFieldType.name());
     if (!fieldDefMap.containsKey(fieldName)) {
-      indexNewField(doc, fieldName, value, schemaFieldType);
+      indexNewField(doc, fieldName, value, schemaFieldType, indexStrategy);
     } else {
       LuceneFieldDef registeredField = fieldDefMap.get(fieldName);
       // If the field types are same or the fields are type aliases
@@ -137,7 +162,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
                 registeredField.fieldType);
             // Add new field with new type
             String newFieldName = makeNewFieldOfType(fieldName, valueType);
-            indexNewField(doc, newFieldName, value, schemaFieldType);
+            indexNewField(doc, newFieldName, value, schemaFieldType, indexStrategy);
             LOG.debug(
                 "Added new field {} of type {} due to type conflict", newFieldName, valueType);
             convertAndDuplicateFieldCounter.increment();
@@ -153,11 +178,40 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
   }
 
   private void indexNewField(
-      Document doc, String key, Object value, Schema.SchemaFieldType schemaFieldType) {
-    final LuceneFieldDef newFieldDef = getLuceneFieldDef(key, schemaFieldType);
+      Document doc,
+      String key,
+      Object value,
+      Schema.SchemaFieldType schemaFieldType,
+      Trace.IndexStrategy indexStrategy) {
     totalFieldsCounter.increment();
-    fieldDefMap.put(key, newFieldDef);
-    indexTypedField(doc, key, value, newFieldDef);
+    final LuceneFieldDef newFieldDef = getLuceneFieldDef(key, schemaFieldType, indexStrategy);
+    // UNKNOWN - old behavior - this is when the preprocessor is on an "older version" without this
+    // proto set
+    if (indexStrategy.equals(Trace.IndexStrategy.UNKNOWN)) {
+      fieldDefMap.put(key, newFieldDef);
+      indexTypedField(doc, key, value, newFieldDef);
+    } else if (indexStrategy.equals(Trace.IndexStrategy.IN_SCHEMA_INDEX)) {
+      fieldDefMap.put(key, newFieldDef);
+      indexTypedField(doc, key, value, newFieldDef);
+    } else if (indexStrategy.equals(Trace.IndexStrategy.DYNAMIC_INDEX)) {
+      int numDynamicFields = dynamicFields.getAndIncrement();
+      if (numDynamicFields <= MAX_DYNAMIC_FIELDS) {
+        fieldDefMap.put(key, newFieldDef);
+        indexTypedField(doc, key, value, newFieldDef);
+        LOG.info(
+            "Added new field {} of type {} due to dynamic index strategy, {}/{} dynamic fields added",
+            key,
+            schemaFieldType,
+            numDynamicFields,
+            MAX_DYNAMIC_FIELDS);
+      } else {
+        droppedFieldsCounter.increment();
+        LOG.info(
+            "Dropped field {} due to field limit of {} fields. The field is not indexed.",
+            key,
+            MAX_DYNAMIC_FIELDS);
+      }
+    }
   }
 
   private boolean isStored(String fieldName) {
@@ -178,12 +232,14 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
   // that way we can make isIndexed/isStored etc. configurable
   // we don't put it in th proto today but when we move to ZK we'll change the KeyValue to take
   // SchemaField info in the future
-  private LuceneFieldDef getLuceneFieldDef(String key, Schema.SchemaFieldType schemaFieldType) {
+  private LuceneFieldDef getLuceneFieldDef(
+      String key, Schema.SchemaFieldType schemaFieldType, Trace.IndexStrategy indexStrategy) {
+    boolean indexSignal = !indexStrategy.equals(Trace.IndexStrategy.DO_NOT_INDEX);
     return new LuceneFieldDef(
         key,
         schemaFieldType.name(),
         isStored(key),
-        isIndexed(schemaFieldType, key),
+        isIndexed(schemaFieldType, key) && indexSignal,
         isDocValueField(schemaFieldType, key));
   }
 
@@ -239,6 +295,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
   private final FieldConflictPolicy indexFieldConflictPolicy;
   private final boolean enableFullTextSearch;
   private final ConcurrentHashMap<String, LuceneFieldDef> fieldDefMap = new ConcurrentHashMap<>();
+  private AtomicInteger dynamicFields;
   private final Counter droppedFieldsCounter;
   private final Counter convertErrorCounter;
   private final Counter convertFieldValueCounter;
@@ -257,6 +314,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
     convertAndDuplicateFieldCounter = meterRegistry.counter(CONVERT_AND_DUPLICATE_FIELD_COUNTER);
     convertErrorCounter = meterRegistry.counter(CONVERT_ERROR_COUNTER);
     totalFieldsCounter = meterRegistry.counter(TOTAL_FIELDS_COUNTER);
+    dynamicFields = new AtomicInteger(0);
   }
 
   @Override
@@ -275,6 +333,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
           message.getParentId().toStringUtf8(),
           Schema.SchemaFieldType.KEYWORD,
           "",
+          Trace.IndexStrategy.IN_SCHEMA_INDEX,
           0);
     }
     if (!message.getTraceId().isEmpty()) {
@@ -285,6 +344,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
           message.getTraceId().toStringUtf8(),
           Schema.SchemaFieldType.KEYWORD,
           "",
+          Trace.IndexStrategy.IN_SCHEMA_INDEX,
           0);
     }
     if (!message.getName().isEmpty()) {
@@ -295,6 +355,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
           message.getName(),
           Schema.SchemaFieldType.KEYWORD,
           "",
+          Trace.IndexStrategy.IN_SCHEMA_INDEX,
           0);
     }
     if (message.getDuration() != 0) {
@@ -305,6 +366,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
           message.getDuration(),
           Schema.SchemaFieldType.LONG,
           "",
+          Trace.IndexStrategy.IN_SCHEMA_INDEX,
           0);
     }
     if (!message.getId().isEmpty()) {
@@ -314,6 +376,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
           message.getId().toStringUtf8(),
           Schema.SchemaFieldType.ID,
           "",
+          Trace.IndexStrategy.IN_SCHEMA_INDEX,
           0);
     } else {
       throw new IllegalArgumentException("Span id is empty");
@@ -330,6 +393,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
           message.getTimestamp(),
           Schema.SchemaFieldType.LONG,
           "",
+          Trace.IndexStrategy.IN_SCHEMA_INDEX,
           0);
       jsonMap.put(
           LogMessage.ReservedField.ASTRA_INVALID_TIMESTAMP.fieldName, message.getTimestamp());
@@ -341,6 +405,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
         timestamp.toEpochMilli(),
         Schema.SchemaFieldType.LONG,
         "",
+        Trace.IndexStrategy.IN_SCHEMA_INDEX,
         0);
     // todo - this should be removed once we simplify the time handling
     // this will be overridden below if a user provided value exists
@@ -369,6 +434,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
         indexName,
         Schema.SchemaFieldType.KEYWORD,
         "",
+        Trace.IndexStrategy.IN_SCHEMA_INDEX,
         0);
     addField(
         doc,
@@ -376,6 +442,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
         indexName,
         Schema.SchemaFieldType.KEYWORD,
         "",
+        Trace.IndexStrategy.IN_SCHEMA_INDEX,
         0);
 
     tags.remove(LogMessage.ReservedField.SERVICE_NAME.fieldName);
@@ -389,33 +456,74 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
 
     for (Trace.KeyValue keyValue : tags.values()) {
       Schema.SchemaFieldType schemaFieldType = keyValue.getFieldType();
+      Trace.IndexStrategy indexStrategy = keyValue.getIndexStrategy();
       // move to switch statements
       if (schemaFieldType == Schema.SchemaFieldType.STRING
           || schemaFieldType == Schema.SchemaFieldType.KEYWORD) {
-        addField(doc, keyValue.getKey(), keyValue.getVStr(), Schema.SchemaFieldType.KEYWORD, "", 0);
+        addField(
+            doc,
+            keyValue.getKey(),
+            keyValue.getVStr(),
+            Schema.SchemaFieldType.KEYWORD,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVStr());
       } else if (schemaFieldType == Schema.SchemaFieldType.TEXT) {
-        addField(doc, keyValue.getKey(), keyValue.getVStr(), Schema.SchemaFieldType.TEXT, "", 0);
+        addField(
+            doc,
+            keyValue.getKey(),
+            keyValue.getVStr(),
+            Schema.SchemaFieldType.TEXT,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVStr());
       } else if (schemaFieldType == Schema.SchemaFieldType.IP) {
-        addField(doc, keyValue.getKey(), keyValue.getVStr(), Schema.SchemaFieldType.IP, "", 0);
+        addField(
+            doc,
+            keyValue.getKey(),
+            keyValue.getVStr(),
+            Schema.SchemaFieldType.IP,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVStr());
       } else if (schemaFieldType == Schema.SchemaFieldType.DATE) {
         Instant instant =
             Instant.ofEpochSecond(keyValue.getVDate().getSeconds(), keyValue.getVDate().getNanos());
-        addField(doc, keyValue.getKey(), instant, Schema.SchemaFieldType.DATE, "", 0);
+        addField(
+            doc, keyValue.getKey(), instant, Schema.SchemaFieldType.DATE, "", indexStrategy, 0);
         jsonMap.put(keyValue.getKey(), instant.toString());
       } else if (schemaFieldType == Schema.SchemaFieldType.BOOLEAN) {
         addField(
-            doc, keyValue.getKey(), keyValue.getVBool(), Schema.SchemaFieldType.BOOLEAN, "", 0);
+            doc,
+            keyValue.getKey(),
+            keyValue.getVBool(),
+            Schema.SchemaFieldType.BOOLEAN,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVBool());
       } else if (schemaFieldType == Schema.SchemaFieldType.DOUBLE) {
         addField(
-            doc, keyValue.getKey(), keyValue.getVFloat64(), Schema.SchemaFieldType.DOUBLE, "", 0);
+            doc,
+            keyValue.getKey(),
+            keyValue.getVFloat64(),
+            Schema.SchemaFieldType.DOUBLE,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVFloat64());
       } else if (schemaFieldType == Schema.SchemaFieldType.FLOAT) {
         addField(
-            doc, keyValue.getKey(), keyValue.getVFloat32(), Schema.SchemaFieldType.FLOAT, "", 0);
+            doc,
+            keyValue.getKey(),
+            keyValue.getVFloat32(),
+            Schema.SchemaFieldType.FLOAT,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVFloat32());
       } else if (schemaFieldType == Schema.SchemaFieldType.HALF_FLOAT) {
         addField(
@@ -424,27 +532,68 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
             keyValue.getVFloat32(),
             Schema.SchemaFieldType.HALF_FLOAT,
             "",
+            indexStrategy,
             0);
         jsonMap.put(keyValue.getKey(), keyValue.getVFloat32());
       } else if (schemaFieldType == Schema.SchemaFieldType.INTEGER) {
         addField(
-            doc, keyValue.getKey(), keyValue.getVInt32(), Schema.SchemaFieldType.INTEGER, "", 0);
+            doc,
+            keyValue.getKey(),
+            keyValue.getVInt32(),
+            Schema.SchemaFieldType.INTEGER,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVInt32());
       } else if (schemaFieldType == Schema.SchemaFieldType.LONG) {
-        addField(doc, keyValue.getKey(), keyValue.getVInt64(), Schema.SchemaFieldType.LONG, "", 0);
+        addField(
+            doc,
+            keyValue.getKey(),
+            keyValue.getVInt64(),
+            Schema.SchemaFieldType.LONG,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVInt64());
       } else if (schemaFieldType == Schema.SchemaFieldType.SCALED_LONG) {
-        addField(doc, keyValue.getKey(), keyValue.getVInt64(), Schema.SchemaFieldType.LONG, "", 0);
+        addField(
+            doc,
+            keyValue.getKey(),
+            keyValue.getVInt64(),
+            Schema.SchemaFieldType.LONG,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVInt64());
       } else if (schemaFieldType == Schema.SchemaFieldType.SHORT) {
-        addField(doc, keyValue.getKey(), keyValue.getVInt32(), Schema.SchemaFieldType.SHORT, "", 0);
+        addField(
+            doc,
+            keyValue.getKey(),
+            keyValue.getVInt32(),
+            Schema.SchemaFieldType.SHORT,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVInt32());
       } else if (schemaFieldType == Schema.SchemaFieldType.BYTE) {
-        addField(doc, keyValue.getKey(), keyValue.getVInt32(), Schema.SchemaFieldType.BYTE, "", 0);
+        addField(
+            doc,
+            keyValue.getKey(),
+            keyValue.getVInt32(),
+            Schema.SchemaFieldType.BYTE,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVInt32());
       } else if (schemaFieldType == Schema.SchemaFieldType.BINARY) {
         addField(
-            doc, keyValue.getKey(), keyValue.getVBinary(), Schema.SchemaFieldType.BINARY, "", 0);
+            doc,
+            keyValue.getKey(),
+            keyValue.getVBinary(),
+            Schema.SchemaFieldType.BINARY,
+            "",
+            indexStrategy,
+            0);
         jsonMap.put(keyValue.getKey(), keyValue.getVBinary().toStringUtf8());
       } else {
         LOG.warn(
@@ -467,10 +616,17 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
         msgString,
         Schema.SchemaFieldType.TEXT,
         "",
+        Trace.IndexStrategy.IN_SCHEMA_INDEX,
         0);
     if (enableFullTextSearch) {
       addField(
-          doc, LogMessage.SystemField.ALL.fieldName, msgString, Schema.SchemaFieldType.TEXT, "", 0);
+          doc,
+          LogMessage.SystemField.ALL.fieldName,
+          msgString,
+          Schema.SchemaFieldType.TEXT,
+          "",
+          Trace.IndexStrategy.IN_SCHEMA_INDEX,
+          0);
     }
 
     return doc;

--- a/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -189,7 +189,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
       fieldDefMap.put(key, newFieldDef);
       indexTypedField(doc, key, value, newFieldDef);
     } else if (indexSignal.equals(Trace.IndexSignal.DYNAMIC_INDEX)) {
-      int numDynamicFields = dynamicFields.getAndIncrement();
+      int numDynamicFields = dynamicFields.incrementAndGet();
       if (numDynamicFields <= MAX_DYNAMIC_FIELDS) {
         fieldDefMap.put(key, newFieldDef);
         indexTypedField(doc, key, value, newFieldDef);

--- a/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -218,9 +218,12 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
         && !schemaFieldType.equals(Schema.SchemaFieldType.TEXT);
   }
 
-  private boolean isIndexed(Schema.SchemaFieldType schemaFieldType, String fieldName) {
+  private boolean isIndexed(
+      Schema.SchemaFieldType schemaFieldType, String fieldName, Trace.IndexSignal indexSignal) {
+    boolean shouldIndex = !indexSignal.equals(Trace.IndexSignal.DO_NOT_INDEX);
     return !fieldName.equals(LogMessage.SystemField.SOURCE.fieldName)
-        && !schemaFieldType.equals(Schema.SchemaFieldType.BINARY);
+        && !schemaFieldType.equals(Schema.SchemaFieldType.BINARY)
+        && shouldIndex;
   }
 
   // In the future, we need this to take SchemaField instead of FieldType
@@ -230,12 +233,11 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
   // be dynamically indexed.
   private LuceneFieldDef getLuceneFieldDef(
       String key, Schema.SchemaFieldType schemaFieldType, Trace.IndexSignal indexSignal) {
-    boolean shouldIndex = !indexSignal.equals(Trace.IndexSignal.DO_NOT_INDEX);
     return new LuceneFieldDef(
         key,
         schemaFieldType.name(),
         isStored(key),
-        isIndexed(schemaFieldType, key) && shouldIndex,
+        isIndexed(schemaFieldType, key, indexSignal),
         isDocValueField(schemaFieldType, key));
   }
 

--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -39,8 +39,10 @@ public class SpanFormatter {
         .build();
   }
 
-  public static Trace.KeyValue makeTraceKV(String key, Object value, Schema.SchemaFieldType type) {
+  public static Trace.KeyValue makeTraceKV(
+      String key, Object value, Schema.SchemaFieldType type, Boolean isDynamic) {
     Trace.KeyValue.Builder tagBuilder = Trace.KeyValue.newBuilder();
+    Trace.IndexStrategy indexStrategy = indexStrategy(type, isDynamic);
     tagBuilder.setKey(key);
     try {
       switch (type) {
@@ -104,13 +106,35 @@ public class SpanFormatter {
           tagBuilder.setVBinary(ByteString.copyFrom(value.toString().getBytes()));
         }
       }
+      tagBuilder.setIndexStrategy(indexStrategy);
       return tagBuilder.build();
     } catch (Exception e) {
       tagBuilder.setKey(String.format("failed_%s", key));
       tagBuilder.setFieldType(Schema.SchemaFieldType.KEYWORD);
       tagBuilder.setVStr(value.toString());
+      tagBuilder.setIndexStrategy(Trace.IndexStrategy.DO_NOT_INDEX);
       return tagBuilder.build();
     }
+  }
+
+  private static Trace.IndexStrategy indexStrategy(Schema.SchemaFieldType type, Boolean isDynamic) {
+    if (isDynamic) {
+      return dynamicIndexStrategy(type);
+    } else {
+      return inSchemaIndexStrategy(type);
+    }
+  }
+
+  private static Trace.IndexStrategy inSchemaIndexStrategy(Schema.SchemaFieldType type) {
+    return type == Schema.SchemaFieldType.BINARY
+        ? Trace.IndexStrategy.DO_NOT_INDEX
+        : Trace.IndexStrategy.IN_SCHEMA_INDEX;
+  }
+
+  private static Trace.IndexStrategy dynamicIndexStrategy(Schema.SchemaFieldType type) {
+    return type == Schema.SchemaFieldType.BINARY
+        ? Trace.IndexStrategy.DO_NOT_INDEX
+        : Trace.IndexStrategy.DYNAMIC_INDEX;
   }
 
   public static List<Trace.KeyValue> convertKVtoProto(
@@ -122,7 +146,7 @@ public class SpanFormatter {
     if (schema.containsFields(key)) {
       List<Trace.KeyValue> tags = new ArrayList<>();
       Schema.SchemaField schemaFieldDef = schema.getFieldsMap().get(key);
-      tags.add(makeTraceKV(key, value, schemaFieldDef.getType()));
+      tags.add(makeTraceKV(key, value, schemaFieldDef.getType(), false));
       for (Map.Entry<String, Schema.SchemaField> additionalField :
           schemaFieldDef.getFieldsMap().entrySet()) {
         // skip conditions
@@ -135,7 +159,8 @@ public class SpanFormatter {
             makeTraceKV(
                 String.format("%s.%s", key, additionalField.getKey()),
                 value,
-                additionalField.getValue().getType());
+                additionalField.getValue().getType(),
+                false);
         tags.add(additionalKV);
       }
       return tags;
@@ -165,7 +190,8 @@ public class SpanFormatter {
               .findFirst();
 
       if (defaultStringField.isPresent()) {
-        tags.add(makeTraceKV(key, value, defaultStringField.get().getMapping().getType()));
+        Schema.SchemaFieldType fieldType = defaultStringField.get().getMapping().getType();
+        tags.add(makeTraceKV(key, value, fieldType, true));
         for (Map.Entry<String, Schema.SchemaField> additionalField :
             defaultStringField.get().getMapping().getFieldsMap().entrySet()) {
           // skip conditions
@@ -174,28 +200,30 @@ public class SpanFormatter {
               && value.toString().length() > additionalField.getValue().getIgnoreAbove()) {
             continue;
           }
+          Schema.SchemaFieldType additionalFieldType = additionalField.getValue().getType();
           Trace.KeyValue additionalKV =
               makeTraceKV(
                   String.format("%s.%s", key, additionalField.getKey()),
                   value,
-                  additionalField.getValue().getType());
+                  additionalFieldType,
+                  true);
           tags.add(additionalKV);
         }
       } else {
-        tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.KEYWORD));
+        tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.KEYWORD, true));
       }
     } else if (value instanceof Boolean) {
-      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.BOOLEAN));
+      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.BOOLEAN, true));
     } else if (value instanceof Integer) {
-      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.INTEGER));
+      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.INTEGER, true));
     } else if (value instanceof Long) {
-      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.LONG));
+      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.LONG, true));
     } else if (value instanceof Float) {
-      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.FLOAT));
+      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.FLOAT, true));
     } else if (value instanceof Double) {
-      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.DOUBLE));
+      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.DOUBLE, true));
     } else if (value != null) {
-      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.BINARY));
+      tags.add(makeTraceKV(key, value, Schema.SchemaFieldType.BINARY, true));
     }
     return tags;
   }

--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -42,7 +42,7 @@ public class SpanFormatter {
   public static Trace.KeyValue makeTraceKV(
       String key, Object value, Schema.SchemaFieldType type, Boolean isDynamic) {
     Trace.KeyValue.Builder tagBuilder = Trace.KeyValue.newBuilder();
-    Trace.IndexStrategy indexStrategy = indexStrategy(type, isDynamic);
+    Trace.IndexSignal indexSignal = indexSignal(type, isDynamic);
     tagBuilder.setKey(key);
     try {
       switch (type) {
@@ -106,35 +106,35 @@ public class SpanFormatter {
           tagBuilder.setVBinary(ByteString.copyFrom(value.toString().getBytes()));
         }
       }
-      tagBuilder.setIndexStrategy(indexStrategy);
+      tagBuilder.setIndexSignal(indexSignal);
       return tagBuilder.build();
     } catch (Exception e) {
       tagBuilder.setKey(String.format("failed_%s", key));
       tagBuilder.setFieldType(Schema.SchemaFieldType.KEYWORD);
       tagBuilder.setVStr(value.toString());
-      tagBuilder.setIndexStrategy(Trace.IndexStrategy.DO_NOT_INDEX);
+      tagBuilder.setIndexSignal(Trace.IndexSignal.DO_NOT_INDEX);
       return tagBuilder.build();
     }
   }
 
-  private static Trace.IndexStrategy indexStrategy(Schema.SchemaFieldType type, Boolean isDynamic) {
+  private static Trace.IndexSignal indexSignal(Schema.SchemaFieldType type, Boolean isDynamic) {
     if (isDynamic) {
-      return dynamicIndexStrategy(type);
+      return dynamicIndexSignal(type);
     } else {
-      return inSchemaIndexStrategy(type);
+      return inSchemaIndexSignal(type);
     }
   }
 
-  private static Trace.IndexStrategy inSchemaIndexStrategy(Schema.SchemaFieldType type) {
+  private static Trace.IndexSignal inSchemaIndexSignal(Schema.SchemaFieldType type) {
     return type == Schema.SchemaFieldType.BINARY
-        ? Trace.IndexStrategy.DO_NOT_INDEX
-        : Trace.IndexStrategy.IN_SCHEMA_INDEX;
+        ? Trace.IndexSignal.DO_NOT_INDEX
+        : Trace.IndexSignal.IN_SCHEMA_INDEX;
   }
 
-  private static Trace.IndexStrategy dynamicIndexStrategy(Schema.SchemaFieldType type) {
+  private static Trace.IndexSignal dynamicIndexSignal(Schema.SchemaFieldType type) {
     return type == Schema.SchemaFieldType.BINARY
-        ? Trace.IndexStrategy.DO_NOT_INDEX
-        : Trace.IndexStrategy.DYNAMIC_INDEX;
+        ? Trace.IndexSignal.DO_NOT_INDEX
+        : Trace.IndexSignal.DYNAMIC_INDEX;
   }
 
   public static List<Trace.KeyValue> convertKVtoProto(

--- a/astra/src/main/proto/trace.proto
+++ b/astra/src/main/proto/trace.proto
@@ -12,7 +12,7 @@ import "google/protobuf/timestamp.proto";
 
 import "schema.proto";
 
-enum IndexStrategy {
+enum IndexSignal {
   UNKNOWN          = 0;
   IN_SCHEMA_INDEX  = 1;
   DYNAMIC_INDEX    = 2;
@@ -32,7 +32,7 @@ message KeyValue {
   slack.proto.astra.schema.SchemaFieldType fieldType = 10;
 
   // pick much later id to allow for value types to be consecutively added
-  IndexStrategy index_strategy    = 100;
+  IndexSignal index_signal    = 100;
 }
 
 // A span defines a single event in a trace.

--- a/astra/src/main/proto/trace.proto
+++ b/astra/src/main/proto/trace.proto
@@ -12,6 +12,13 @@ import "google/protobuf/timestamp.proto";
 
 import "schema.proto";
 
+enum IndexStrategy {
+  UNKNOWN          = 0;
+  IN_SCHEMA_INDEX  = 1;
+  DYNAMIC_INDEX    = 2;
+  DO_NOT_INDEX     = 3;
+};
+
 message KeyValue {
   string    key       = 1;
   string    v_str     = 3;
@@ -23,6 +30,9 @@ message KeyValue {
   float     v_float32 = 9;
   google.protobuf.Timestamp v_date = 11;
   slack.proto.astra.schema.SchemaFieldType fieldType = 10;
+
+  // pick much later id to allow for value types to be consecutively added
+  IndexStrategy index_strategy    = 100;
 }
 
 // A span defines a single event in a trace.

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -677,11 +677,12 @@ public class IndexingChunkImplTest {
           .withFailMessage("Expected 1 commit recorded")
           .isEqualTo(1);
 
-      // todo adjust when the dynamic flag exists
-      int totalFieldsInSchema = chunk.getSchema().size();
-      assertThat(totalFieldsInSchema)
-          .withFailMessage("Schema should not exceed 1600 fields but had %s", totalFieldsInSchema)
-          .isLessThanOrEqualTo(1600);
+      long dynamicFieldsInSchema =
+          chunk.getSchema().keySet().stream().filter(key -> key.startsWith("custom.field")).count();
+
+      assertThat(dynamicFieldsInSchema)
+          .withFailMessage("Schema should not exceed 1500 fields but had %s", dynamicFieldsInSchema)
+          .isLessThanOrEqualTo(1500);
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -660,6 +660,16 @@ public class IndexingChunkImplTest {
                 .setIndexSignal(Trace.IndexSignal.DYNAMIC_INDEX)
                 .build());
       }
+
+      for (int i = 0; i < 100; i++) {
+        spanBuilder.addTags(
+            Trace.KeyValue.newBuilder()
+                .setKey("schema.field." + i)
+                .setVStr("value" + i)
+                .setIndexSignal(Trace.IndexSignal.IN_SCHEMA_INDEX)
+                .build());
+      }
+
       Trace.Span spanWithTooManyFields = spanBuilder.build();
 
       // Add and commit the message
@@ -683,6 +693,13 @@ public class IndexingChunkImplTest {
       assertThat(dynamicFieldsInSchema)
           .withFailMessage("Schema should not exceed 1500 fields but had %s", dynamicFieldsInSchema)
           .isLessThanOrEqualTo(1500);
+
+      long schemaFieldsInSchema =
+          chunk.getSchema().keySet().stream().filter(key -> key.startsWith("schema.field")).count();
+
+      assertThat(schemaFieldsInSchema)
+          .withFailMessage("Schema should not exceed 1500 fields but had %s", dynamicFieldsInSchema)
+          .isLessThanOrEqualTo(100);
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -657,7 +657,7 @@ public class IndexingChunkImplTest {
             Trace.KeyValue.newBuilder()
                 .setKey("custom.field." + i)
                 .setVStr("value" + i)
-                .setIndexStrategy(Trace.IndexStrategy.DYNAMIC_INDEX)
+                .setIndexSignal(Trace.IndexSignal.DYNAMIC_INDEX)
                 .build());
       }
       Trace.Span spanWithTooManyFields = spanBuilder.build();

--- a/astra/src/test/java/com/slack/astra/elasticsearchApi/ElasticsearchApiServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/elasticsearchApi/ElasticsearchApiServiceTest.java
@@ -168,6 +168,7 @@ public class ElasticsearchApiServiceTest {
             "cost",
             "amount",
             "amount_half_float",
+            "message.keyword",
             "value",
             "count",
             "count_scaled_long",
@@ -191,19 +192,15 @@ public class ElasticsearchApiServiceTest {
             "floatproperty",
             "intproperty",
             "longproperty",
-            "message.keyword",
             "name",
             "parent_id",
             "service_name",
             "stringproperty",
-            "trace_id",
-            "username");
+            "trace_id");
 
     // Verify all required keys are retained
     assertThat(map.keySet()).containsAll(requiredKeys);
 
-    // Ensure total fields remain within limit. TODO Update when dynamic field config exists
-    // 1500 is the dynamic limit. This should check that.
     int dynamicFieldsCount = map.keySet().size() - schemaKeys.size() - requiredKeys.size();
     assertThat(dynamicFieldsCount)
         .withFailMessage(

--- a/astra/src/test/java/com/slack/astra/elasticsearchApi/ElasticsearchApiServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/elasticsearchApi/ElasticsearchApiServiceTest.java
@@ -129,7 +129,7 @@ public class ElasticsearchApiServiceTest {
           Trace.KeyValue.newBuilder()
               .setKey("dynamic.extra_field." + i)
               .setVStr("value" + i)
-              .setIndexStrategy(Trace.IndexStrategy.DYNAMIC_INDEX)
+              .setIndexSignal(Trace.IndexSignal.DYNAMIC_INDEX)
               .build());
     }
     Trace.Span spanWithExtras = spanBuilder.build();
@@ -312,7 +312,7 @@ public class ElasticsearchApiServiceTest {
     assertThat(map.keySet()).containsAll(requiredKeys);
 
     // No dynamic fields are dropped with the "old" logic when preprocessor does not have
-    // indexStrategy set.
+    // indexSignal set.
     int dynamicFieldsCount = map.keySet().size() - schemaKeys.size() - requiredKeys.size();
     assertThat(dynamicFieldsCount)
         .withFailMessage(

--- a/astra/src/test/java/com/slack/astra/elasticsearchApi/ElasticsearchApiServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/elasticsearchApi/ElasticsearchApiServiceTest.java
@@ -46,6 +46,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.assertj.core.data.Offset;
@@ -98,6 +99,225 @@ public class ElasticsearchApiServiceTest {
   public void tearDown() throws TimeoutException, IOException {
     chunkManagerUtil.close();
     metricsRegistry.close();
+  }
+
+  @Test
+  public void testSchemaIsRetainedAndDynamicFieldsAreDroppedOverLimit() throws Exception {
+    // Load schema from test_schema.yaml
+    final File schemaFile =
+        new File(getClass().getClassLoader().getResource("schema/test_schema.yaml").getFile());
+    Schema.IngestSchema schema = SchemaUtil.parseSchema(schemaFile.toPath());
+
+    // Build a request with all schema fields (reusing test fixture) and extra dynamic fields
+    byte[] rawRequest = getIndexRequestBytes("index_all_schema_fields");
+    List<IndexRequest> indexRequests = BulkApiRequestParser.parseBulkRequest(rawRequest);
+    assertThat(indexRequests.size()).isEqualTo(2);
+
+    // Insert schema-based spans first
+    for (IndexRequest indexRequest : indexRequests) {
+      IngestDocument ingestDocument = convertRequestToDocument(indexRequest);
+      Trace.Span span = BulkApiRequestParser.fromIngestDocument(ingestDocument, schema);
+      ConsumerRecord<String, byte[]> spanRecord = consumerRecordWithValue(span.toByteArray());
+      LogMessageWriterImpl messageWriter = new LogMessageWriterImpl(chunkManagerUtil.chunkManager);
+      assertThat(messageWriter.insertRecord(spanRecord)).isTrue();
+    }
+
+    // Now add one large span with 3000 dynamic fields
+    Trace.Span.Builder spanBuilder = SpanUtil.makeSpan(100).toBuilder();
+    for (int i = 0; i < 3000; i++) {
+      spanBuilder.addTags(
+          Trace.KeyValue.newBuilder()
+              .setKey("dynamic.extra_field." + i)
+              .setVStr("value" + i)
+              .setIndexStrategy(Trace.IndexStrategy.DYNAMIC_INDEX)
+              .build());
+    }
+    Trace.Span spanWithExtras = spanBuilder.build();
+    ConsumerRecord<String, byte[]> extraSpanRecord =
+        consumerRecordWithValue(spanWithExtras.toByteArray());
+    LogMessageWriterImpl messageWriter = new LogMessageWriterImpl(chunkManagerUtil.chunkManager);
+    assertThat(messageWriter.insertRecord(extraSpanRecord)).isTrue();
+
+    // Validate counts
+    assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(3);
+    assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
+    chunkManagerUtil.chunkManager.getActiveChunk().commit();
+
+    // Fetch and parse mapping
+    HttpResponse response =
+        elasticsearchApiService.mapping(
+            Optional.of("test"), Optional.of(0L), Optional.of(Long.MAX_VALUE));
+
+    AggregatedHttpResponse aggregatedRes = response.aggregate().join();
+    String body = aggregatedRes.content(StandardCharsets.UTF_8);
+    JsonNode jsonNode = new ObjectMapper().readTree(body);
+    assertThat(jsonNode).isNotNull();
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    Map<String, Object> map =
+        objectMapper.convertValue(
+            jsonNode.get("test").get("mappings").get("properties"), Map.class);
+
+    Set<String> schemaKeys =
+        Set.of(
+            "host",
+            "message",
+            "ip",
+            "my_date",
+            "success",
+            "cost",
+            "amount",
+            "amount_half_float",
+            "value",
+            "count",
+            "count_scaled_long",
+            "count_short",
+            "bucket");
+
+    // Verify all original schema fields are retained
+    assertThat(map.keySet()).containsAll(schemaKeys);
+
+    // Additional Keys that are required via indexing logic.
+    Set<String> requiredKeys =
+        Set.of(
+            "@timestamp",
+            "_all",
+            "_id",
+            "_index",
+            "_source",
+            "_timesinceepoch",
+            "doubleproperty",
+            "duration",
+            "floatproperty",
+            "intproperty",
+            "longproperty",
+            "message.keyword",
+            "name",
+            "parent_id",
+            "service_name",
+            "stringproperty",
+            "trace_id",
+            "username");
+
+    // Verify all required keys are retained
+    assertThat(map.keySet()).containsAll(requiredKeys);
+
+    // Ensure total fields remain within limit. TODO Update when dynamic field config exists
+    // 1500 is the dynamic limit. This should check that.
+    int dynamicFieldsCount = map.keySet().size() - schemaKeys.size() - requiredKeys.size();
+    assertThat(dynamicFieldsCount)
+        .withFailMessage(
+            "Expected dynamic field count to not exceed limit but got %s", dynamicFieldsCount)
+        .isEqualTo(1500);
+  }
+
+  @Test
+  public void testSchemaIsRetainedAndDynamicFieldsAreNotDroppedWhenUNKNOWN() throws Exception {
+    // Load schema from test_schema.yaml
+    final File schemaFile =
+        new File(getClass().getClassLoader().getResource("schema/test_schema.yaml").getFile());
+    Schema.IngestSchema schema = SchemaUtil.parseSchema(schemaFile.toPath());
+
+    // Build a request with all schema fields (reusing test fixture) and extra dynamic fields
+    byte[] rawRequest = getIndexRequestBytes("index_all_schema_fields");
+    List<IndexRequest> indexRequests = BulkApiRequestParser.parseBulkRequest(rawRequest);
+    assertThat(indexRequests.size()).isEqualTo(2);
+
+    // Insert schema-based spans first
+    for (IndexRequest indexRequest : indexRequests) {
+      IngestDocument ingestDocument = convertRequestToDocument(indexRequest);
+      Trace.Span span = BulkApiRequestParser.fromIngestDocument(ingestDocument, schema);
+      ConsumerRecord<String, byte[]> spanRecord = consumerRecordWithValue(span.toByteArray());
+      LogMessageWriterImpl messageWriter = new LogMessageWriterImpl(chunkManagerUtil.chunkManager);
+      assertThat(messageWriter.insertRecord(spanRecord)).isTrue();
+    }
+
+    // Now add one large span with 3000 dynamic fields
+    Trace.Span.Builder spanBuilder = SpanUtil.makeSpan(100).toBuilder();
+    for (int i = 0; i < 3000; i++) {
+      spanBuilder.addTags(
+          Trace.KeyValue.newBuilder()
+              .setKey("dynamic.extra_field." + i)
+              .setVStr("value" + i)
+              .build());
+    }
+    Trace.Span spanWithExtras = spanBuilder.build();
+    ConsumerRecord<String, byte[]> extraSpanRecord =
+        consumerRecordWithValue(spanWithExtras.toByteArray());
+    LogMessageWriterImpl messageWriter = new LogMessageWriterImpl(chunkManagerUtil.chunkManager);
+    assertThat(messageWriter.insertRecord(extraSpanRecord)).isTrue();
+
+    // Validate counts
+    assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(3);
+    assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
+    chunkManagerUtil.chunkManager.getActiveChunk().commit();
+
+    // Fetch and parse mapping
+    HttpResponse response =
+        elasticsearchApiService.mapping(
+            Optional.of("test"), Optional.of(0L), Optional.of(Long.MAX_VALUE));
+
+    AggregatedHttpResponse aggregatedRes = response.aggregate().join();
+    String body = aggregatedRes.content(StandardCharsets.UTF_8);
+    JsonNode jsonNode = new ObjectMapper().readTree(body);
+    assertThat(jsonNode).isNotNull();
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    Map<String, Object> map =
+        objectMapper.convertValue(
+            jsonNode.get("test").get("mappings").get("properties"), Map.class);
+
+    Set<String> schemaKeys =
+        Set.of(
+            "host",
+            "message",
+            "ip",
+            "my_date",
+            "success",
+            "cost",
+            "amount",
+            "amount_half_float",
+            "value",
+            "count",
+            "count_scaled_long",
+            "count_short",
+            "bucket");
+
+    // Verify all original schema fields are retained
+    assertThat(map.keySet()).containsAll(schemaKeys);
+
+    // Additional Keys that are required via indexing logic.
+    Set<String> requiredKeys =
+        Set.of(
+            "@timestamp",
+            "_all",
+            "_id",
+            "_index",
+            "_source",
+            "_timesinceepoch",
+            "doubleproperty",
+            "duration",
+            "floatproperty",
+            "intproperty",
+            "longproperty",
+            "message.keyword",
+            "name",
+            "parent_id",
+            "service_name",
+            "stringproperty",
+            "trace_id",
+            "username");
+
+    // Verify all required keys are retained
+    assertThat(map.keySet()).containsAll(requiredKeys);
+
+    // No dynamic fields are dropped with the "old" logic when preprocessor does not have
+    // indexStrategy set.
+    int dynamicFieldsCount = map.keySet().size() - schemaKeys.size() - requiredKeys.size();
+    assertThat(dynamicFieldsCount)
+        .withFailMessage(
+            "Expected dynamic field count to not exceed limit but got %s", dynamicFieldsCount)
+        .isEqualTo(3000);
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
+++ b/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
@@ -248,17 +248,17 @@ public class SpanFormatterWithSchemaTest {
     Trace.KeyValue kv = SpanFormatter.convertKVtoProto("host", "host1", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("host1");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("message", "my message", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("my message");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.TEXT);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("ip", "8.8.8.8", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("8.8.8.8");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.IP);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     String myTimestamp = "2021-01-01T00:00:00Z";
     Instant myDateInstant = Instant.parse(myTimestamp);
@@ -269,7 +269,7 @@ public class SpanFormatterWithSchemaTest {
             .build();
     kv = SpanFormatter.convertKVtoProto("myTimestamp", myTimestamp, schema).get(0);
     assertThat(kv.getVDate()).isEqualTo(myDateTimestamp);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     myTimestamp = "2021-01-01T00:00:00Z";
     myDateInstant = Instant.parse(myTimestamp);
@@ -280,59 +280,59 @@ public class SpanFormatterWithSchemaTest {
             .build();
     kv = SpanFormatter.convertKVtoProto("myTimestamp", myTimestamp, schema).get(0);
     assertThat(kv.getVDate()).isEqualTo(myDateTimestamp);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.DATE);
 
     kv = SpanFormatter.convertKVtoProto("success", "true", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.BOOLEAN);
     assertThat(kv.getVBool()).isEqualTo(true);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("success", true, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.BOOLEAN);
     assertThat(kv.getVBool()).isEqualTo(true);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("cost", "10.0", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.DOUBLE);
     assertThat(kv.getVFloat64()).isEqualTo(10.0);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("cost", 10.0, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.DOUBLE);
     assertThat(kv.getVFloat64()).isEqualTo(10.0);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount", "10.0", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount", 10.0, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount_half_float", "10.0", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.HALF_FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount_half_float", 10.0, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.HALF_FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("value", "10", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.INTEGER);
     assertThat(kv.getVInt32()).isEqualTo(10);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("value", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.INTEGER);
     assertThat(kv.getVInt32()).isEqualTo(10);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count", "10", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.LONG);
@@ -341,32 +341,32 @@ public class SpanFormatterWithSchemaTest {
     kv = SpanFormatter.convertKVtoProto("count", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.LONG);
     assertThat(kv.getVInt64()).isEqualTo(10L);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count_scaled_long", "10", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.SCALED_LONG);
     assertThat(kv.getVInt64()).isEqualTo(10);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count_scaled_long", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.SCALED_LONG);
     assertThat(kv.getVInt64()).isEqualTo(10L);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count_short", "10", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.SHORT);
     assertThat(kv.getVInt32()).isEqualTo(10L);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count_short", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.SHORT);
     assertThat(kv.getVInt32()).isEqualTo(10);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("bucket", "e30=", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.BINARY);
     assertThat(kv.getVBinary().toStringUtf8()).isEqualTo("e30=");
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DO_NOT_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DO_NOT_INDEX);
   }
 
   @Test
@@ -418,56 +418,56 @@ public class SpanFormatterWithSchemaTest {
     Trace.KeyValue kv = SpanFormatter.convertKVtoProto("host", "host1", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("host1");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("ip", "8.8.8.8", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("8.8.8.8");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("myTimestamp", "2021-01-01T00:00:00Z", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("2021-01-01T00:00:00Z");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("success", "true", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
     assertThat(kv.getVStr()).isEqualTo("true");
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("success", true, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.BOOLEAN);
     assertThat(kv.getVBool()).isEqualTo(true);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("cost", "10.0", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
     assertThat(kv.getVStr()).isEqualTo("10.0");
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount", 10.0f, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("cost", 10.0, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.DOUBLE);
     assertThat(kv.getVFloat64()).isEqualTo(10.0);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("value", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.INTEGER);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count", 10L, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.LONG);
     assertThat(kv.getVInt64()).isEqualTo(10L);
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("bucket", "e30=", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
     assertThat(kv.getVStr()).isEqualTo("e30=");
-    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
+    assertThat(kv.getIndexSignal()).isEqualTo(Trace.IndexSignal.DYNAMIC_INDEX);
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
+++ b/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
@@ -248,14 +248,17 @@ public class SpanFormatterWithSchemaTest {
     Trace.KeyValue kv = SpanFormatter.convertKVtoProto("host", "host1", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("host1");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("message", "my message", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("my message");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.TEXT);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("ip", "8.8.8.8", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("8.8.8.8");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.IP);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     String myTimestamp = "2021-01-01T00:00:00Z";
     Instant myDateInstant = Instant.parse(myTimestamp);
@@ -266,6 +269,7 @@ public class SpanFormatterWithSchemaTest {
             .build();
     kv = SpanFormatter.convertKVtoProto("myTimestamp", myTimestamp, schema).get(0);
     assertThat(kv.getVDate()).isEqualTo(myDateTimestamp);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     myTimestamp = "2021-01-01T00:00:00Z";
     myDateInstant = Instant.parse(myTimestamp);
@@ -276,48 +280,59 @@ public class SpanFormatterWithSchemaTest {
             .build();
     kv = SpanFormatter.convertKVtoProto("myTimestamp", myTimestamp, schema).get(0);
     assertThat(kv.getVDate()).isEqualTo(myDateTimestamp);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.DATE);
 
     kv = SpanFormatter.convertKVtoProto("success", "true", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.BOOLEAN);
     assertThat(kv.getVBool()).isEqualTo(true);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("success", true, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.BOOLEAN);
     assertThat(kv.getVBool()).isEqualTo(true);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("cost", "10.0", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.DOUBLE);
     assertThat(kv.getVFloat64()).isEqualTo(10.0);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("cost", 10.0, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.DOUBLE);
     assertThat(kv.getVFloat64()).isEqualTo(10.0);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount", "10.0", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount", 10.0, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount_half_float", "10.0", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.HALF_FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount_half_float", 10.0, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.HALF_FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("value", "10", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.INTEGER);
     assertThat(kv.getVInt32()).isEqualTo(10);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("value", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.INTEGER);
     assertThat(kv.getVInt32()).isEqualTo(10);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count", "10", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.LONG);
@@ -326,26 +341,32 @@ public class SpanFormatterWithSchemaTest {
     kv = SpanFormatter.convertKVtoProto("count", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.LONG);
     assertThat(kv.getVInt64()).isEqualTo(10L);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count_scaled_long", "10", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.SCALED_LONG);
     assertThat(kv.getVInt64()).isEqualTo(10);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count_scaled_long", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.SCALED_LONG);
     assertThat(kv.getVInt64()).isEqualTo(10L);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count_short", "10", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.SHORT);
     assertThat(kv.getVInt32()).isEqualTo(10L);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count_short", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.SHORT);
     assertThat(kv.getVInt32()).isEqualTo(10);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.IN_SCHEMA_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("bucket", "e30=", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.BINARY);
     assertThat(kv.getVBinary().toStringUtf8()).isEqualTo("e30=");
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DO_NOT_INDEX);
   }
 
   @Test
@@ -397,45 +418,56 @@ public class SpanFormatterWithSchemaTest {
     Trace.KeyValue kv = SpanFormatter.convertKVtoProto("host", "host1", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("host1");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("ip", "8.8.8.8", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("8.8.8.8");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("myTimestamp", "2021-01-01T00:00:00Z", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("2021-01-01T00:00:00Z");
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("success", "true", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
     assertThat(kv.getVStr()).isEqualTo("true");
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("success", true, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.BOOLEAN);
     assertThat(kv.getVBool()).isEqualTo(true);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("cost", "10.0", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
     assertThat(kv.getVStr()).isEqualTo("10.0");
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("amount", 10.0f, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.FLOAT);
     assertThat(kv.getVFloat32()).isEqualTo(10.0f);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("cost", 10.0, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.DOUBLE);
     assertThat(kv.getVFloat64()).isEqualTo(10.0);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("value", 10, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.INTEGER);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("count", 10L, schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.LONG);
     assertThat(kv.getVInt64()).isEqualTo(10L);
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
 
     kv = SpanFormatter.convertKVtoProto("bucket", "e30=", schema).get(0);
     assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
     assertThat(kv.getVStr()).isEqualTo("e30=");
+    assertThat(kv.getIndexStrategy()).isEqualTo(Trace.IndexStrategy.DYNAMIC_INDEX);
   }
 
   @Test

--- a/docs/topics/System-properties-reference.md
+++ b/docs/topics/System-properties-reference.md
@@ -86,7 +86,9 @@ defaultValue
 
 ## astra.mapping.dynamicFieldsLimit
 <tldr>experimental</tldr>
-Maximum amount of dynamic fields used indexer service when building a schema.
+Maximum amount of dynamic fields indexed in indexer when building a schema.
+
+Should be lower than astra.mapping.totalFieldsLimit to account for required fields and schema fields.
 
 {style="narrow"}
 defaultValue

--- a/docs/topics/System-properties-reference.md
+++ b/docs/topics/System-properties-reference.md
@@ -83,3 +83,11 @@ Maximum amount of total fields used by the mapper service for query parsing.
 {style="narrow"}
 defaultValue
 : 2500
+
+## astra.mapping.dynamicFieldsLimit
+<tldr>experimental</tldr>
+Maximum amount of dynamic fields used indexer service when building a schema.
+
+{style="narrow"}
+defaultValue
+: 1500


### PR DESCRIPTION
###  Summary
- this safeguards from bad services sending high cardinality field names. When high cardinality field names come in, and we have dynamic indexing, we can easily get above anything we have configured for `astra.mapping.totalFieldsLimit` for the lucene index, causing the entire segment to fail to be saved and then not servable by cache pods or index pods.
- All fields explicitly defined in the schema are indexed.
- fields not explicitly defined in the schema but are indexable and are a tag on an incoming span (e.g. not binary), will be indexed up to `astra.mapping.dynamicFieldsLimit` for a particular segment
- Ideally, `dynamicFieldsLimit` should be defined lower than `astra.mapping.totalFieldsLimit` which includes all indexed fields
- Preprocessor adds signal as to field being explicitly in schema or should be dynamically added. indexer uses that information and has max dynamic fields which it enforces based on those signals.

### Requirements

* [ ] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
