### PR TITLE
Fix: Propagate Kafka send errors when transactions are disabled (Fixes #1173)

### DIFF
--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducer.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducer.java
@@ -226,11 +226,6 @@ public class BulkIngestKafkaProducer extends AbstractExecutionThreadService {
                   request.getInputDocs().values().stream().mapToInt(List::size).sum(),
                   e.getMessage());
           responseMap.put(request, resp);
-          // propagate failure response
-          if (!request.setResponse(resp)) {
-            LOG.warn("Failed to add result to the bulk ingest request on error", e);
-            failedSetResponseCounter.increment();
-          }
         }
       }
       return responseMap;

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -19,17 +19,17 @@ import com.slack.astra.testlib.TestKafkaServer;
 import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.CompletableFuture;
-import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -37,8 +37,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.junit.jupiter.api.AfterEach;
@@ -228,15 +228,15 @@ class BulkIngestKafkaProducerTest {
 
     // Create producer that returns futures - some succeed, some fail
     AtomicInteger callCount = new AtomicInteger(0);
-    KafkaProducer<String, byte[]> futureBasedProducer = new KafkaProducer<>(props) {
+    KafkaProducer<String, byte[]> futureBasedProducer =
+        new KafkaProducer<>(props) {
           @Override
           public Future<RecordMetadata> send(ProducerRecord<String, byte[]> record) {
             int call = callCount.incrementAndGet();
             if (call <= 2) {
               // First 2 calls succeed
               return CompletableFuture.completedFuture(
-                  new RecordMetadata(
-                      new TopicPartition("test", 0), 0, 0, 0, 0, 0));
+                  new RecordMetadata(new TopicPartition("test", 0), 0, 0, 0, 0, 0));
             } else {
               // Last call fails with ExecutionException
               return CompletableFuture.failedFuture(
@@ -253,7 +253,8 @@ class BulkIngestKafkaProducerTest {
     Trace.Span doc2 = Trace.Span.newBuilder().setId(ByteString.copyFromUtf8("success2")).build();
     Trace.Span doc3 = Trace.Span.newBuilder().setId(ByteString.copyFromUtf8("failure")).build();
 
-    BulkIngestRequest request = bulkIngestKafkaProducer.submitRequest(Map.of(INDEX_NAME, List.of(doc1, doc2, doc3)));
+    BulkIngestRequest request =
+        bulkIngestKafkaProducer.submitRequest(Map.of(INDEX_NAME, List.of(doc1, doc2, doc3)));
 
     AtomicReference<BulkIngestResponse> response = new AtomicReference<>();
     Thread.ofVirtual()
@@ -272,7 +273,7 @@ class BulkIngestKafkaProducerTest {
     assertThat(response.get().failedDocs()).isEqualTo(1);
     assertThat(response.get().errorMsg())
         .isEqualTo(
-    "Kafka send failure. index: testtransactionindex partition: 0 failures: 1 - check logs for details.");
+            "Kafka send failure. index: testtransactionindex partition: 0 failures: 1 - check logs for details.");
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -30,6 +30,7 @@ import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.junit.jupiter.api.AfterEach;
@@ -195,6 +196,66 @@ class BulkIngestKafkaProducerTest {
     assertThat(
             MetricsUtil.getTimerCount(BulkIngestKafkaProducer.KAFKA_RESTART_COUNTER, meterRegistry))
         .isEqualTo(1);
+  }
+
+  @Test
+  public void testKafkaSendErrorPropagatedWithoutTransactions() throws Exception {
+    bulkIngestKafkaProducer.stopAsync().awaitTerminated(DEFAULT_START_STOP_DURATION);
+    System.setProperty("astra.bulkIngest.useKafkaTransactions", "false");
+
+    bulkIngestKafkaProducer =
+        new BulkIngestKafkaProducer(datasetMetadataStore, preprocessorConfig, meterRegistry);
+
+    java.lang.reflect.Field kafkaProducerField =
+        BulkIngestKafkaProducer.class.getDeclaredField("kafkaProducer");
+    kafkaProducerField.setAccessible(true);
+
+    Properties props = new Properties();
+    props.put(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.StringSerializer");
+    props.put(
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.ByteArraySerializer");
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+
+    org.apache.kafka.clients.producer.KafkaProducer<String, byte[]> failingProducer =
+        new org.apache.kafka.clients.producer.KafkaProducer<>(props) {
+          @Override
+          public java.util.concurrent.Future<org.apache.kafka.clients.producer.RecordMetadata> send(
+              org.apache.kafka.clients.producer.ProducerRecord<String, byte[]> record,
+              org.apache.kafka.clients.producer.Callback callback) {
+            if (callback != null) {
+              callback.onCompletion(null, new RuntimeException("Kafka send error"));
+            }
+            return null;
+          }
+        };
+
+    kafkaProducerField.set(bulkIngestKafkaProducer, failingProducer);
+
+    bulkIngestKafkaProducer.startAsync().awaitRunning(DEFAULT_START_STOP_DURATION);
+
+    Trace.Span testDoc = Trace.Span.newBuilder().setId(ByteString.copyFromUtf8("test-doc")).build();
+    BulkIngestRequest request =
+        bulkIngestKafkaProducer.submitRequest(Map.of(INDEX_NAME, List.of(testDoc)));
+
+    AtomicReference<BulkIngestResponse> response = new AtomicReference<>();
+    Thread.ofVirtual()
+        .start(
+            () -> {
+              try {
+                response.set(request.getResponse());
+              } catch (InterruptedException ignored) {
+              }
+            });
+
+    await().until(() -> response.get() != null);
+
+    assertThat(response.get().failedDocs()).isEqualTo(1);
+    assertThat(response.get().errorMsg()).contains("Kafka send error");
+
+    System.setProperty("astra.bulkIngest.useKafkaTransactions", "true");
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -199,7 +199,7 @@ class BulkIngestKafkaProducerTest {
   }
 
   @Test
-  public void testKafkaSendErrorPropagatedWithoutTransactions() throws Exception {
+  public void testNonTransactionalFutureErrorHandling() throws Exception {
     bulkIngestKafkaProducer.stopAsync().awaitTerminated(DEFAULT_START_STOP_DURATION);
     System.setProperty("astra.bulkIngest.useKafkaTransactions", "false");
 
@@ -219,26 +219,39 @@ class BulkIngestKafkaProducerTest {
         "org.apache.kafka.common.serialization.ByteArraySerializer");
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
 
-    org.apache.kafka.clients.producer.KafkaProducer<String, byte[]> failingProducer =
+    // Create producer that returns futures - some succeed, some fail
+    java.util.concurrent.atomic.AtomicInteger callCount =
+        new java.util.concurrent.atomic.AtomicInteger(0);
+    org.apache.kafka.clients.producer.KafkaProducer<String, byte[]> futureBasedProducer =
         new org.apache.kafka.clients.producer.KafkaProducer<>(props) {
           @Override
           public java.util.concurrent.Future<org.apache.kafka.clients.producer.RecordMetadata> send(
-              org.apache.kafka.clients.producer.ProducerRecord<String, byte[]> record,
-              org.apache.kafka.clients.producer.Callback callback) {
-            if (callback != null) {
-              callback.onCompletion(null, new RuntimeException("Kafka send error"));
+              org.apache.kafka.clients.producer.ProducerRecord<String, byte[]> record) {
+            int call = callCount.incrementAndGet();
+            if (call <= 2) {
+              // First 2 calls succeed
+              return java.util.concurrent.CompletableFuture.completedFuture(
+                  new org.apache.kafka.clients.producer.RecordMetadata(
+                      new org.apache.kafka.common.TopicPartition("test", 0), 0, 0, 0, 0, 0));
+            } else {
+              // Last call fails with ExecutionException
+              return java.util.concurrent.CompletableFuture.failedFuture(
+                  new java.util.concurrent.ExecutionException(
+                      "Future failed", new RuntimeException("Network error")));
             }
-            return null;
           }
         };
 
-    kafkaProducerField.set(bulkIngestKafkaProducer, failingProducer);
-
+    kafkaProducerField.set(bulkIngestKafkaProducer, futureBasedProducer);
     bulkIngestKafkaProducer.startAsync().awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    Trace.Span testDoc = Trace.Span.newBuilder().setId(ByteString.copyFromUtf8("test-doc")).build();
+    // Test with 3 docs - 2 succeed, 1 fails
+    Trace.Span doc1 = Trace.Span.newBuilder().setId(ByteString.copyFromUtf8("success1")).build();
+    Trace.Span doc2 = Trace.Span.newBuilder().setId(ByteString.copyFromUtf8("success2")).build();
+    Trace.Span doc3 = Trace.Span.newBuilder().setId(ByteString.copyFromUtf8("failure")).build();
+
     BulkIngestRequest request =
-        bulkIngestKafkaProducer.submitRequest(Map.of(INDEX_NAME, List.of(testDoc)));
+        bulkIngestKafkaProducer.submitRequest(Map.of(INDEX_NAME, List.of(doc1, doc2, doc3)));
 
     AtomicReference<BulkIngestResponse> response = new AtomicReference<>();
     Thread.ofVirtual()
@@ -252,8 +265,14 @@ class BulkIngestKafkaProducerTest {
 
     await().until(() -> response.get() != null);
 
+    // Verify that futures are waited for and errors propagated
+    assertThat(response.get().totalDocs()).isEqualTo(2); // 3 total - 1 failure
     assertThat(response.get().failedDocs()).isEqualTo(1);
-    assertThat(response.get().errorMsg()).contains("Kafka send error");
+    assertThat(response.get().errorMsg())
+        .isEqualTo(
+            String.format(
+                "Kafka send failure. index: %s partition: 0 failures: 1 - check logs for details.",
+                INDEX_NAME));
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -254,8 +254,6 @@ class BulkIngestKafkaProducerTest {
 
     assertThat(response.get().failedDocs()).isEqualTo(1);
     assertThat(response.get().errorMsg()).contains("Kafka send error");
-
-    System.setProperty("astra.bulkIngest.useKafkaTransactions", "true");
   }
 
   @Test


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

This PR fixes [issue #1173](https://github.com/slackhq/astra/issues/1173).  
Previously, when Kafka transactions were disabled (`useKafkaTransactions = false`), any exceptions raised via the Kafka `send(...)` callback were logged but not propagated. As a result, requests would silently time out instead of failing clearly.

This change ensures that when a send error occurs:
- It is counted as a failed document.
- The error message is captured and returned in the `BulkIngestResponse`.

### Fix Details

- In the non-transactional `produceDocuments(...)` code path:
  - Captures any callback exceptions from `KafkaProducer.send(...)`.
  - Accumulates error messages and failure count.
  - Returns a `BulkIngestResponse` that reflects the failure.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

cc @baroquebobcat for review, please let me know if you'd like anything adjusted.
I have a local test that simulates a callback failure when Kafka transactions are disabled.
I'm happy to include it (or update it) if you think it's helpful.