### PR TITLE
Clean error prone Warnings (Fixes #501 partially)

### DIFF
--- a/astra/src/main/java/com/slack/astra/blobfs/BlobStore.java
+++ b/astra/src/main/java/com/slack/astra/blobfs/BlobStore.java
@@ -1,7 +1,5 @@
 package com.slack.astra.blobfs;
 
-import static software.amazon.awssdk.services.s3.model.ListObjectsV2Request.builder;
-
 import com.slack.astra.chunk.ReadWriteChunk;
 import java.nio.file.Path;
 import java.util.List;
@@ -162,7 +160,8 @@ public class BlobStore {
   public List<String> listFiles(String prefix) {
     assert prefix != null && !prefix.isEmpty();
 
-    ListObjectsV2Request listRequest = builder().bucket(bucketName).prefix(prefix).build();
+    ListObjectsV2Request listRequest =
+        ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).build();
     ListObjectsV2Publisher asyncPaginatedListResponse =
         s3AsyncClient.listObjectsV2Paginator(listRequest);
 
@@ -189,7 +188,8 @@ public class BlobStore {
   public boolean delete(String prefix) {
     assert prefix != null && !prefix.isEmpty();
 
-    ListObjectsV2Request listRequest = builder().bucket(bucketName).prefix(prefix).build();
+    ListObjectsV2Request listRequest =
+        ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).build();
     ListObjectsV2Publisher asyncPaginatedListResponse =
         s3AsyncClient.listObjectsV2Paginator(listRequest);
 

--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/BulkIngestApi.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/BulkIngestApi.java
@@ -68,7 +68,7 @@ public class BulkIngestApi {
     // 2. The "index" is used as the span name
     CompletableFuture<HttpResponse> future = new CompletableFuture<>();
     Timer.Sample sample = Timer.start(meterRegistry);
-    future.thenRun(() -> sample.stop(bulkIngestTimer));
+    var unused = future.thenRun(() -> sample.stop(bulkIngestTimer));
 
     try {
       byte[] bulkRequestBytes = bulkRequest.getBytes(StandardCharsets.UTF_8);

--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
@@ -96,7 +96,7 @@ public class BulkApiRequestParser {
     }
 
     Trace.Span.Builder spanBuilder = Trace.Span.newBuilder();
-    spanBuilder.setId(ByteString.copyFrom(id.getBytes()));
+    spanBuilder.setId(ByteString.copyFromUtf8(id));
     // Trace.Span proto expects duration in microseconds today
     spanBuilder.setTimestamp(timestampInMicros);
 
@@ -205,7 +205,7 @@ public class BulkApiRequestParser {
     List<DocWriteRequest<?>> requests = bulkRequest.requests();
     for (DocWriteRequest<?> request : requests) {
       if (request.opType() == DocWriteRequest.OpType.INDEX
-          | request.opType() == DocWriteRequest.OpType.CREATE) {
+          || request.opType() == DocWriteRequest.OpType.CREATE) {
 
         // The client makes a DocWriteRequest and sends it to the server
         // IngestService#innerExecute is where the server eventually reads when request is an

--- a/astra/src/main/java/com/slack/astra/chunk/ChunkInfo.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ChunkInfo.java
@@ -227,7 +227,7 @@ public class ChunkInfo {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof ChunkInfo)) return false;
     ChunkInfo chunkInfo = (ChunkInfo) o;
     return chunkCreationTimeEpochMs == chunkInfo.chunkCreationTimeEpochMs
         && maxOffset == chunkInfo.maxOffset

--- a/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
@@ -277,7 +277,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
       }
 
       // set chunk state
-      cacheNodeAssignmentStore.updateAssignmentState(
+      var unused = cacheNodeAssignmentStore.updateAssignmentState(
           getCacheNodeAssignment(), Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE);
       lastKnownAssignmentState = Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE;
 

--- a/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
@@ -277,8 +277,9 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
       }
 
       // set chunk state
-      var unused = cacheNodeAssignmentStore.updateAssignmentState(
-          getCacheNodeAssignment(), Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE);
+      var unused =
+          cacheNodeAssignmentStore.updateAssignmentState(
+              getCacheNodeAssignment(), Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE);
       lastKnownAssignmentState = Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE;
 
       // register searchmetadata

--- a/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
@@ -239,7 +239,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
                     assignment,
                     snapshotsBySnapshotId.get(assignment.snapshotId),
                     cacheNodeMetadataStore);
-            executorService.submit(newChunk::downloadChunkData);
+            var unused = executorService.submit(newChunk::downloadChunkData);
             chunkMap.put(assignment.assignmentId, newChunk);
           }
         }

--- a/astra/src/main/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategy.java
+++ b/astra/src/main/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategy.java
@@ -80,7 +80,7 @@ public class DiskOrMessageCountBasedRolloverStrategy implements ChunkRollOverStr
     this.rolloverStartTime = Instant.now();
     this.liveBytesDirGauge = this.registry.gauge(LIVE_BYTES_DIR, new AtomicLong(0));
 
-    directorySizeExecutorService.scheduleAtFixedRate(
+    var unused = directorySizeExecutorService.scheduleAtFixedRate(
         () -> {
           try {
             long dirSize = calculateDirectorySize(activeChunkDirectory);

--- a/astra/src/main/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategy.java
+++ b/astra/src/main/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategy.java
@@ -80,30 +80,32 @@ public class DiskOrMessageCountBasedRolloverStrategy implements ChunkRollOverStr
     this.rolloverStartTime = Instant.now();
     this.liveBytesDirGauge = this.registry.gauge(LIVE_BYTES_DIR, new AtomicLong(0));
 
-    var unused = directorySizeExecutorService.scheduleAtFixedRate(
-        () -> {
-          try {
-            long dirSize = calculateDirectorySize(activeChunkDirectory);
-            // in case the method fails to calculate we return -1 so don't update the old value
-            if (dirSize > 0) {
-              approximateDirectoryBytes.set(dirSize);
-            }
-            if (!maxTimePerChunksMinsReached.get()
-                && Instant.now()
-                    .isAfter(rolloverStartTime.plus(maxTimePerChunksSeconds, ChronoUnit.SECONDS))) {
-              LOG.info(
-                  "Max time per chunk reached. chunkStartTime: {} currentTime: {}",
-                  rolloverStartTime,
-                  Instant.now());
-              maxTimePerChunksMinsReached.set(true);
-            }
-          } catch (Exception e) {
-            LOG.error("Error calculating directory size", e);
-          }
-        },
-        DIRECTORY_SIZE_EXECUTOR_PERIOD_MS,
-        DIRECTORY_SIZE_EXECUTOR_PERIOD_MS,
-        TimeUnit.MILLISECONDS);
+    var unused =
+        directorySizeExecutorService.scheduleAtFixedRate(
+            () -> {
+              try {
+                long dirSize = calculateDirectorySize(activeChunkDirectory);
+                // in case the method fails to calculate we return -1 so don't update the old value
+                if (dirSize > 0) {
+                  approximateDirectoryBytes.set(dirSize);
+                }
+                if (!maxTimePerChunksMinsReached.get()
+                    && Instant.now()
+                        .isAfter(
+                            rolloverStartTime.plus(maxTimePerChunksSeconds, ChronoUnit.SECONDS))) {
+                  LOG.info(
+                      "Max time per chunk reached. chunkStartTime: {} currentTime: {}",
+                      rolloverStartTime,
+                      Instant.now());
+                  maxTimePerChunksMinsReached.set(true);
+                }
+              } catch (Exception e) {
+                LOG.error("Error calculating directory size", e);
+              }
+            },
+            DIRECTORY_SIZE_EXECUTOR_PERIOD_MS,
+            DIRECTORY_SIZE_EXECUTOR_PERIOD_MS,
+            TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/astra/src/main/java/com/slack/astra/logstore/AstraMergeScheduler.java
+++ b/astra/src/main/java/com/slack/astra/logstore/AstraMergeScheduler.java
@@ -56,7 +56,7 @@ public class AstraMergeScheduler extends ConcurrentMergeScheduler {
     boolean paused = super.maybeStall(mergeSource);
 
     long elapsed = System.nanoTime() - startTime;
-    stallCounter.increment(elapsed);
+    stallCounter.increment((double) elapsed);
     activeStallThreadsCount.decrementAndGet();
 
     return paused;

--- a/astra/src/main/java/com/slack/astra/logstore/AstraMergeScheduler.java
+++ b/astra/src/main/java/com/slack/astra/logstore/AstraMergeScheduler.java
@@ -55,8 +55,8 @@ public class AstraMergeScheduler extends ConcurrentMergeScheduler {
 
     boolean paused = super.maybeStall(mergeSource);
 
-    long elapsed = System.nanoTime() - startTime;
-    stallCounter.increment((double) elapsed);
+    double elapsed = System.nanoTime() - startTime;
+    stallCounter.increment(elapsed);
     activeStallThreadsCount.decrementAndGet();
 
     return paused;

--- a/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
@@ -139,29 +139,31 @@ public class LuceneIndexStoreImpl implements LogStore {
             ShardId.fromString("[shard-index][%d]".formatted(UUID.fromString(id).hashCode())));
     this.astraSearcherManager = new AstraSearcherManager(openSearchDirectoryReader);
 
-    var unused = scheduledCommit.scheduleWithFixedDelay(
-        () -> {
-          try {
-            commit();
-          } catch (Exception e) {
-            LOG.error("Error running scheduled commit", e);
-          }
-        },
-        config.commitDuration.toMillis(),
-        config.commitDuration.toMillis(),
-        TimeUnit.MILLISECONDS);
+    var unused =
+        scheduledCommit.scheduleWithFixedDelay(
+            () -> {
+              try {
+                commit();
+              } catch (Exception e) {
+                LOG.error("Error running scheduled commit", e);
+              }
+            },
+            config.commitDuration.toMillis(),
+            config.commitDuration.toMillis(),
+            TimeUnit.MILLISECONDS);
 
-    var unused_1 = scheduledRefresh.scheduleWithFixedDelay(
-        () -> {
-          try {
-            refresh();
-          } catch (Exception e) {
-            LOG.error("Error running scheduled commit", e);
-          }
-        },
-        config.refreshDuration.toMillis(),
-        config.refreshDuration.toMillis(),
-        TimeUnit.MILLISECONDS);
+    var unused_1 =
+        scheduledRefresh.scheduleWithFixedDelay(
+            () -> {
+              try {
+                refresh();
+              } catch (Exception e) {
+                LOG.error("Error running scheduled commit", e);
+              }
+            },
+            config.refreshDuration.toMillis(),
+            config.refreshDuration.toMillis(),
+            TimeUnit.MILLISECONDS);
 
     // Initialize stats counters
     messagesReceivedCounter = registry.counter(MESSAGES_RECEIVED_COUNTER);

--- a/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
@@ -139,7 +139,7 @@ public class LuceneIndexStoreImpl implements LogStore {
             ShardId.fromString("[shard-index][%d]".formatted(UUID.fromString(id).hashCode())));
     this.astraSearcherManager = new AstraSearcherManager(openSearchDirectoryReader);
 
-    scheduledCommit.scheduleWithFixedDelay(
+    var unused = scheduledCommit.scheduleWithFixedDelay(
         () -> {
           try {
             commit();
@@ -151,7 +151,7 @@ public class LuceneIndexStoreImpl implements LogStore {
         config.commitDuration.toMillis(),
         TimeUnit.MILLISECONDS);
 
-    scheduledRefresh.scheduleWithFixedDelay(
+    var unused_1 = scheduledRefresh.scheduleWithFixedDelay(
         () -> {
           try {
             refresh();
@@ -203,7 +203,7 @@ public class LuceneIndexStoreImpl implements LogStore {
         new IndexWriterConfig(analyzer)
             .setOpenMode(IndexWriterConfig.OpenMode.CREATE)
             .setMergeScheduler(new AstraMergeScheduler(metricsRegistry))
-            .setRAMBufferSizeMB(ramBufferSizeMb)
+            .setRAMBufferSizeMB((double) ramBufferSizeMb)
             .setUseCompoundFile(useCFSFiles)
             // we sort by timestamp descending, as that is the order we expect to return results the
             // majority of the time

--- a/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
@@ -29,7 +29,6 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
-import org.apache.lucene.search.SortField.Type;
 import org.apache.lucene.search.TopFieldCollector;
 import org.apache.lucene.search.TopFieldDocs;
 import org.opensearch.index.query.QueryBuilder;
@@ -204,7 +203,8 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
   private CollectorManager<TopFieldCollector, TopFieldDocs> buildTopFieldCollector(
       int howMany, int totalHitsThreshold) {
     if (howMany > 0) {
-      SortField sortField = new SortField(SystemField.TIME_SINCE_EPOCH.fieldName, SortField.Type.LONG, true);
+      SortField sortField =
+          new SortField(SystemField.TIME_SINCE_EPOCH.fieldName, SortField.Type.LONG, true);
       return TopFieldCollector.createSharedManager(
           new Sort(sortField), howMany, null, totalHitsThreshold);
     } else {

--- a/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
@@ -204,7 +204,7 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
   private CollectorManager<TopFieldCollector, TopFieldDocs> buildTopFieldCollector(
       int howMany, int totalHitsThreshold) {
     if (howMany > 0) {
-      SortField sortField = new SortField(SystemField.TIME_SINCE_EPOCH.fieldName, Type.LONG, true);
+      SortField sortField = new SortField(SystemField.TIME_SINCE_EPOCH.fieldName, SortField.Type.LONG, true);
       return TopFieldCollector.createSharedManager(
           new Sort(sortField), howMany, null, totalHitsThreshold);
     } else {

--- a/astra/src/main/java/com/slack/astra/logstore/search/SearchResult.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/SearchResult.java
@@ -77,7 +77,7 @@ public class SearchResult<T> {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof SearchResult)) return false;
 
     SearchResult<?> that = (SearchResult<?>) o;
 

--- a/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionStoredFieldVisitor.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionStoredFieldVisitor.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.StoredFieldVisitor;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * RedactionStoreFieldVisitor reads the individual fields of the logs that come back from a search
  * and redacts the values if necessary using the values in FieldRedactionMetadataStore.
@@ -70,7 +72,7 @@ class RedactionStoredFieldVisitor extends StoredFieldVisitor {
   @Override
   public void stringField(FieldInfo fieldInfo, String value) throws IOException {
     if (fieldInfo.name.equals("_source")) {
-      Map<String, Object> source = redactField(value.getBytes());
+      Map<String, Object> source = redactField(value.getBytes(UTF_8));
       delegate.stringField(fieldInfo, om.writeValueAsString(source));
     } else {
       delegate.stringField(fieldInfo, value);

--- a/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionStoredFieldVisitor.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionStoredFieldVisitor.java
@@ -1,5 +1,7 @@
 package com.slack.astra.logstore.search.fieldRedaction;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.slack.astra.logstore.LogMessage;
@@ -10,8 +12,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.StoredFieldVisitor;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * RedactionStoreFieldVisitor reads the individual fields of the logs that come back from a search

--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadata.java
@@ -19,7 +19,7 @@ public abstract class AstraMetadata implements NodeName {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof AstraMetadata)) return false;
     AstraMetadata that = (AstraMetadata) o;
     return name.equals(that.name);
   }

--- a/astra/src/main/java/com/slack/astra/metadata/core/MetadataSerializer.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/MetadataSerializer.java
@@ -4,6 +4,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import org.apache.curator.x.async.modeled.ModelSerializer;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * An interface that helps us covert protobuf objects to and from json.
  *
@@ -28,7 +30,7 @@ public interface MetadataSerializer<T extends AstraMetadata> {
         }
 
         try {
-          return toJsonStr(model).getBytes();
+          return toJsonStr(model).getBytes(UTF_8);
         } catch (Exception e) {
           throw new IllegalArgumentException(e);
         }
@@ -41,7 +43,7 @@ public interface MetadataSerializer<T extends AstraMetadata> {
         }
 
         try {
-          return fromJsonStr(new String(bytes));
+          return fromJsonStr(new String(bytes, UTF_8));
         } catch (Exception e) {
           throw new IllegalStateException(e);
         }

--- a/astra/src/main/java/com/slack/astra/metadata/core/MetadataSerializer.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/MetadataSerializer.java
@@ -1,10 +1,10 @@
 package com.slack.astra.metadata.core;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import org.apache.curator.x.async.modeled.ModelSerializer;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * An interface that helps us covert protobuf objects to and from json.

--- a/astra/src/main/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadata.java
@@ -49,7 +49,7 @@ public class DatasetPartitionMetadata {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof DatasetPartitionMetadata)) return false;
     DatasetPartitionMetadata that = (DatasetPartitionMetadata) o;
     return startTimeEpochMs == that.startTimeEpochMs
         && endTimeEpochMs == that.endTimeEpochMs

--- a/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryNodeMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryNodeMetadata.java
@@ -42,7 +42,7 @@ public class RecoveryNodeMetadata extends AstraMetadata {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof RecoveryNodeMetadata)) return false;
     if (!super.equals(o)) return false;
     RecoveryNodeMetadata that = (RecoveryNodeMetadata) o;
     return updatedTimeEpochMs == that.updatedTimeEpochMs

--- a/astra/src/main/java/com/slack/astra/metadata/schema/ChunkSchema.java
+++ b/astra/src/main/java/com/slack/astra/metadata/schema/ChunkSchema.java
@@ -1,5 +1,7 @@
 package com.slack.astra.metadata.schema;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.common.base.Objects;
 import com.slack.astra.metadata.core.AstraMetadata;
 import java.io.File;
@@ -7,8 +9,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This schema class enforces schema for a chunk. The schema is only written in indexer and on the

--- a/astra/src/main/java/com/slack/astra/metadata/schema/ChunkSchema.java
+++ b/astra/src/main/java/com/slack/astra/metadata/schema/ChunkSchema.java
@@ -8,6 +8,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * This schema class enforces schema for a chunk. The schema is only written in indexer and on the
  * cache node the schema is read only.
@@ -24,7 +26,7 @@ public class ChunkSchema extends AstraMetadata {
   }
 
   public static ChunkSchema deserializeBytes(byte[] bytes) throws IOException {
-    return serDe.fromJsonStr(new String(bytes));
+    return serDe.fromJsonStr(new String(bytes, UTF_8));
   }
 
   public static ChunkSchema deserializeFile(Path path) throws IOException {
@@ -57,7 +59,7 @@ public class ChunkSchema extends AstraMetadata {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof ChunkSchema)) return false;
     if (!super.equals(o)) return false;
     ChunkSchema that = (ChunkSchema) o;
     return Objects.equal(fieldDefMap, that.fieldDefMap) && Objects.equal(metadata, that.metadata);

--- a/astra/src/main/java/com/slack/astra/metadata/schema/FieldType.java
+++ b/astra/src/main/java/com/slack/astra/metadata/schema/FieldType.java
@@ -399,7 +399,7 @@ public enum FieldType {
         try {
           return Long.valueOf((String) value);
         } catch (NumberFormatException e) {
-          return (long) 0;
+          return 0L;
         }
       }
       if (toType == FieldType.DOUBLE) {
@@ -413,7 +413,7 @@ public enum FieldType {
         try {
           return Float.valueOf((String) value);
         } catch (NumberFormatException e) {
-          return (float) 0;
+          return 0.0f;
         }
       }
       if (toType == FieldType.BOOLEAN) {

--- a/astra/src/main/java/com/slack/astra/metadata/schema/LuceneFieldDef.java
+++ b/astra/src/main/java/com/slack/astra/metadata/schema/LuceneFieldDef.java
@@ -24,7 +24,7 @@ public class LuceneFieldDef extends AstraMetadata {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof LuceneFieldDef)) return false;
     if (!super.equals(o)) return false;
     LuceneFieldDef that = (LuceneFieldDef) o;
     return isStored == that.isStored

--- a/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadata.java
@@ -51,7 +51,7 @@ public class SearchMetadata extends AstraMetadata {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof SearchMetadata)) return false;
     if (!super.equals(o)) return false;
 
     SearchMetadata that = (SearchMetadata) o;

--- a/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
+++ b/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
@@ -312,8 +312,9 @@ public class RecoveryService extends AbstractIdleService {
       if (partitionOffsets.startOffset != recoveryTaskMetadata.startOffset
           || recoveryTaskMetadata.endOffset != partitionOffsets.endOffset) {
         recoveryRecordsNoLongerAvailable.increment(
-                (double) ((partitionOffsets.startOffset - recoveryTaskMetadata.startOffset)
-                + (partitionOffsets.endOffset - recoveryTaskMetadata.endOffset)));
+            (double)
+                ((partitionOffsets.startOffset - recoveryTaskMetadata.startOffset)
+                    + (partitionOffsets.endOffset - recoveryTaskMetadata.endOffset)));
       }
 
       try {
@@ -373,7 +374,7 @@ public class RecoveryService extends AbstractIdleService {
           recoveryTaskMetadata,
           nanosToMillis(offsetsValidatedTime - startTime));
       recoveryRecordsNoLongerAvailable.increment(
-              (double) (recoveryTaskMetadata.endOffset - recoveryTaskMetadata.startOffset + 1));
+          (double) (recoveryTaskMetadata.endOffset - recoveryTaskMetadata.startOffset + 1));
       return true;
     }
   }

--- a/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
+++ b/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
@@ -312,8 +312,8 @@ public class RecoveryService extends AbstractIdleService {
       if (partitionOffsets.startOffset != recoveryTaskMetadata.startOffset
           || recoveryTaskMetadata.endOffset != partitionOffsets.endOffset) {
         recoveryRecordsNoLongerAvailable.increment(
-            (partitionOffsets.startOffset - recoveryTaskMetadata.startOffset)
-                + (partitionOffsets.endOffset - recoveryTaskMetadata.endOffset));
+                (double) ((partitionOffsets.startOffset - recoveryTaskMetadata.startOffset)
+                + (partitionOffsets.endOffset - recoveryTaskMetadata.endOffset)));
       }
 
       try {
@@ -373,7 +373,7 @@ public class RecoveryService extends AbstractIdleService {
           recoveryTaskMetadata,
           nanosToMillis(offsetsValidatedTime - startTime));
       recoveryRecordsNoLongerAvailable.increment(
-          recoveryTaskMetadata.endOffset - recoveryTaskMetadata.startOffset + 1);
+              (double) (recoveryTaskMetadata.endOffset - recoveryTaskMetadata.startOffset + 1));
       return true;
     }
   }

--- a/astra/src/main/java/com/slack/astra/util/JsonUtil.java
+++ b/astra/src/main/java/com/slack/astra/util/JsonUtil.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class JsonUtil {
   private static JsonUtil ourInstance = new JsonUtil();
   private final ObjectMapper mapper;
@@ -20,7 +22,7 @@ public class JsonUtil {
   }
 
   public static <T> ByteBuffer toByteBuffer(T obj) throws JsonProcessingException {
-    return ByteBuffer.wrap(writeAsString(obj).getBytes());
+    return ByteBuffer.wrap(writeAsString(obj).getBytes(UTF_8));
   }
 
   public static <T> String writeAsString(T obj) throws JsonProcessingException {

--- a/astra/src/main/java/com/slack/astra/util/JsonUtil.java
+++ b/astra/src/main/java/com/slack/astra/util/JsonUtil.java
@@ -1,5 +1,7 @@
 package com.slack.astra.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -10,8 +12,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class JsonUtil {
   private static JsonUtil ourInstance = new JsonUtil();

--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -101,7 +101,7 @@ public class SpanFormatter {
         }
         case BINARY -> {
           tagBuilder.setFieldType(Schema.SchemaFieldType.BINARY);
-          tagBuilder.setVBinary(ByteString.copyFrom(value.toString().getBytes()));
+          tagBuilder.setVBinary(ByteString.copyFromUtf8(value.toString()));
         }
       }
       return tagBuilder.build();

--- a/astra/src/main/java/com/slack/astra/writer/kafka/AstraKafkaConsumer.java
+++ b/astra/src/main/java/com/slack/astra/writer/kafka/AstraKafkaConsumer.java
@@ -124,14 +124,14 @@ public class AstraKafkaConsumer {
     for (String property : props.stringPropertyNames()) {
       Preconditions.checkArgument(
           props.getProperty(property) != null && !props.getProperty(property).isEmpty(),
-          String.format("Property %s cannot be null or empty", property));
+          "Property %s cannot be null or empty", property);
     }
 
     // Check required configs.
     for (String requiredConfig : REQUIRED_CONFIGS) {
       checkNotNull(
           props.getProperty(requiredConfig),
-          String.format("Property %s is required but not provided", requiredConfig));
+          "Property %s is required but not provided", requiredConfig);
     }
 
     StringBuilder propertiesBuilder = new StringBuilder("Kafka params are: ");
@@ -211,7 +211,7 @@ public class AstraKafkaConsumer {
         kafkaError = ex;
         LOG.warn(String.format("Caught unexpected exception, retry number: %d", i), ex);
         try {
-          Thread.sleep((i + 1) * 3000);
+          Thread.sleep((i + 1) * 3000L);
         } catch (InterruptedException exex) {
           LOG.warn("Caught unexpected exception during sleep.", exex);
         }

--- a/astra/src/main/java/com/slack/astra/writer/kafka/AstraKafkaConsumer.java
+++ b/astra/src/main/java/com/slack/astra/writer/kafka/AstraKafkaConsumer.java
@@ -124,14 +124,16 @@ public class AstraKafkaConsumer {
     for (String property : props.stringPropertyNames()) {
       Preconditions.checkArgument(
           props.getProperty(property) != null && !props.getProperty(property).isEmpty(),
-          "Property %s cannot be null or empty", property);
+          "Property %s cannot be null or empty",
+          property);
     }
 
     // Check required configs.
     for (String requiredConfig : REQUIRED_CONFIGS) {
       checkNotNull(
           props.getProperty(requiredConfig),
-          "Property %s is required but not provided", requiredConfig);
+          "Property %s is required but not provided",
+          requiredConfig);
     }
 
     StringBuilder propertiesBuilder = new StringBuilder("Kafka params are: ");

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -37,8 +37,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-/*
+/**
  * Zipkin compatible API service
  *
  * @see <a
@@ -48,6 +47,7 @@ import org.slf4j.LoggerFactory;
  *     compatible with Zipkin</a> <a href="https://zipkin.io/zipkin-api/#/">Trace API Swagger
  *     Hub</a>
  */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class ZipkinService {
 
   protected static String convertLogWireMessageToZipkinSpan(List<LogWireMessage> messages)

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-/**
+/*
  * Zipkin compatible API service
  *
  * @see <a


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

This PR fixes issue [#501](https://github.com/slackhq/astra/issues/501) partially. 

### Fix Details

This PR addresses 30 low-risk Error Prone warnings throughout the codebase to improve code quality and prevent potential issues.

Changes Summary:

  DefaultCharset Fixes (8)

  - Added explicit UTF-8 charset specification instead of using platform defaults in:
    - MetadataSerializer.java (toJsonStr, fromJsonStr)
    - BulkApiRequestParser.java (ByteString.copyFromUtf8)
    - SpanFormatter.java (ByteString conversion)
    - ChunkSchema.java (String constructor)
    - RedactionStoredFieldVisitor.java (getBytes)
    - JsonUtil.java (getBytes)

  FutureReturnValueIgnored Fixes (7)

  - Added explicit handling for ignored Future return values by storing in var unused variables:
    - BulkIngestApi.java (thenRun)
    - CachingChunkManager.java (submit)
    - ReadOnlyChunkImpl.java (updateAssignmentState)
    - DiskOrMessageCountBasedRolloverStrategy.java (scheduleAtFixedRate)
    - LuceneIndexStoreImpl.java (scheduleWithFixedDelay - both instances)

  EqualsGetClass Improvements (7)

  - Replaced getClass() comparison with more flexible instanceof pattern:
    - AstraMetadata.java
    - ChunkInfo.java
    - SearchResult.java
    - LuceneFieldDef.java
    - SearchMetadata.java
    - ChunkSchema.java
    - RecoveryNodeMetadata.java

  Type Conversion Improvements (5)

  - Added explicit casts for numeric type conversions:
    - FieldType.java (int literals to 0L, 0.0f)
    - LuceneIndexStoreImpl.java (ramBufferSizeMb to double)
    - AstraMergeScheduler.java (long to double)
    - RecoveryService.java (two long calculations to double)
    - AstraKafkaConsumer.java (int multiplication to long - 3000L)

  Other Fixes (3)

  - Fixed BadImport issue in LogIndexSearcherImpl.java (SortField.Type qualification)
  - Fixed PreconditionsExpensiveString in AstraKafkaConsumer.java (removed String.format)
  - Fixed NotJavadoc in ZipkinService.java (/** to /*)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

cc @baroquebobcat for review, please let me know if you'd like anything adjusted.