### PR TITLE
add checks that all files successfully uploaded to s3 and downloaded from s3

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadOnlyChunkImpl.java
@@ -411,10 +411,12 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
 
         List<String> filesInS3 = blobStore.listFiles(snapshotMetadata.snapshotId);
         if (numFilesLocal != filesInS3.size()) {
-          throw new IOException(
+          String errorString =
               String.format(
                   "Mismatch in number of files in S3 (%s) and local directory (%s) for snapshot %s",
-                  filesInS3.size(), numFilesLocal, snapshotMetadata.toString()));
+                  filesInS3.size(), numFilesLocal, snapshotMetadata.toString());
+          LOG.error(errorString);
+          throw new IOException(errorString);
         }
       }
 

--- a/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
@@ -239,6 +239,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
       filesToUpload.add(schemaFile.getName());
       indexCommit = logStore.getIndexCommit();
       filesToUpload.addAll(indexCommit.getFileNames());
+      int numFilesToUpload = filesToUpload.size();
 
       // Upload files
       logger.info("{} active files in {} in index", filesToUpload.size(), dirPath);
@@ -249,10 +250,33 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
       }
       this.fileUploadAttempts.increment(filesToUpload.size());
       Timer.Sample snapshotTimer = Timer.start(meterRegistry);
+
+      // blobstore.upload uploads everything in the directory, including write.lock if it exists.
       blobStore.upload(chunkInfo.chunkId, dirPath);
 
       snapshotTimer.stop(meterRegistry.timer(SNAPSHOT_TIMER));
       chunkInfo.setSizeInBytesOnDisk(totalBytes);
+
+      List<String> filesUploaded = blobStore.listFiles(chunkInfo.chunkId);
+      filesUploaded.removeIf(file -> file.endsWith("write.lock"));
+
+      // check here that all files are uploaded
+      if (filesUploaded.size() != numFilesToUpload) {
+        filesToUpload.sort(String::compareTo);
+        filesUploaded.sort(String::compareTo);
+        logger.error(
+            "Not all files were uploaded to S3. Expected {}, but got {}.\nFiles to upload: {}\nFiles uploaded: {}",
+            numFilesToUpload,
+            filesUploaded.size(),
+            filesToUpload,
+            filesUploaded);
+        return false;
+      }
+      // and schema file exists in s3
+      if (!filesUploaded.contains(chunkInfo.chunkId + "/" + SCHEMA_FILE_NAME)) {
+        logger.error("Schema file {} was not uploaded to S3.", SCHEMA_FILE_NAME);
+        return false;
+      }
       logger.info("Finished RW chunk snapshot to S3 {}.", chunkInfo);
       return true;
     } catch (Exception e) {

--- a/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
@@ -274,7 +274,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
       }
       // and schema file exists in s3
       if (!filesUploaded.contains(chunkInfo.chunkId + "/" + SCHEMA_FILE_NAME)) {
-        logger.error("Schema file {} was not uploaded to S3.", SCHEMA_FILE_NAME);
+        logger.error("Schema file was not uploaded to S3: {}", SCHEMA_FILE_NAME);
         return false;
       }
       logger.info("Finished RW chunk snapshot to S3 {}.", chunkInfo);

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -15,6 +15,8 @@ import static com.slack.astra.testlib.TemporaryLogStoreAndSearcherExtension.MAX_
 import static com.slack.astra.util.AggregatorFactoriesUtil.createGenericDateHistogramAggregatorFactoriesBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
@@ -39,6 +41,7 @@ import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -48,6 +51,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.curator.test.TestingServer;
@@ -58,6 +62,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
@@ -700,6 +705,69 @@ public class IndexingChunkImplTest {
       assertThat(schemaFieldsInSchema)
           .withFailMessage("Schema should not exceed 1500 fields but had %s", dynamicFieldsInSchema)
           .isLessThanOrEqualTo(100);
+    }
+
+    @Test
+    public void testSnapshotFailsOnBadUpload() throws Exception {
+      // Setup
+      List<Trace.Span> messages = SpanUtil.makeSpansWithTimeDifference(1, 10, 1, Instant.now());
+      int offset = 1;
+      for (Trace.Span m : messages) {
+        chunk.addMessage(m, TEST_KAFKA_PARTITION_ID, offset++);
+      }
+
+      chunk.preSnapshot();
+      assertThat(chunk.isReadOnly()).isTrue();
+
+      // Create S3 bucket and BlobStore
+      String bucket = "test-bucket-bad-upload";
+      S3AsyncClient s3Client =
+          S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
+      s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build()).get();
+
+      // Spy the real blobstore
+      BlobStore realBlobStore = new BlobStore(s3Client, bucket);
+      BlobStore spyBlobStore = org.mockito.Mockito.spy(realBlobStore);
+
+      // Override upload to simulate skipping schema.json and injecting write.lock
+      doAnswer(
+              invocation -> {
+                String chunkId = invocation.getArgument(0);
+                Path dirPath = invocation.getArgument(1);
+
+                // Upload all files except schema.json
+                try (Stream<Path> stream = Files.list(dirPath)) {
+                  stream
+                      .filter(path -> !path.getFileName().toString().equals(SCHEMA_FILE_NAME))
+                      .forEach(
+                          path -> {
+                            try {
+                              s3Client
+                                  .putObject(
+                                      b -> b.bucket(bucket).key(chunkId + "/" + path.getFileName()),
+                                      AsyncRequestBody.fromBytes(Files.readAllBytes(path)))
+                                  .get();
+                            } catch (Exception e) {
+                              throw new RuntimeException(e);
+                            }
+                          });
+                }
+
+                // Inject a write.lock file. It doesn't matter what the content is.
+                s3Client
+                    .putObject(
+                        b -> b.bucket(bucket).key(chunkId + "/write.lock"),
+                        AsyncRequestBody.fromBytes("junk".getBytes()))
+                    .get();
+
+                return null;
+              })
+          .when(spyBlobStore)
+          .upload(any(), any());
+
+      // Run snapshot — should fail due to missing schema.json
+      boolean result = chunk.snapshotToS3(spyBlobStore);
+      assertThat(result).isFalse();
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")


### PR DESCRIPTION
###  Summary
Very rarely we are seeing missing files that do not allow segments to be loaded. It is unclear if there is a failure to upload all files, download all files, or something else. This adds checks that we upload all segment files to s3 at rollover, failing if we do not. Similarly on the cache side, we check that we download all the files for a given segment.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
