### PR TITLE
[Trace Caching] Handling empty trace search result

### DIFF
--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -275,7 +275,7 @@ public class ZipkinService {
     List<LogWireMessage> messages = searchResultToLogWireMessage(searchResult);
     String output = convertLogWireMessageToZipkinSpan(messages);
 
-    if (userRequest.isPresent() && userRequest.get() && !output.isEmpty()) {
+    if (userRequest.isPresent() && userRequest.get() && !messages.isEmpty()) {
       long dataFreshnessInSecondsValue =
           dataFreshnessInSeconds.orElse(
               this.defaultDataFreshnessInSeconds); // default to 15 minutes if not

--- a/astra/src/test/resources/zipkinApi/empty_search_result.json
+++ b/astra/src/test/resources/zipkinApi/empty_search_result.json
@@ -1,0 +1,7 @@
+{
+  "hits": [],
+  "tookMicros": "2732",
+  "totalNodes": 1,
+  "totalSnapshots": 1,
+  "snapshotsWithReplicas": 1
+}


### PR DESCRIPTION
###  Summary

Handling empty trace search result in zipkin api response when trace caching is enabled

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
