### PR TITLE
new graph service skeleton

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -1,0 +1,45 @@
+package com.slack.astra.graphApi;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Path;
+import com.slack.astra.server.AstraQueryServiceBase;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+
+/*
+  APIs for exposing traces and their spans as subgraph dependencies.
+*/
+public class GraphService {
+  private static final Logger LOG = LoggerFactory.getLogger(GraphService.class);
+  private final AstraQueryServiceBase searcher;
+
+  private static final ObjectMapper objectMapper =
+      JsonMapper.builder()
+          // sort alphabetically for easier test asserts
+          .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+          // don't serialize null values or empty maps
+          .serializationInclusion(JsonInclude.Include.NON_EMPTY)
+          .build();
+
+  public GraphService(AstraQueryServiceBase searcher) {
+    this.searcher = searcher;
+  }
+
+  @Get
+  @Path("/api/v1/trace/{traceId}/subgraph")
+  public HttpResponse getSubgraph(@Param("traceId") String traceId) throws IOException {
+    String output = "[]";
+    return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
+  }
+}

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -15,8 +15,6 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-
 /*
   APIs for exposing traces and their spans as subgraph dependencies.
 */

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -23,6 +23,7 @@ import com.slack.astra.clusterManager.ReplicaEvictionService;
 import com.slack.astra.clusterManager.ReplicaRestoreService;
 import com.slack.astra.clusterManager.SnapshotDeletionService;
 import com.slack.astra.elasticsearchApi.ElasticsearchApiService;
+import com.slack.astra.graphApi.GraphService;
 import com.slack.astra.logstore.LogMessage;
 import com.slack.astra.logstore.schema.ReservedFields;
 import com.slack.astra.logstore.search.AstraDistributedQueryService;
@@ -251,6 +252,7 @@ public class Astra {
                       astraConfig.getQueryConfig().getZipkinDefaultMaxSpans(),
                       astraConfig.getQueryConfig().getZipkinDefaultLookbackMins(),
                       astraConfig.getQueryConfig().getZipkinDefaultDataFreshnessSecs()))
+              .withAnnotatedService(new GraphService(astraDistributedQueryService))
               .withGrpcService(astraDistributedQueryService)
               .build();
       services.add(armeriaService);

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -1,0 +1,34 @@
+package com.slack.astra.graphApi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.spy;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.slack.astra.server.AstraQueryServiceBase;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class GraphServiceTest {
+  @Mock private AstraQueryServiceBase searcher;
+  private GraphService graphService;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    graphService = spy(new GraphService(searcher));
+  }
+
+  @Test
+  public void testGetSubgraphByTraceId_emptyResult() throws Exception {
+    String traceId = "test_trace_1";
+
+    HttpResponse response = graphService.getSubgraph(traceId);
+    AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
+
+    assertEquals(HttpStatus.OK, aggregatedResponse.status());
+    assertEquals("[]", aggregatedResponse.contentUtf8());
+  }
+}


### PR DESCRIPTION
###  Summary

Set up a new graph service for all endpoints and logic related to converting traces/spans into dependency subgraphs.

tested locally
```
 △ airlab/repos/kaldb docker build -t slackhq/astra .
 △ airlab/repos/kaldb docker compose up
 ▲ ~ curl --location 'http://localhost:8081/api/v1/trace/abcd/subgraph'
[]%
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
