### PR TITLE
special case handling to look up traceId in both base64 and hex 

### DIFF
--- a/astra/pom.xml
+++ b/astra/pom.xml
@@ -140,7 +140,14 @@
             <version>${curator.version}</version>
         </dependency>
 
-        <!-- Lucene dependencies -->
+        <dependency>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+          <version>1.17.0</version>
+        </dependency>
+
+
+      <!-- Lucene dependencies -->
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +39,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import org.apache.commons.codec.binary.Hex;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -218,6 +221,53 @@ public class ZipkinService {
     return s != null && DIGITS.matcher(s).matches();
   }
 
+  private static String convertTraceId(String traceId) {
+    if (traceId == null || traceId.isEmpty()) return null;
+
+    // Try hex → base64
+    if (traceId.matches("^[0-9a-fA-F]+$") && traceId.length() % 2 == 0) {
+      try {
+        byte[] bytes = Hex.decodeHex(traceId.toCharArray());
+        return Base64.getEncoder().encodeToString(bytes);
+      } catch (Exception ignored) {
+        return null;
+      }
+    }
+
+    // Try base64 → hex
+    try {
+      byte[] bytes = Base64.getDecoder().decode(traceId);
+      return Hex.encodeHexString(bytes);
+    } catch (Exception ignored) {
+      return null;
+    }
+  }
+
+  private static JSONObject buildTraceIdQuery(String traceFieldName, List<String> traceIds) {
+    JSONArray shouldArray = new JSONArray();
+
+    for (String traceId : traceIds) {
+      if (traceId == null || traceId.isEmpty()) continue;
+
+      JSONObject term = new JSONObject();
+      term.put(traceFieldName, traceId);
+
+      JSONObject termQuery = new JSONObject();
+      termQuery.put("term", term);
+
+      shouldArray.put(termQuery);
+    }
+
+    JSONObject boolQuery = new JSONObject();
+    boolQuery.put("should", shouldArray);
+    boolQuery.put("minimum_should_match", 1);
+
+    JSONObject queryJson = new JSONObject();
+    queryJson.put("bool", boolQuery);
+
+    return queryJson;
+  }
+
   @Blocking
   @Get("/api/v2/trace/{traceId}")
   public HttpResponse getTraceByTraceId(
@@ -232,9 +282,15 @@ public class ZipkinService {
       throws IOException {
 
     String traceFieldName = "trace_id";
-    // if trace id looks like dd_trace_id, then use dd_trace_id field to search
+    List<String> traceIds = new ArrayList<>(List.of(traceId));
+    // if trace id looks like dd_trace_id, then use dd_trace_id field to search. If true, ignores
+    // the hex/base64 flag
     if (ddTraceId.isPresent() && isDDTraceId(traceId)) {
       traceFieldName = "dd_trace_id";
+    } else if (searchByHexAndBase64.isPresent()) {
+      String convertedId = convertTraceId(traceId);
+      traceIds.add(convertedId);
+      System.out.println("CONVERSION: \ntraceId: " + traceId + "\nconvertedId: " + convertedId);
     }
 
     // Log the custom header userRequest value if present
@@ -250,11 +306,9 @@ public class ZipkinService {
         return HttpResponse.of(HttpStatus.OK, MediaType.ANY_APPLICATION_TYPE, traceData);
       }
     }
-    JSONObject traceObject = new JSONObject();
-    traceObject.put(traceFieldName, traceId);
-    JSONObject queryJson = new JSONObject();
-    queryJson.put("term", traceObject);
+    JSONObject queryJson = buildTraceIdQuery(traceFieldName, traceIds);
     String queryString = queryJson.toString();
+    System.out.println("queryString: " + queryString);
     long startTime =
         startTimeEpochMs.orElseGet(
             () -> Instant.now().minus(this.defaultLookbackMins, ChronoUnit.MINUTES).toEpochMilli());

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -221,23 +221,32 @@ public class ZipkinService {
     return s != null && DIGITS.matcher(s).matches();
   }
 
-  private static String convertTraceId(String traceId) {
+  private record TraceIds(String hex, String base64) {}
+
+  private static TraceIds convertTraceId(String traceId) {
     if (traceId == null || traceId.isEmpty()) return null;
 
-    // Try hex → base64
+    String hex = null;
+    String base64Url = null;
+
+    // If input is hex → convert to Base64 URL-safe
     if (traceId.matches("^[0-9a-fA-F]+$") && traceId.length() % 2 == 0) {
       try {
         byte[] bytes = Hex.decodeHex(traceId.toCharArray());
-        return Base64.getUrlEncoder().encodeToString(bytes);
+        hex = traceId.toLowerCase();
+        base64Url = Base64.getUrlEncoder().encodeToString(bytes);
+        return new TraceIds(hex, base64Url);
       } catch (Exception ignored) {
         return null;
       }
     }
 
-    // Try base64 → hex
+    // Otherwise, assume Base64-URL → convert to hex
     try {
       byte[] bytes = Base64.getUrlDecoder().decode(traceId);
-      return Hex.encodeHexString(bytes);
+      hex = Hex.encodeHexString(bytes);
+      base64Url = traceId;
+      return new TraceIds(hex, base64Url);
     } catch (Exception ignored) {
       return null;
     }
@@ -294,7 +303,10 @@ public class ZipkinService {
     if (ddTraceId.isPresent() && isDDTraceId(traceId)) {
       traceFieldName = "dd_trace_id";
     } else if (searchByHexAndBase64.isPresent()) {
-      convertedId = convertTraceId(traceId);
+      TraceIds traceIds = convertTraceId(traceId);
+      // to ensure we only cache the same trace once, we use the base64 version as the traceId
+      traceId = traceIds.base64;
+      convertedId = traceIds.hex;
     }
 
     // Log the custom header userRequest value if present

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -228,7 +228,7 @@ public class ZipkinService {
     if (traceId.matches("^[0-9a-fA-F]+$") && traceId.length() % 2 == 0) {
       try {
         byte[] bytes = Hex.decodeHex(traceId.toCharArray());
-        return Base64.getEncoder().encodeToString(bytes);
+        return Base64.getUrlEncoder().encodeToString(bytes);
       } catch (Exception ignored) {
         return null;
       }
@@ -236,7 +236,7 @@ public class ZipkinService {
 
     // Try base64 → hex
     try {
-      byte[] bytes = Base64.getDecoder().decode(traceId);
+      byte[] bytes = Base64.getUrlDecoder().decode(traceId);
       return Hex.encodeHexString(bytes);
     } catch (Exception ignored) {
       return null;

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -227,6 +227,7 @@ public class ZipkinService {
       @Param("maxSpans") Optional<Integer> maxSpans,
       @Header("X-User-Request") Optional<Boolean> userRequest,
       @Header("X-DD-TRACE-ID") Optional<String> ddTraceId,
+      @Header("X-E2E-hex-base64") Optional<String> searchByHexAndBase64,
       @Header("X-Data-Freshness-In-Seconds") Optional<Long> dataFreshnessInSeconds)
       throws IOException {
 

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -291,8 +291,8 @@ public class ZipkinService {
       @Param("endTimeEpochMs") Optional<Long> endTimeEpochMs,
       @Param("maxSpans") Optional<Integer> maxSpans,
       @Header("X-User-Request") Optional<Boolean> userRequest,
-      @Header("X-DD-TRACE-ID") Optional<String> ddTraceId,
-      @Header("X-E2E-hex-base64") Optional<String> searchByHexAndBase64,
+      @Header("X-DD-TRACE-ID") Optional<Boolean> ddTraceId,
+      @Header("X-E2E-hex-base64") Optional<Boolean> searchByHexAndBase64,
       @Header("X-Data-Freshness-In-Seconds") Optional<Long> dataFreshnessInSeconds)
       throws IOException {
 
@@ -300,9 +300,9 @@ public class ZipkinService {
     String convertedId = null;
     // if trace id looks like dd_trace_id, then use dd_trace_id field to search. If true, ignores
     // the hex/base64 flag
-    if (ddTraceId.isPresent() && isDDTraceId(traceId)) {
+    if (ddTraceId.isPresent() && ddTraceId.get() && isDDTraceId(traceId)) {
       traceFieldName = "dd_trace_id";
-    } else if (searchByHexAndBase64.isPresent()) {
+    } else if (searchByHexAndBase64.isPresent() && searchByHexAndBase64.get()) {
       TraceIds traceIds = convertTraceId(traceId);
       // to ensure we only cache the same trace once, we use the base64 version as the traceId
       traceId = traceIds.base64;

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -290,7 +290,7 @@ public class ZipkinService {
     } else if (searchByHexAndBase64.isPresent()) {
       String convertedId = convertTraceId(traceId);
       traceIds.add(convertedId);
-      System.out.println("CONVERSION: \ntraceId: " + traceId + "\nconvertedId: " + convertedId);
+      LOG.info("CONVERSION: \ntraceId: " + traceId + "\nconvertedId: " + convertedId);
     }
 
     // Log the custom header userRequest value if present
@@ -308,7 +308,7 @@ public class ZipkinService {
     }
     JSONObject queryJson = buildTraceIdQuery(traceFieldName, traceIds);
     String queryString = queryJson.toString();
-    System.out.println("queryString: " + queryString);
+    LOG.info("queryString: " + queryString);
     long startTime =
         startTimeEpochMs.orElseGet(
             () -> Instant.now().minus(this.defaultLookbackMins, ChronoUnit.MINUTES).toEpochMilli());

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -304,9 +304,13 @@ public class ZipkinService {
       traceFieldName = "dd_trace_id";
     } else if (searchByHexAndBase64.isPresent() && searchByHexAndBase64.get()) {
       TraceIds traceIds = convertTraceId(traceId);
-      // to ensure we only cache the same trace once, we use the base64 version as the traceId
-      traceId = traceIds.base64;
-      convertedId = traceIds.hex;
+      // to ensure we only cache the same trace once, we use the base64 version as the traceId.
+      // TraceIds are null
+      // in the case of being unable to convert, fallback to original traceId
+      if (traceIds != null) {
+        traceId = traceIds.base64;
+        convertedId = traceIds.hex;
+      }
     }
 
     // Log the custom header userRequest value if present

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -243,21 +243,27 @@ public class ZipkinService {
     }
   }
 
-  private static JSONObject buildTraceIdQuery(String traceFieldName, List<String> traceIds) {
-    JSONArray shouldArray = new JSONArray();
+  private static JSONObject singleTermQuery(String traceFieldName, String traceId) {
+    JSONObject traceObject = new JSONObject();
+    traceObject.put(traceFieldName, traceId);
+    JSONObject queryJson = new JSONObject();
+    queryJson.put("term", traceObject);
+    return queryJson;
+  }
 
-    for (String traceId : traceIds) {
-      if (traceId == null || traceId.isEmpty()) continue;
-
-      JSONObject term = new JSONObject();
-      term.put(traceFieldName, traceId);
-
-      JSONObject termQuery = new JSONObject();
-      termQuery.put("term", term);
-
-      shouldArray.put(termQuery);
+  private static JSONObject buildTraceIdQuery(
+      String traceFieldName, String traceId, String convertedId) {
+    // When there is no converted ID, return the original simple term query
+    if (convertedId == null) {
+      return singleTermQuery(traceFieldName, traceId);
     }
 
+    // When we have a convertedId, do traceId OR convertedId
+    JSONArray shouldArray = new JSONArray();
+    // term for original traceId
+    shouldArray.put(singleTermQuery(traceFieldName, traceId));
+    // term for convertedId
+    shouldArray.put(singleTermQuery(traceFieldName, convertedId));
     JSONObject boolQuery = new JSONObject();
     boolQuery.put("should", shouldArray);
     boolQuery.put("minimum_should_match", 1);
@@ -282,15 +288,13 @@ public class ZipkinService {
       throws IOException {
 
     String traceFieldName = "trace_id";
-    List<String> traceIds = new ArrayList<>(List.of(traceId));
+    String convertedId = null;
     // if trace id looks like dd_trace_id, then use dd_trace_id field to search. If true, ignores
     // the hex/base64 flag
     if (ddTraceId.isPresent() && isDDTraceId(traceId)) {
       traceFieldName = "dd_trace_id";
     } else if (searchByHexAndBase64.isPresent()) {
-      String convertedId = convertTraceId(traceId);
-      traceIds.add(convertedId);
-      LOG.info("CONVERSION: \ntraceId: " + traceId + "\nconvertedId: " + convertedId);
+      convertedId = convertTraceId(traceId);
     }
 
     // Log the custom header userRequest value if present
@@ -306,9 +310,9 @@ public class ZipkinService {
         return HttpResponse.of(HttpStatus.OK, MediaType.ANY_APPLICATION_TYPE, traceData);
       }
     }
-    JSONObject queryJson = buildTraceIdQuery(traceFieldName, traceIds);
+    JSONObject queryJson = buildTraceIdQuery(traceFieldName, traceId, convertedId);
     String queryString = queryJson.toString();
-    LOG.info("queryString: " + queryString);
+    LOG.debug("Querying with queryString={}", queryString);
     long startTime =
         startTimeEpochMs.orElseGet(
             () -> Instant.now().minus(this.defaultLookbackMins, ChronoUnit.MINUTES).toEpochMilli());

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
@@ -124,6 +124,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.empty(),
+              Optional.empty(),
               Optional.empty());
       AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
@@ -147,6 +148,7 @@ public class ZipkinServiceTest {
 
       zipkinService.getTraceByTraceId(
           traceId,
+          Optional.empty(),
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
@@ -184,6 +186,7 @@ public class ZipkinServiceTest {
           Optional.empty(),
           Optional.empty(),
           Optional.of(ddTraceIdHeaderVal),
+          Optional.empty(),
           Optional.empty());
 
       verify(searcher)
@@ -210,6 +213,7 @@ public class ZipkinServiceTest {
 
       zipkinService.getTraceByTraceId(
           traceId,
+          Optional.empty(),
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
@@ -247,6 +251,7 @@ public class ZipkinServiceTest {
           Optional.of(maxSpansParam),
           Optional.empty(),
           Optional.empty(),
+          Optional.empty(),
           Optional.empty());
 
       verify(searcher)
@@ -281,6 +286,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.empty(),
               Optional.empty());
 
@@ -332,6 +338,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.of(userRequest),
               Optional.empty(),
+              Optional.empty(),
               Optional.empty());
 
       verify(searcher)
@@ -381,6 +388,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.of(userRequest),
               Optional.empty(),
+              Optional.empty(),
               Optional.empty());
 
       verify(mockBlobStore).readFileData(eq(traceFilePath), eq(true));
@@ -428,6 +436,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.empty(),
               Optional.of(dataFreshnessInSeconds));
 
@@ -483,6 +492,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.empty(),
               Optional.of(dataFreshnessInSeconds));
 

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
@@ -302,6 +302,38 @@ public class ZipkinServiceTest {
   }
 
   @Test
+  public void testGetTraceByTraceIdHexBase64_partially_invalid_base64() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "invalid_id="; // Base64-like but invalid
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+
+      zipkinService.getTraceByTraceId(
+          traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(Boolean.TRUE),
+          Optional.empty());
+
+      // Assert that the fallback trace_id was used in the query
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"trace_id\":\"" + traceId + "\"")));
+    }
+  }
+
+  @Test
   public void testGetTraceByTraceIdHexBase64_disabled() throws Exception {
     try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
       // Mocking Tracing and Span

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
@@ -245,8 +245,8 @@ public class ZipkinServiceTest {
       mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
       when(mockTracer.currentSpan()).thenReturn(mockSpan);
 
-      String traceId = "cd16d07cb8c5d49227860550ca01b61d";
-      String convertedTraceId = "zRbQfLjF1JInhgVQygG2HQ==";
+      String traceId = "de21aa6013083a3adfd66f985ddfc26c";
+      String convertedTraceId = "3iGqYBMIOjrf1m-YXd_CbA==";
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
       String searchByHexAndBase64 = "value_does_not_matter";
 

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
@@ -177,7 +177,6 @@ public class ZipkinServiceTest {
 
       String traceId = "4541183944276361430";
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
-      String ddTraceIdHeaderVal = "value_does_not_matter";
 
       zipkinService.getTraceByTraceId(
           traceId,
@@ -185,7 +184,7 @@ public class ZipkinServiceTest {
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
-          Optional.of(ddTraceIdHeaderVal),
+          Optional.of(Boolean.TRUE),
           Optional.empty(),
           Optional.empty());
 
@@ -211,7 +210,6 @@ public class ZipkinServiceTest {
       String traceId = "zRbQfLjF1JInhgVQygG2HQ==";
       String convertedTraceId = "cd16d07cb8c5d49227860550ca01b61d";
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
-      String searchByHexAndBase64 = "value_does_not_matter";
 
       zipkinService.getTraceByTraceId(
           traceId,
@@ -220,7 +218,7 @@ public class ZipkinServiceTest {
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
-          Optional.of(searchByHexAndBase64),
+          Optional.of(Boolean.TRUE),
           Optional.empty());
 
       verify(searcher)
@@ -248,7 +246,6 @@ public class ZipkinServiceTest {
       String traceId = "de21aa6013083a3adfd66f985ddfc26c";
       String convertedTraceId = "3iGqYBMIOjrf1m-YXd_CbA==";
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
-      String searchByHexAndBase64 = "value_does_not_matter";
 
       zipkinService.getTraceByTraceId(
           traceId,
@@ -257,7 +254,7 @@ public class ZipkinServiceTest {
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
-          Optional.of(searchByHexAndBase64),
+          Optional.of(Boolean.TRUE),
           Optional.empty());
 
       verify(searcher)
@@ -284,7 +281,6 @@ public class ZipkinServiceTest {
 
       String traceId = "invalid_id";
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
-      String searchByHexAndBase64 = "value_does_not_matter";
 
       zipkinService.getTraceByTraceId(
           traceId,
@@ -293,7 +289,7 @@ public class ZipkinServiceTest {
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
-          Optional.of(searchByHexAndBase64),
+          Optional.of(Boolean.TRUE),
           Optional.empty());
 
       verify(searcher)

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
@@ -199,6 +199,149 @@ public class ZipkinServiceTest {
   }
 
   @Test
+  public void testGetTraceByTraceIdHexBase64_base_64() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "zRbQfLjF1JInhgVQygG2HQ==";
+      String convertedTraceId = "cd16d07cb8c5d49227860550ca01b61d";
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+      String searchByHexAndBase64 = "value_does_not_matter";
+
+      zipkinService.getTraceByTraceId(
+          traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(searchByHexAndBase64),
+          Optional.empty());
+
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"trace_id\":\"" + traceId + "\"")
+                          && request
+                              .getQuery()
+                              .contains("\"trace_id\":\"" + convertedTraceId + "\"")));
+    }
+  }
+
+  @Test
+  public void testGetTraceByTraceIdHexBase64_hex() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "cd16d07cb8c5d49227860550ca01b61d";
+      String convertedTraceId = "zRbQfLjF1JInhgVQygG2HQ==";
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+      String searchByHexAndBase64 = "value_does_not_matter";
+
+      zipkinService.getTraceByTraceId(
+          traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(searchByHexAndBase64),
+          Optional.empty());
+
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"trace_id\":\"" + traceId + "\"")
+                          && request
+                              .getQuery()
+                              .contains("\"trace_id\":\"" + convertedTraceId + "\"")));
+    }
+  }
+
+  @Test
+  public void testGetTraceByTraceIdHexBase64_invalid_to_convert() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "invalid_id";
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+      String searchByHexAndBase64 = "value_does_not_matter";
+
+      zipkinService.getTraceByTraceId(
+          traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(searchByHexAndBase64),
+          Optional.empty());
+
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"trace_id\":\"" + traceId + "\"")));
+    }
+  }
+
+  @Test
+  public void testGetTraceByTraceIdHexBase64_disabled() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "cd16d07cb8c5d49227860550ca01b61d";
+      String convertedTraceId = "zRbQfLjF1JInhgVQygG2HQ==";
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+
+      zipkinService.getTraceByTraceId(
+          traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty());
+
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"trace_id\":\"" + traceId + "\"")
+                          && !request
+                              .getQuery()
+                              .contains("\"trace_id\":\"" + convertedTraceId + "\"")));
+    }
+  }
+
+  @Test
   public void testGetTraceByTraceId_dd_trace_id_Disabled() throws Exception {
     try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
       // Mocking Tracing and Span


### PR DESCRIPTION
###  Summary

Some systems send base64, some hex and but it is the same trace. render the whole trace in zipkin

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
