### PR TITLE
refactor Zipkin trace fetching

### DIFF
--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -49,6 +49,7 @@ import com.slack.astra.proto.metadata.Metadata;
 import com.slack.astra.proto.schema.Schema;
 import com.slack.astra.recovery.RecoveryService;
 import com.slack.astra.util.RuntimeHalterImpl;
+import com.slack.astra.zipkinApi.TraceFetcher;
 import com.slack.astra.zipkinApi.ZipkinService;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
@@ -251,18 +252,20 @@ public class Astra {
         LOG.info("No dependency graph config file provided, using empty config");
       }
 
+      TraceFetcher tf =
+          new TraceFetcher(
+              astraDistributedQueryService,
+              blobStore,
+              astraConfig.getQueryConfig().getZipkinDefaultMaxSpans(),
+              astraConfig.getQueryConfig().getZipkinDefaultLookbackMins(),
+              astraConfig.getQueryConfig().getZipkinDefaultDataFreshnessSecs());
+
       ArmeriaService armeriaService =
           new ArmeriaService.Builder(serverPort, "astraQuery", meterRegistry)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .withAnnotatedService(new ElasticsearchApiService(astraDistributedQueryService))
-              .withAnnotatedService(
-                  new ZipkinService(
-                      astraDistributedQueryService,
-                      blobStore,
-                      astraConfig.getQueryConfig().getZipkinDefaultMaxSpans(),
-                      astraConfig.getQueryConfig().getZipkinDefaultLookbackMins(),
-                      astraConfig.getQueryConfig().getZipkinDefaultDataFreshnessSecs()))
+              .withAnnotatedService(new ZipkinService(tf))
               .withAnnotatedService(new GraphService(astraDistributedQueryService, graphConfig))
               .withGrpcService(astraDistributedQueryService)
               .build();

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -58,10 +58,7 @@ public class TraceFetcher {
     this.defaultDataFreshnessInSeconds = defaultDataFreshnessInSeconds;
   }
 
-  private static class Result {
-    final String rawJson;
-    final List<ZipkinSpanResponse> spans;
-
+  private static record Result(String rawJson, List<ZipkinSpanResponse> {
     Result(String rawJson) {
       this.rawJson = rawJson;
       this.spans = null;

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -1,0 +1,372 @@
+package com.slack.astra.zipkinApi;
+
+import static com.slack.astra.metadata.dataset.DatasetPartitionMetadata.MATCH_ALL_DATASET;
+
+import brave.Tracing;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
+import com.slack.astra.blobfs.BlobStore;
+import com.slack.astra.logstore.LogMessage;
+import com.slack.astra.logstore.LogWireMessage;
+import com.slack.astra.proto.service.AstraSearch;
+import com.slack.astra.server.AstraQueryServiceBase;
+import com.slack.astra.util.JsonUtil;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TraceFetcher {
+  private static final Logger LOG = LoggerFactory.getLogger(TraceFetcher.class);
+
+  private final AstraQueryServiceBase searcher;
+  private final BlobStore blobStore;
+
+  private final int defaultMaxSpans;
+  private final int defaultLookbackMins;
+  private final long defaultDataFreshnessInSeconds;
+
+  public static final String TRACE_CACHE_PREFIX = "traceCacheData";
+
+  public TraceFetcher(
+      AstraQueryServiceBase searcher,
+      BlobStore blobStore,
+      int defaultMaxSpans,
+      int defaultLookbackMins,
+      long defaultDataFreshnessInSeconds) {
+    this.searcher = searcher;
+    this.blobStore = blobStore;
+    this.defaultMaxSpans = defaultMaxSpans;
+    this.defaultLookbackMins = defaultLookbackMins;
+    this.defaultDataFreshnessInSeconds = defaultDataFreshnessInSeconds;
+  }
+
+  private static class Result {
+    final String rawJson;
+    final List<ZipkinSpanResponse> spans;
+
+    Result(String rawJson) {
+      this.rawJson = rawJson;
+      this.spans = null;
+    }
+
+    Result(List<ZipkinSpanResponse> spans) {
+      this.spans = spans;
+      this.rawJson = null;
+    }
+
+    boolean isCached() {
+      return rawJson != null;
+    }
+  }
+
+  private static final ObjectMapper objectMapper =
+      JsonMapper.builder()
+          // sort alphabetically for easier test asserts
+          .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+          // don't serialize null values or empty maps
+          .serializationInclusion(JsonInclude.Include.NON_EMPTY)
+          .build();
+
+  private Result fetchTraceResult(
+      String traceId,
+      Optional<Long> startTimeEpochMs,
+      Optional<Long> endTimeEpochMs,
+      Optional<Integer> maxSpans,
+      Optional<Boolean> userRequest,
+      Optional<Long> dataFreshnessInSeconds)
+      throws IOException {
+    // Log the custom header userRequest value if present
+    if (userRequest.isPresent()) {
+      LOG.info("Received custom header X-User-Request: {}", userRequest.get());
+
+      // try to retrieve trace data from blob store cache; check timestamp before using blob store
+      // cache for data freshness
+      String traceData = retrieveDataFromBlobStoreCache(traceId);
+      if (traceData != null) {
+        LOG.info("Trace data retrieved from blob store cache for traceId={}", traceId);
+        return new Result(traceData);
+      }
+    }
+
+    JSONObject traceObject = new JSONObject();
+    traceObject.put("trace_id", traceId);
+    JSONObject queryJson = new JSONObject();
+    queryJson.put("term", traceObject);
+    String queryString = queryJson.toString();
+
+    long startTime =
+        startTimeEpochMs.orElseGet(
+            () -> Instant.now().minus(this.defaultLookbackMins, ChronoUnit.MINUTES).toEpochMilli());
+    // we are adding a buffer to end time also because some machines clock may be ahead of current
+    // system clock and those spans would be stored but can't be queried
+
+    long endTime =
+        endTimeEpochMs.orElseGet(
+            () -> Instant.now().plus(this.defaultLookbackMins, ChronoUnit.MINUTES).toEpochMilli());
+    int howMany = maxSpans.orElse(this.defaultMaxSpans);
+
+    brave.Span span = Tracing.currentTracer().currentSpan();
+    span.tag("startTimeEpochMs", String.valueOf(startTime));
+    span.tag("endTimeEpochMs", String.valueOf(endTime));
+    span.tag("howMany", String.valueOf(howMany));
+    // Add custom header to span tags if present
+    userRequest.ifPresent(headerValue -> span.tag("userRequest", headerValue.toString()));
+
+    AstraSearch.SearchRequest.Builder searchRequestBuilder = AstraSearch.SearchRequest.newBuilder();
+    AstraSearch.SearchResult searchResult =
+        searcher.doSearch(
+            searchRequestBuilder
+                .setDataset(MATCH_ALL_DATASET)
+                .setQuery(queryString)
+                .setStartTimeEpochMs(startTime)
+                .setEndTimeEpochMs(endTime)
+                .setHowMany(howMany)
+                .build());
+
+    List<LogWireMessage> messages = searchResultToLogWireMessage(searchResult);
+    List<ZipkinSpanResponse> spans = convertLogWireMessageToZipkinSpan(messages);
+
+    if (userRequest.isPresent() && userRequest.get() && !messages.isEmpty()) {
+      long dataFreshnessInSecondsValue =
+          dataFreshnessInSeconds.orElse(
+              this.defaultDataFreshnessInSeconds); // default to 15 minutes if not
+      // Check if no new spans in trace data, it can be saved
+      Instant latestSpanTimestamp = getLatestSpanTimestamp(messages);
+
+      if (shouldSaveToBlobStoreCache(latestSpanTimestamp, dataFreshnessInSecondsValue)) {
+        LOG.info(
+            "Data freshness check done, can be saved to blob store cache for traceId={}", traceId);
+        // Save the trace data to blob store cache
+        saveDataToBlobStoreCache(traceId, objectMapper.writeValueAsString(spans));
+      }
+    }
+
+    return new Result(spans);
+  }
+
+  public List<ZipkinSpanResponse> getSpansByTraceId(
+      String traceId,
+      Optional<Long> startTimeEpochMs,
+      Optional<Long> endTimeEpochMs,
+      Optional<Integer> maxSpans,
+      Optional<Boolean> userRequest,
+      Optional<Long> dataFreshnessInSeconds)
+      throws IOException {
+    Result result =
+        fetchTraceResult(
+            traceId,
+            startTimeEpochMs,
+            endTimeEpochMs,
+            maxSpans,
+            userRequest,
+            dataFreshnessInSeconds);
+
+    if (result.isCached()) {
+      return objectMapper.readValue(result.rawJson, new TypeReference<>() {});
+    }
+    return result.spans;
+  }
+
+  public String getByTraceId(
+      String traceId,
+      Optional<Long> startTimeEpochMs,
+      Optional<Long> endTimeEpochMs,
+      Optional<Integer> maxSpans,
+      Optional<Boolean> userRequest,
+      Optional<Long> dataFreshnessInSeconds)
+      throws IOException {
+    Result result =
+        fetchTraceResult(
+            traceId,
+            startTimeEpochMs,
+            endTimeEpochMs,
+            maxSpans,
+            userRequest,
+            dataFreshnessInSeconds);
+
+    if (result.isCached()) {
+      return result.rawJson;
+    }
+    return objectMapper.writeValueAsString(result.spans);
+  }
+
+  protected static List<ZipkinSpanResponse> convertLogWireMessageToZipkinSpan(
+      List<LogWireMessage> messages) throws JsonProcessingException {
+    List<ZipkinSpanResponse> traces = new ArrayList<>(messages.size());
+    for (LogWireMessage message : messages) {
+      if (message.getId() == null) {
+        LOG.warn("Document={} cannot have missing id ", message);
+        continue;
+      }
+
+      String id = message.getId();
+      String messageTraceId = null;
+      String parentId = null;
+      String name = null;
+      String serviceName = null;
+      String timestamp = String.valueOf(message.getTimestamp().toEpochMilli());
+      long duration = 0L;
+      Map<String, String> messageTags = new HashMap<>();
+
+      for (String k : message.getSource().keySet()) {
+        Object value = message.getSource().get(k);
+        if (LogMessage.ReservedField.TRACE_ID.fieldName.equals(k)) {
+          messageTraceId = (String) value;
+        } else if (LogMessage.ReservedField.PARENT_ID.fieldName.equals(k)) {
+          parentId = (String) value;
+        } else if (LogMessage.ReservedField.NAME.fieldName.equals(k)) {
+          name = (String) value;
+        } else if (LogMessage.ReservedField.SERVICE_NAME.fieldName.equals(k)) {
+          serviceName = (String) value;
+        } else if (LogMessage.ReservedField.DURATION.fieldName.equals(k)) {
+          duration = ((Number) value).longValue();
+        } else if (LogMessage.ReservedField.ID.fieldName.equals(k)) {
+          id = (String) value;
+        } else {
+          messageTags.put(k, String.valueOf(value));
+        }
+      }
+
+      // TODO: today at Slack the duration is sent as "duration_ms"
+      // We we have this special handling which should be addressed upstream
+      // and then removed from here
+      if (duration == 0) {
+        Object value =
+            message.getSource().getOrDefault(LogMessage.ReservedField.DURATION_MS.fieldName, 0);
+        duration = TimeUnit.MICROSECONDS.convert(Duration.ofMillis(((Number) value).intValue()));
+      }
+
+      // these are some mandatory fields without which the grafana zipkin plugin fails to display
+      // the span
+      if (messageTraceId == null) {
+        messageTraceId = message.getId();
+      }
+      if (timestamp == null) {
+        LOG.warn(
+            "Document id={} missing {}",
+            message,
+            LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName);
+        continue;
+      }
+
+      final ZipkinSpanResponse span = new ZipkinSpanResponse(id, messageTraceId);
+      span.setParentId(parentId);
+      span.setName(name);
+      if (serviceName != null) {
+        ZipkinEndpointResponse remoteEndpoint = new ZipkinEndpointResponse();
+        remoteEndpoint.setServiceName(serviceName);
+        span.setRemoteEndpoint(remoteEndpoint);
+      }
+      span.setTimestamp(convertToMicroSeconds(message.getTimestamp()));
+      span.setDuration(duration);
+      span.setTags(messageTags);
+      traces.add(span);
+    }
+
+    return traces;
+  }
+
+  // returning LogWireMessage instead of LogMessage
+  // If we return LogMessage the caller then needs to call getSource which is a deep copy of the
+  // object. To return LogWireMessage we do a JSON parse
+  static List<LogWireMessage> searchResultToLogWireMessage(AstraSearch.SearchResult searchResult)
+      throws IOException {
+    List<ByteString> hitsByteList = searchResult.getHitsList().asByteStringList();
+    List<LogWireMessage> messages = new ArrayList<>(hitsByteList.size());
+    for (ByteString byteString : hitsByteList) {
+      LogWireMessage hit = JsonUtil.read(byteString.toStringUtf8(), LogWireMessage.class);
+      // LogMessage message = LogMessage.fromWireMessage(hit);
+      messages.add(hit);
+    }
+    return messages;
+  }
+
+  @VisibleForTesting
+  protected static long convertToMicroSeconds(Instant instant) {
+    return ChronoUnit.MICROS.between(Instant.EPOCH, instant);
+  }
+
+  @VisibleForTesting
+  protected Instant getLatestSpanTimestamp(List<LogWireMessage> spanList) {
+    return spanList.stream()
+        .map(LogWireMessage::getTimestamp)
+        .max(Comparator.naturalOrder())
+        .orElse(null);
+  }
+
+  protected String retrieveDataFromBlobStoreCache(String traceId) {
+    assert traceId != null && !traceId.isEmpty();
+
+    try {
+      // Retrieve the compressed trace data from blob store cache
+      String jsonData =
+          blobStore.readFileData(
+              String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, traceId), true);
+
+      if (jsonData == null || jsonData.isEmpty()) {
+        LOG.warn("No trace data found in blob store cache for traceId={}", traceId);
+        return null;
+      }
+      LOG.info(
+          "Retrieved and decompressed trace data from blob store cache for traceId={}", traceId);
+      return jsonData;
+
+    } catch (Exception e) {
+      // Log other exceptions as errors
+      LOG.error("Error retrieving trace data from blob store cache for traceId={}", traceId, e);
+      return null;
+    }
+  }
+
+  private static boolean shouldSaveToBlobStoreCache(
+      Instant latestSpanTimestamp, long dataFreshnessInSeconds) {
+    Instant currentTime = Instant.now();
+    return latestSpanTimestamp.isBefore(
+        currentTime.minus(dataFreshnessInSeconds, ChronoUnit.SECONDS));
+  }
+
+  protected void saveDataToBlobStoreCache(String traceId, String output) {
+    assert traceId != null && !traceId.isEmpty();
+    assert output != null && !output.isEmpty();
+
+    try {
+      // Upload the compressed trace data to blob store cache
+      String srcLocation =
+          String.format("%s/tmp-%s/%s.json.gz", TRACE_CACHE_PREFIX, traceId, UUID.randomUUID());
+      String dstLocation = String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, traceId);
+
+      if (blobStore.pathExists("%s/tmp-%s".formatted(TRACE_CACHE_PREFIX, traceId))) {
+        LOG.info("Temporary location found in blob store cache for traceId={}", traceId);
+        return;
+      }
+
+      blobStore.uploadData(srcLocation, output, true);
+      blobStore.copyFile(srcLocation, dstLocation);
+      blobStore.delete(String.format("%s/tmp-%s", TRACE_CACHE_PREFIX, traceId));
+
+      LOG.info("Compressed trace data saved to blob store cache for traceId={}", traceId);
+
+    } catch (Exception e) {
+      LOG.error("Error saving trace data to blob store cache for traceId={}", traceId, e);
+      throw new RuntimeException("Failed to save trace data to blob store cache", e);
+    }
+  }
+}

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -58,15 +58,13 @@ public class TraceFetcher {
     this.defaultDataFreshnessInSeconds = defaultDataFreshnessInSeconds;
   }
 
-  private static record Result(String rawJson, List<ZipkinSpanResponse> {
+  private static record Result(String rawJson, List<ZipkinSpanResponse> spans) {
     Result(String rawJson) {
-      this.rawJson = rawJson;
-      this.spans = null;
+      this(rawJson, null);
     }
 
     Result(List<ZipkinSpanResponse> spans) {
-      this.spans = spans;
-      this.rawJson = null;
+      this(null, spans);
     }
 
     boolean isCached() {

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -1,15 +1,5 @@
 package com.slack.astra.zipkinApi;
 
-import static com.slack.astra.metadata.dataset.DatasetPartitionMetadata.MATCH_ALL_DATASET;
-
-import brave.Tracing;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.protobuf.ByteString;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -19,25 +9,8 @@ import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
-import com.slack.astra.blobfs.BlobStore;
-import com.slack.astra.logstore.LogMessage;
-import com.slack.astra.logstore.LogWireMessage;
-import com.slack.astra.proto.service.AstraSearch;
-import com.slack.astra.server.AstraQueryServiceBase;
-import com.slack.astra.util.JsonUtil;
 import java.io.IOException;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,132 +26,11 @@ import org.slf4j.LoggerFactory;
  *     Hub</a>
  */
 public class ZipkinService {
-
-  protected static String convertLogWireMessageToZipkinSpan(List<LogWireMessage> messages)
-      throws JsonProcessingException {
-    List<ZipkinSpanResponse> traces = new ArrayList<>(messages.size());
-    for (LogWireMessage message : messages) {
-      if (message.getId() == null) {
-        LOG.warn("Document={} cannot have missing id ", message);
-        continue;
-      }
-
-      String id = message.getId();
-      String messageTraceId = null;
-      String parentId = null;
-      String name = null;
-      String serviceName = null;
-      String timestamp = String.valueOf(message.getTimestamp().toEpochMilli());
-      long duration = 0L;
-      Map<String, String> messageTags = new HashMap<>();
-
-      for (String k : message.getSource().keySet()) {
-        Object value = message.getSource().get(k);
-        if (LogMessage.ReservedField.TRACE_ID.fieldName.equals(k)) {
-          messageTraceId = (String) value;
-        } else if (LogMessage.ReservedField.PARENT_ID.fieldName.equals(k)) {
-          parentId = (String) value;
-        } else if (LogMessage.ReservedField.NAME.fieldName.equals(k)) {
-          name = (String) value;
-        } else if (LogMessage.ReservedField.SERVICE_NAME.fieldName.equals(k)) {
-          serviceName = (String) value;
-        } else if (LogMessage.ReservedField.DURATION.fieldName.equals(k)) {
-          duration = ((Number) value).longValue();
-        } else if (LogMessage.ReservedField.ID.fieldName.equals(k)) {
-          id = (String) value;
-        } else {
-          messageTags.put(k, String.valueOf(value));
-        }
-      }
-
-      // TODO: today at Slack the duration is sent as "duration_ms"
-      // We we have this special handling which should be addressed upstream
-      // and then removed from here
-      if (duration == 0) {
-        Object value =
-            message.getSource().getOrDefault(LogMessage.ReservedField.DURATION_MS.fieldName, 0);
-        duration = TimeUnit.MICROSECONDS.convert(Duration.ofMillis(((Number) value).intValue()));
-      }
-
-      // these are some mandatory fields without which the grafana zipkin plugin fails to display
-      // the span
-      if (messageTraceId == null) {
-        messageTraceId = message.getId();
-      }
-      if (timestamp == null) {
-        LOG.warn(
-            "Document id={} missing {}",
-            message,
-            LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName);
-        continue;
-      }
-
-      final ZipkinSpanResponse span = new ZipkinSpanResponse(id, messageTraceId);
-      span.setParentId(parentId);
-      span.setName(name);
-      if (serviceName != null) {
-        ZipkinEndpointResponse remoteEndpoint = new ZipkinEndpointResponse();
-        remoteEndpoint.setServiceName(serviceName);
-        span.setRemoteEndpoint(remoteEndpoint);
-      }
-      span.setTimestamp(convertToMicroSeconds(message.getTimestamp()));
-      span.setDuration(duration);
-      span.setTags(messageTags);
-      traces.add(span);
-    }
-    return objectMapper.writeValueAsString(traces);
-  }
-
-  // returning LogWireMessage instead of LogMessage
-  // If we return LogMessage the caller then needs to call getSource which is a deep copy of the
-  // object. To return LogWireMessage we do a JSON parse
-  static List<LogWireMessage> searchResultToLogWireMessage(AstraSearch.SearchResult searchResult)
-      throws IOException {
-    List<ByteString> hitsByteList = searchResult.getHitsList().asByteStringList();
-    List<LogWireMessage> messages = new ArrayList<>(hitsByteList.size());
-    for (ByteString byteString : hitsByteList) {
-      LogWireMessage hit = JsonUtil.read(byteString.toStringUtf8(), LogWireMessage.class);
-      // LogMessage message = LogMessage.fromWireMessage(hit);
-      messages.add(hit);
-    }
-    return messages;
-  }
-
-  @VisibleForTesting
-  protected static long convertToMicroSeconds(Instant instant) {
-    return ChronoUnit.MICROS.between(Instant.EPOCH, instant);
-  }
-
   private static final Logger LOG = LoggerFactory.getLogger(ZipkinService.class);
-  private final int defaultMaxSpans;
-  private final int defaultLookbackMins;
-  private final long defaultDataFreshnessInSeconds;
+  private final TraceFetcher traceFetcher;
 
-  private final AstraQueryServiceBase searcher;
-
-  private final BlobStore blobStore;
-
-  public static final String TRACE_CACHE_PREFIX = "traceCacheData";
-
-  private static final ObjectMapper objectMapper =
-      JsonMapper.builder()
-          // sort alphabetically for easier test asserts
-          .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
-          // don't serialize null values or empty maps
-          .serializationInclusion(JsonInclude.Include.NON_EMPTY)
-          .build();
-
-  public ZipkinService(
-      AstraQueryServiceBase searcher,
-      BlobStore blobStore,
-      int defaultMaxSpans,
-      int defaultLookbackMins,
-      long defaultDataFreshnessInSeconds) {
-    this.searcher = searcher;
-    this.blobStore = blobStore;
-    this.defaultMaxSpans = defaultMaxSpans;
-    this.defaultLookbackMins = defaultLookbackMins;
-    this.defaultDataFreshnessInSeconds = defaultDataFreshnessInSeconds;
+  public ZipkinService(TraceFetcher traceFetcher) {
+    this.traceFetcher = traceFetcher;
   }
 
   @Get
@@ -220,141 +72,14 @@ public class ZipkinService {
       @Header("X-User-Request") Optional<Boolean> userRequest,
       @Header("X-Data-Freshness-In-Seconds") Optional<Long> dataFreshnessInSeconds)
       throws IOException {
-
-    // Log the custom header userRequest value if present
-    if (userRequest.isPresent()) {
-      LOG.info("Received custom header X-User-Request: {}", userRequest.get());
-      // try to retrieve trace data from blob store cache; check timestamp before using blob store
-      // cache for data freshness
-
-      String traceData = retrieveDataFromBlobStoreCache(traceId);
-      // if found, return the data
-      if (traceData != null) {
-        LOG.info("Trace data retrieved from blob store cache for traceId={}", traceId);
-        return HttpResponse.of(HttpStatus.OK, MediaType.ANY_APPLICATION_TYPE, traceData);
-      }
-    }
-    JSONObject traceObject = new JSONObject();
-    traceObject.put("trace_id", traceId);
-    JSONObject queryJson = new JSONObject();
-    queryJson.put("term", traceObject);
-    String queryString = queryJson.toString();
-
-    long startTime =
-        startTimeEpochMs.orElseGet(
-            () -> Instant.now().minus(this.defaultLookbackMins, ChronoUnit.MINUTES).toEpochMilli());
-    // we are adding a buffer to end time also because some machines clock may be ahead of current
-    // system clock and those spans would be stored but can't be queried
-
-    long endTime =
-        endTimeEpochMs.orElseGet(
-            () -> Instant.now().plus(this.defaultLookbackMins, ChronoUnit.MINUTES).toEpochMilli());
-    int howMany = maxSpans.orElse(this.defaultMaxSpans);
-
-    brave.Span span = Tracing.currentTracer().currentSpan();
-    span.tag("startTimeEpochMs", String.valueOf(startTime));
-    span.tag("endTimeEpochMs", String.valueOf(endTime));
-    span.tag("howMany", String.valueOf(howMany));
-    // Add custom header to span tags if present
-    userRequest.ifPresent(headerValue -> span.tag("userRequest", headerValue.toString()));
-
-    // TODO: when MAX_SPANS is hit the results will look weird because the index is sorted in
-    // reverse timestamp and the spans returned will be the tail. We should support sort in the
-    // search request
-    AstraSearch.SearchRequest.Builder searchRequestBuilder = AstraSearch.SearchRequest.newBuilder();
-    AstraSearch.SearchResult searchResult =
-        searcher.doSearch(
-            searchRequestBuilder
-                .setDataset(MATCH_ALL_DATASET)
-                .setQuery(queryString)
-                .setStartTimeEpochMs(startTime)
-                .setEndTimeEpochMs(endTime)
-                .setHowMany(howMany)
-                .build());
-    // we don't account for any failed nodes in the searchResult today
-    List<LogWireMessage> messages = searchResultToLogWireMessage(searchResult);
-    String output = convertLogWireMessageToZipkinSpan(messages);
-
-    if (userRequest.isPresent() && userRequest.get() && !messages.isEmpty()) {
-      long dataFreshnessInSecondsValue =
-          dataFreshnessInSeconds.orElse(
-              this.defaultDataFreshnessInSeconds); // default to 15 minutes if not
-      // Check if no new spans in trace data, it can be saved
-      Instant latestSpanTimestamp = getLatestSpanTimestamp(messages);
-
-      if (shouldSaveToBlobStoreCache(latestSpanTimestamp, dataFreshnessInSecondsValue)) {
-        LOG.info(
-            "Data freshness check done, can be saved to blob store cache for traceId={}", traceId);
-        // Save the trace data to blob store cache
-        saveDataToBlobStoreCache(traceId, output);
-      }
-    }
+    String output =
+        this.traceFetcher.getByTraceId(
+            traceId,
+            startTimeEpochMs,
+            endTimeEpochMs,
+            maxSpans,
+            userRequest,
+            dataFreshnessInSeconds);
     return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
-  }
-
-  protected static boolean shouldSaveToBlobStoreCache(
-      Instant latestSpanTimestamp, long dataFreshnessInSeconds) {
-    Instant currentTime = Instant.now();
-    return latestSpanTimestamp.isBefore(
-        currentTime.minus(dataFreshnessInSeconds, ChronoUnit.SECONDS));
-  }
-
-  @VisibleForTesting
-  protected Instant getLatestSpanTimestamp(List<LogWireMessage> spanList) {
-    return spanList.stream()
-        .map(LogWireMessage::getTimestamp)
-        .max(Comparator.naturalOrder())
-        .orElse(null);
-  }
-
-  protected String retrieveDataFromBlobStoreCache(String traceId) {
-    assert traceId != null && !traceId.isEmpty();
-
-    try {
-      // Retrieve the compressed trace data from blob store cache
-      String jsonData =
-          blobStore.readFileData(
-              String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, traceId), true);
-
-      if (jsonData == null || jsonData.isEmpty()) {
-        LOG.warn("No trace data found in blob store cache for traceId={}", traceId);
-        return null;
-      }
-      LOG.info(
-          "Retrieved and decompressed trace data from blob store cache for traceId={}", traceId);
-      return jsonData;
-
-    } catch (Exception e) {
-      // Log other exceptions as errors
-      LOG.error("Error retrieving trace data from blob store cache for traceId={}", traceId, e);
-      return null;
-    }
-  }
-
-  protected void saveDataToBlobStoreCache(String traceId, String output) {
-    assert traceId != null && !traceId.isEmpty();
-    assert output != null && !output.isEmpty();
-
-    try {
-      // Upload the compressed trace data to blob store cache
-      String srcLocation =
-          String.format("%s/tmp-%s/%s.json.gz", TRACE_CACHE_PREFIX, traceId, UUID.randomUUID());
-      String dstLocation = String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, traceId);
-
-      if (blobStore.pathExists("%s/tmp-%s".formatted(TRACE_CACHE_PREFIX, traceId))) {
-        LOG.info("Temporary location found in blob store cache for traceId={}", traceId);
-        return;
-      }
-
-      blobStore.uploadData(srcLocation, output, true);
-      blobStore.copyFile(srcLocation, dstLocation);
-      blobStore.delete(String.format("%s/tmp-%s", TRACE_CACHE_PREFIX, traceId));
-
-      LOG.info("Compressed trace data saved to blob store cache for traceId={}", traceId);
-
-    } catch (Exception e) {
-      LOG.error("Error saving trace data to blob store cache for traceId={}", traceId, e);
-      throw new RuntimeException("Failed to save trace data to blob store cache", e);
-    }
   }
 }

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -1,6 +1,6 @@
 package com.slack.astra.zipkinApi;
 
-import static com.slack.astra.zipkinApi.ZipkinService.TRACE_CACHE_PREFIX;
+import static com.slack.astra.zipkinApi.TraceFetcher.TRACE_CACHE_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -24,9 +24,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import com.google.protobuf.util.JsonFormat;
-import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.HttpStatus;
 import com.slack.astra.blobfs.BlobStore;
 import com.slack.astra.blobfs.S3TestUtils;
 import com.slack.astra.proto.service.AstraSearch;
@@ -48,10 +45,10 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
-public class ZipkinServiceTest {
+public class TraceFetcherTest {
   private static final String TEST_S3_BUCKET = "zipkin-service-test";
   @Mock private AstraQueryServiceBase searcher;
-  private ZipkinService zipkinService;
+  private TraceFetcher traceFetcher;
   private AstraSearch.SearchResult mockSearchResult;
   private AstraSearch.SearchResult mockEmptySearchResult;
   private BlobStore mockBlobStore;
@@ -76,9 +73,9 @@ public class ZipkinServiceTest {
         S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
     BlobStore blobStore = new BlobStore(s3AsyncClient, TEST_S3_BUCKET);
     mockBlobStore = spy(blobStore);
-    zipkinService =
+    traceFetcher =
         spy(
-            new ZipkinService(
+            new TraceFetcher(
                 searcher,
                 mockBlobStore,
                 defaultMaxSpans,
@@ -116,18 +113,20 @@ public class ZipkinServiceTest {
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
 
       // Act
-      HttpResponse response =
-          zipkinService.getTraceByTraceId(
+      String response =
+          traceFetcher.getByTraceId(
               traceId,
               Optional.empty(),
               Optional.empty(),
               Optional.empty(),
               Optional.empty(),
               Optional.empty());
-      AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
       // Assert
-      assertEquals(HttpStatus.OK, aggregatedResponse.status());
+      assertNotNull(response, "Response should not be null");
+      assertTrue(
+          response.contains("1234556789"),
+          "Response should contain the trace ID from search result");
     }
   }
 
@@ -144,7 +143,7 @@ public class ZipkinServiceTest {
       String traceId = "test_trace_2";
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
 
-      zipkinService.getTraceByTraceId(
+      traceFetcher.getByTraceId(
           traceId,
           Optional.empty(),
           Optional.empty(),
@@ -175,7 +174,7 @@ public class ZipkinServiceTest {
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
       int maxSpansParam = 10000;
 
-      zipkinService.getTraceByTraceId(
+      traceFetcher.getByTraceId(
           traceId,
           Optional.empty(),
           Optional.empty(),
@@ -208,8 +207,8 @@ public class ZipkinServiceTest {
 
       boolean userRequest = true;
 
-      HttpResponse response =
-          zipkinService.getTraceByTraceId(
+      String response =
+          traceFetcher.getByTraceId(
               traceId,
               Optional.empty(),
               Optional.empty(),
@@ -227,13 +226,9 @@ public class ZipkinServiceTest {
       verify(mockBlobStore).delete(anyString());
 
       assertNotNull(response, "Response should not be null");
-      response
-          .aggregate()
-          .thenAccept(
-              aggregatedResponse -> {
-                assertEquals(HttpStatus.OK, aggregatedResponse.status());
-                assertEquals(mockSearchResult.toString(), aggregatedResponse.contentUtf8());
-              });
+      assertTrue(
+          response.contains("1234556789"),
+          "Response should contain the trace ID from search result");
 
       String returnData = mockBlobStore.readFileData(traceFilePath, true);
       assertNotNull(returnData, "Decompressed data should not be null");
@@ -257,8 +252,8 @@ public class ZipkinServiceTest {
 
       boolean userRequest = true;
 
-      HttpResponse response =
-          zipkinService.getTraceByTraceId(
+      String response =
+          traceFetcher.getByTraceId(
               traceId,
               Optional.empty(),
               Optional.empty(),
@@ -276,13 +271,7 @@ public class ZipkinServiceTest {
       verify(mockBlobStore, never()).delete(anyString());
 
       assertNotNull(response, "Response should not be null");
-      response
-          .aggregate()
-          .thenAccept(
-              aggregatedResponse -> {
-                assertEquals(HttpStatus.OK, aggregatedResponse.status());
-                assertEquals(mockSearchResult.toString(), aggregatedResponse.contentUtf8());
-              });
+      assertTrue(response.contains("[]"), "Response should be empty array for empty search result");
     }
   }
 
@@ -305,8 +294,8 @@ public class ZipkinServiceTest {
 
       boolean userRequest = true;
 
-      HttpResponse response =
-          zipkinService.getTraceByTraceId(
+      String response =
+          traceFetcher.getByTraceId(
               traceId,
               Optional.empty(),
               Optional.empty(),
@@ -317,13 +306,8 @@ public class ZipkinServiceTest {
       verify(mockBlobStore).readFileData(eq(traceFilePath), eq(true));
       verify(searcher, never()).doSearch(Mockito.any());
       assertNotNull(response, "Response should not be null");
-      response
-          .aggregate()
-          .thenAccept(
-              aggregatedResponse -> {
-                assertEquals(HttpStatus.OK, aggregatedResponse.status());
-                assertEquals(mockSearchResult.toString(), aggregatedResponse.contentUtf8());
-              });
+      assertTrue(
+          response.contains("1234556789"), "Response should contain the trace ID from cached data");
 
       String returnData = mockBlobStore.readFileData(traceFilePath, true);
       assertNotNull(returnData, "Decompressed data should not be null");
@@ -352,8 +336,8 @@ public class ZipkinServiceTest {
 
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
 
-      HttpResponse response =
-          zipkinService.getTraceByTraceId(
+      String response =
+          traceFetcher.getByTraceId(
               traceId,
               Optional.empty(),
               Optional.empty(),
@@ -370,13 +354,9 @@ public class ZipkinServiceTest {
               Mockito.argThat(
                   request -> request.getQuery().contains("\"trace_id\":\"" + traceId + "\"")));
       assertNotNull(response, "Response should not be null");
-      response
-          .aggregate()
-          .thenAccept(
-              aggregatedResponse -> {
-                assertEquals(HttpStatus.OK, aggregatedResponse.status());
-                assertEquals(mockSearchResult.toString(), aggregatedResponse.contentUtf8());
-              });
+      assertTrue(
+          response.contains("1234556789"),
+          "Response should contain the trace ID from search result");
 
       Path directoryDownloaded = Files.createTempDirectory(traceId);
       mockBlobStore.download(
@@ -406,8 +386,8 @@ public class ZipkinServiceTest {
 
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
 
-      HttpResponse response =
-          zipkinService.getTraceByTraceId(
+      String response =
+          traceFetcher.getByTraceId(
               traceId,
               Optional.empty(),
               Optional.empty(),
@@ -425,13 +405,9 @@ public class ZipkinServiceTest {
       verify(mockBlobStore).copyFile(anyString(), eq(traceFilePath));
       verify(mockBlobStore).delete(anyString());
       assertNotNull(response, "Response should not be null");
-      response
-          .aggregate()
-          .thenAccept(
-              aggregatedResponse -> {
-                assertEquals(HttpStatus.OK, aggregatedResponse.status());
-                assertEquals(mockSearchResult.toString(), aggregatedResponse.contentUtf8());
-              });
+      assertTrue(
+          response.contains("1234556789"),
+          "Response should contain the trace ID from search result");
 
       String returnData = mockBlobStore.readFileData(traceFilePath, true);
 
@@ -445,10 +421,10 @@ public class ZipkinServiceTest {
     String traceId = "test_trace_123";
     String jsonData =
         "[{\"id\":\"101\",\"traceId\":\"test_trace_123\",\"name\":\"test-span\",\"tags\":{\"key1\":\"value1\",\"key2\":\"value2\"}}]";
-    zipkinService.saveDataToBlobStoreCache(traceId, jsonData);
+    traceFetcher.saveDataToBlobStoreCache(traceId, jsonData);
 
     // Act
-    String retrievedData = zipkinService.retrieveDataFromBlobStoreCache(traceId);
+    String retrievedData = traceFetcher.retrieveDataFromBlobStoreCache(traceId);
 
     // Assert
     assertNotNull(retrievedData, "Retrieved data should not be null");
@@ -459,7 +435,7 @@ public class ZipkinServiceTest {
   public void testRetrieveDataFromS3_nullTraceId_throwsException() {
     // Act & Assert
     try {
-      zipkinService.retrieveDataFromBlobStoreCache(null);
+      traceFetcher.retrieveDataFromBlobStoreCache(null);
       fail("Should have thrown an exception");
     } catch (AssertionError e) {
       // Expected - assertion should fail for null traceId
@@ -470,7 +446,7 @@ public class ZipkinServiceTest {
   public void testRetrieveDataFromS3_emptyTraceId_throwsException() {
     // Act & Assert
     try {
-      zipkinService.retrieveDataFromBlobStoreCache("");
+      traceFetcher.retrieveDataFromBlobStoreCache("");
       fail("Should have thrown an exception");
     } catch (AssertionError e) {
       // Expected - assertion should fail for empty traceId
@@ -485,7 +461,7 @@ public class ZipkinServiceTest {
         "[{\"id\":\"101\",\"traceId\":\"test_trace_456\",\"name\":\"test-span\",\"tags\":{\"key1\":\"value1\",\"key2\":\"value2\"}}]";
 
     // Act
-    zipkinService.saveDataToBlobStoreCache(traceId, jsonData);
+    traceFetcher.saveDataToBlobStoreCache(traceId, jsonData);
 
     // Assert
     verify(mockBlobStore).uploadData(anyString(), anyString(), eq(true));
@@ -505,7 +481,7 @@ public class ZipkinServiceTest {
 
     // Act & Assert
     try {
-      zipkinService.saveDataToBlobStoreCache(null, jsonData);
+      traceFetcher.saveDataToBlobStoreCache(null, jsonData);
       assertTrue(false, "Should have thrown an exception");
     } catch (AssertionError e) {
       // Expected - assertion should fail for null traceId
@@ -519,7 +495,7 @@ public class ZipkinServiceTest {
 
     // Act & Assert
     try {
-      zipkinService.saveDataToBlobStoreCache("", jsonData);
+      traceFetcher.saveDataToBlobStoreCache("", jsonData);
       assertTrue(false, "Should have thrown an exception");
     } catch (AssertionError e) {
       // Expected - assertion should fail for empty traceId
@@ -531,7 +507,7 @@ public class ZipkinServiceTest {
 
     // Act & Assert
     try {
-      zipkinService.saveDataToBlobStoreCache("test_trace", null);
+      traceFetcher.saveDataToBlobStoreCache("test_trace", null);
       assertTrue(false, "Should have thrown an exception");
     } catch (AssertionError e) {
       // Expected - assertion should fail for null data

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
@@ -4,7 +4,11 @@ import static com.slack.astra.testlib.MessageUtil.TEST_DATASET_NAME;
 import static com.slack.astra.testlib.MessageUtil.TEST_MESSAGE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.slack.astra.logstore.LogMessage;
 import com.slack.astra.logstore.LogWireMessage;
 import java.time.Instant;
@@ -17,6 +21,14 @@ import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
 public class ZipkinServiceSpanConversionTest {
+  private static final ObjectMapper objectMapper =
+      JsonMapper.builder()
+          // sort alphabetically for easier test asserts
+          .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+          // don't serialize null values or empty maps
+          .serializationInclusion(JsonInclude.Include.NON_EMPTY)
+          .build();
+
   private static LogWireMessage makeWireMessageForSpans(
       String id,
       Instant ts,
@@ -60,15 +72,21 @@ public class ZipkinServiceSpanConversionTest {
     Instant time = Instant.now();
     List<LogWireMessage> messages = generateLogWireMessagesForOneTrace(time, 2, "1");
 
+    List<ZipkinSpanResponse> spans = TraceFetcher.convertLogWireMessageToZipkinSpan(messages);
+    String actualOutput = objectMapper.writeValueAsString(spans);
+
     // follows output format from https://zipkin.io/zipkin-api/#/default/get_trace__traceId_
-    String output =
+    String expectedOutput =
         String.format(
             "[{\"duration\":1,\"id\":\"1\",\"name\":\"Trace1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"1\"},{\"duration\":2,\"id\":\"2\",\"name\":\"Trace2\",\"parentId\":\"1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"1\"}]",
-            ZipkinService.convertToMicroSeconds(time.plusSeconds(1)),
-            ZipkinService.convertToMicroSeconds(time.plusSeconds(2)));
-    assertThat(ZipkinService.convertLogWireMessageToZipkinSpan(messages)).isEqualTo(output);
+            TraceFetcher.convertToMicroSeconds(time.plusSeconds(1)),
+            TraceFetcher.convertToMicroSeconds(time.plusSeconds(2)));
+    assertThat(actualOutput).isEqualTo(expectedOutput);
 
-    assertThat(ZipkinService.convertLogWireMessageToZipkinSpan(new ArrayList<>())).isEqualTo("[]");
+    assertThat(
+            objectMapper.writeValueAsString(
+                TraceFetcher.convertLogWireMessageToZipkinSpan(new ArrayList<>())))
+        .isEqualTo("[]");
   }
 
   @Test
@@ -83,11 +101,14 @@ public class ZipkinServiceSpanConversionTest {
         makeWireMessageForSpans("na", time, "na", Optional.empty(), (long) duration, "na", "na");
     messages = Lists.newArrayList(logWireMessageInt, logWireMessageWithLong);
 
+    List<ZipkinSpanResponse> spans = TraceFetcher.convertLogWireMessageToZipkinSpan(messages);
+    String actualOutput = objectMapper.writeValueAsString(spans);
+
     // follows output format from https://zipkin.io/zipkin-api/#/default/get_trace__traceId_
-    String output =
+    String expectedOutput =
         String.format(
             "[{\"duration\":10,\"id\":\"na\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"},{\"duration\":10,\"id\":\"na\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"}]",
-            ZipkinService.convertToMicroSeconds(time), ZipkinService.convertToMicroSeconds(time));
-    assertThat(ZipkinService.convertLogWireMessageToZipkinSpan(messages)).isEqualTo(output);
+            TraceFetcher.convertToMicroSeconds(time), TraceFetcher.convertToMicroSeconds(time));
+    assertThat(actualOutput).isEqualTo(expectedOutput);
   }
 }


### PR DESCRIPTION
###  Summary

Refactoring Zipkin's trace fetch into a standalone class. This way, the logic can be used for both the `ZipkinService` and the `GraphService`. Logically, everything is the same. Major changes:
- `TraceFetcher` class that now holds the `AstraQueryServiceBase` along with config search options.
- The `ZipkinService` only takes in a `TraceFetcher`
- Move `ZipkinServiceTest` into `TraceFetcherTest`
- `convertLogWireMessageToZipkinSpan` returns a `List<ZipkinSpanResponse>` instead of a JSON string
- `ZipkinService.getTraceByTraceId` split into 3 functions: 
    - `fetchTraceResult` returns  a `Result` containing a cached trace response from the blob store or `List<ZipkinSpanResponse>`. 
    -  `getSpansByTraceId` calls `fetchTraceResult` and de-serializes the cached JSON string into a `List<ZipkinSpanResponse>`or returns a non cached result as is.
    - `getByTraceId` calls `fetchTraceResult` and returns the cached JSON string or serializes into a JSON string.
- The `ZipkinService` now directly calls `TraceFetcher.getByTraceId`.

Eventually,  `GraphService` can leverage `TraceFetcher.getSpansByTraceId` to get a list of spans by trace Id to send to the `GraphBuilder`.

**Testing**

- existing refactored unit tests pass
- `https://airtrace-query-traces-staging.a.musta.ch/api/v2/trace/0Yn8DclcScae6ZhmDb_r2A==`
succeeds before and after branch deploy
- Verified blob store cache fetch by setting `X-User-Request: true`
```
2025-09-29 10:37:56.581 -0700 | Trace data retrieved from blob store cache for traceId=0Yn8DclcScae6ZhmDb_r2A==
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
