### PR TITLE
subgraph api

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -53,29 +52,31 @@ public class GraphBuilder {
             .collect(Collectors.toMap(ZipkinSpanResponse::getId, this::createChildNodeFromSpan));
 
     // Second pass: build unique edges
-    Set<Edge> edges =
-        spans.stream()
-            .filter(span -> span.getId() != null && span.getParentId() != null)
-            .map(
-                span -> {
-                  Node parentNode = spanIdToNode.get(span.getParentId());
-                  Node childNode = spanIdToNode.get(span.getId());
+    long missingParentOrChildCount = 0;
+    Set<Edge> edges = new HashSet<>();
 
-                  if (parentNode != null && childNode != null) {
-                    return new Edge(
-                        parentNode.getId(),
-                        childNode.getId(),
-                        config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE));
-                  } else {
-                    LOG.warn(
-                        "Missing parent or child node for parentSpanId={} and childSpanId={}",
-                        span.getParentId(),
-                        span.getId());
-                    return null;
-                  }
-                })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
+    for (ZipkinSpanResponse span : spans) {
+      if (span.getId() == null || span.getParentId() == null) {
+        continue;
+      }
+
+      Node parentNode = spanIdToNode.get(span.getParentId());
+      Node childNode = spanIdToNode.get(span.getId());
+
+      if (parentNode != null && childNode != null) {
+        edges.add(
+            new Edge(
+                parentNode.getId(),
+                childNode.getId(),
+                config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE)));
+      } else {
+        missingParentOrChildCount++;
+      }
+    }
+
+    if (missingParentOrChildCount > 0) {
+      LOG.warn("Found {} spans with missing parent or child node", missingParentOrChildCount);
+    }
 
     // Dedupe nodes
     Set<Node> nodes = new HashSet<>(spanIdToNode.values());

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -31,7 +31,7 @@ public class GraphBuilder {
    * @param config The GraphConfig to use for node metadata extraction. If GraphConfig.DEFAULT, uses
    *     service name from a span's remote endpoint.
    */
-  GraphBuilder(GraphConfig config) {
+  public GraphBuilder(GraphConfig config) {
     this.config = config;
   }
 

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -8,10 +8,14 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
-import com.slack.astra.server.AstraQueryServiceBase;
+import com.slack.astra.zipkinApi.TraceFetcher;
+import com.slack.astra.zipkinApi.ZipkinSpanResponse;
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,8 +24,8 @@ import org.slf4j.LoggerFactory;
 */
 public class GraphService {
   private static final Logger LOG = LoggerFactory.getLogger(GraphService.class);
-  private final AstraQueryServiceBase searcher;
-  private final GraphConfig graphConfig;
+  private final TraceFetcher traceFetcher;
+  private final GraphBuilder graphBuilder;
 
   private static final ObjectMapper objectMapper =
       JsonMapper.builder()
@@ -31,17 +35,29 @@ public class GraphService {
           .serializationInclusion(JsonInclude.Include.NON_EMPTY)
           .build();
 
-  public GraphService(AstraQueryServiceBase searcher, GraphConfig graphConfig) {
-    this.searcher = searcher;
-    this.graphConfig = graphConfig;
+  public GraphService(TraceFetcher traceFetcher, GraphConfig graphConfig) {
+    this.traceFetcher = traceFetcher;
+    this.graphBuilder = new GraphBuilder(graphConfig);
 
-    LOG.info("Started GraphService with config: {}", this.graphConfig);
+    LOG.info("Started GraphService with GraphBuilder config: {}", graphConfig);
   }
 
   @Get
   @Path("/api/v1/trace/{traceId}/subgraph")
-  public HttpResponse getSubgraph(@Param("traceId") String traceId) throws IOException {
-    String output = "[]";
+  public HttpResponse getSubgraph(
+      @Param("traceId") String traceId, @Header("X-User-Request") Optional<Boolean> userRequest)
+      throws IOException {
+    List<ZipkinSpanResponse> trace =
+        this.traceFetcher.getSpansByTraceId(
+            traceId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            userRequest,
+            Optional.empty());
+
+    Graph subgraph = this.graphBuilder.buildFromSpans(trace);
+    String output = objectMapper.writeValueAsString(subgraph);
     return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -42,6 +42,9 @@ public class GraphService {
     LOG.info("Started GraphService with GraphBuilder config: {}", graphConfig);
   }
 
+  private record SubgraphResponse(
+      Graph subgraph, long traceFetchTimeMs, long subgraphBuildTimeMs) {}
+
   @Get
   @Path("/api/v1/trace/{traceId}/subgraph")
   public HttpResponse getSubgraph(
@@ -56,16 +59,16 @@ public class GraphService {
             Optional.empty(),
             userRequest,
             Optional.empty());
-
     long end = System.currentTimeMillis();
-      LOG.info("Time to fetch trace: " + (end - start) + " ms");
+    long traceFetchTime = end - start;
 
     start = System.currentTimeMillis();
     Graph subgraph = this.graphBuilder.buildFromSpans(trace);
     end = System.currentTimeMillis();
-      LOG.info("Time to build subgraph: " + (end - start) + " ms");
+    long subgraphBuildTime = end - start;
 
-    String output = objectMapper.writeValueAsString(subgraph);
+    SubgraphResponse response = new SubgraphResponse(subgraph, traceFetchTime, subgraphBuildTime);
+    String output = objectMapper.writeValueAsString(response);
     return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -48,17 +48,14 @@ public class GraphService {
   @Get
   @Path("/api/v1/trace/{traceId}/subgraph")
   public HttpResponse getSubgraph(
-      @Param("traceId") String traceId, @Header("X-User-Request") Optional<Boolean> userRequest)
+      @Param("traceId") String traceId,
+      @Param("maxSpans") Optional<Integer> maxSpans,
+      @Header("X-User-Request") Optional<Boolean> userRequest)
       throws IOException {
     long start = System.currentTimeMillis();
     List<ZipkinSpanResponse> trace =
         this.traceFetcher.getSpansByTraceId(
-            traceId,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            userRequest,
-            Optional.empty());
+            traceId, Optional.empty(), Optional.empty(), maxSpans, userRequest, Optional.empty());
     long end = System.currentTimeMillis();
     long traceFetchTime = end - start;
 

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -47,6 +47,7 @@ public class GraphService {
   public HttpResponse getSubgraph(
       @Param("traceId") String traceId, @Header("X-User-Request") Optional<Boolean> userRequest)
       throws IOException {
+    long start = System.currentTimeMillis();
     List<ZipkinSpanResponse> trace =
         this.traceFetcher.getSpansByTraceId(
             traceId,
@@ -56,7 +57,14 @@ public class GraphService {
             userRequest,
             Optional.empty());
 
+    long end = System.currentTimeMillis();
+      LOG.info("Time to fetch trace: " + (end - start) + " ms");
+
+    start = System.currentTimeMillis();
     Graph subgraph = this.graphBuilder.buildFromSpans(trace);
+    end = System.currentTimeMillis();
+      LOG.info("Time to build subgraph: " + (end - start) + " ms");
+
     String output = objectMapper.writeValueAsString(subgraph);
     return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
   }

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -266,7 +266,7 @@ public class Astra {
               .withTracing(astraConfig.getTracingConfig())
               .withAnnotatedService(new ElasticsearchApiService(astraDistributedQueryService))
               .withAnnotatedService(new ZipkinService(tf))
-              .withAnnotatedService(new GraphService(astraDistributedQueryService, graphConfig))
+              .withAnnotatedService(new GraphService(tf, graphConfig))
               .withGrpcService(astraDistributedQueryService)
               .build();
       services.add(armeriaService);

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -61,7 +61,7 @@ public class GraphServiceTest {
             any(Optional.class)))
         .thenReturn(Collections.emptyList());
 
-    HttpResponse response = graphService.getSubgraph(traceId, Optional.empty());
+    HttpResponse response = graphService.getSubgraph(traceId, Optional.empty(), Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.OK, aggregatedResponse.status());
@@ -169,7 +169,7 @@ public class GraphServiceTest {
             any(Optional.class)))
         .thenReturn(testSpans);
 
-    HttpResponse response = graphService.getSubgraph(traceId, Optional.empty());
+    HttpResponse response = graphService.getSubgraph(traceId, Optional.empty(), Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.OK, aggregatedResponse.status());

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -92,7 +92,7 @@ public class GraphServiceTest {
                 Map.of(
                     "kube.app", "api-gateway",
                     "kube.namespace", "prod",
-                    "kube.operation", "http.request",
+                    "operation_name", "http.request",
                     "resource", "/api/users/profile")),
 
             // First level children
@@ -103,7 +103,7 @@ public class GraphServiceTest {
                 Map.of(
                     "kube.app", "auth-service",
                     "kube.namespace", "prod",
-                    "kube.operation", "http.request",
+                    "operation_name", "http.request",
                     "resource", "/api/auth/validate")),
             TestUtils.createSpanWithTags(
                 "child2",
@@ -112,7 +112,7 @@ public class GraphServiceTest {
                 Map.of(
                     "kube.app", "user-service",
                     "kube.namespace", "prod",
-                    "kube.operation", "user.fetch",
+                    "operation_name", "user.fetch",
                     "resource", "getUserProfile")),
             TestUtils.createSpanWithTags(
                 "child3",
@@ -121,7 +121,7 @@ public class GraphServiceTest {
                 Map.of(
                     "kube.app", "notification-service",
                     "kube.namespace", "prod",
-                    "kube.operation", "notify.send",
+                    "operation_name", "notify.send",
                     "resource", "sendNotification")),
 
             // Second level children (grandchildren)
@@ -132,7 +132,7 @@ public class GraphServiceTest {
                 Map.of(
                     "kube.app", "postgres-db",
                     "kube.namespace", "prod",
-                    "kube.operation", "db.query",
+                    "operation_name", "db.query",
                     "resource", "SELECT * FROM users WHERE id = ?")),
             TestUtils.createSpanWithTags(
                 "grandchild2",
@@ -141,7 +141,7 @@ public class GraphServiceTest {
                 Map.of(
                     "kube.app", "redis-cache",
                     "kube.namespace", "prod",
-                    "kube.operation", "cache.get",
+                    "operation_name", "cache.get",
                     "resource", "user:profile:12345")),
             TestUtils.createSpanWithTags(
                 "grandchild3",
@@ -150,7 +150,7 @@ public class GraphServiceTest {
                 Map.of(
                     "kube.app", "email-service",
                     "kube.namespace", "prod",
-                    "kube.operation", "email.send",
+                    "operation_name", "email.send",
                     "resource", "sendEmail")));
 
     when(traceFetcher.getSpansByTraceId(
@@ -193,7 +193,6 @@ public class GraphServiceTest {
       JsonNode metadata = node.get("metadata");
       assertTrue(metadata.has("app"));
       assertTrue(metadata.has("namespace"));
-      assertTrue(metadata.has("operation"));
       assertTrue(metadata.has("resource"));
     }
 
@@ -201,6 +200,9 @@ public class GraphServiceTest {
     for (JsonNode edge : edges) {
       assertTrue(edge.has("sourceNodeId"));
       assertTrue(edge.has("targetNodeId"));
+
+      JsonNode metadata = edge.get("metadata");
+      assertTrue(metadata.has("operation"));
     }
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -1,34 +1,206 @@
 package com.slack.astra.graphApi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.slack.astra.server.AstraQueryServiceBase;
+import com.slack.astra.zipkinApi.TraceFetcher;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class GraphServiceTest {
-  @Mock private AstraQueryServiceBase searcher;
+  @Mock private TraceFetcher traceFetcher;
   private GraphService graphService;
+  private ObjectMapper objectMapper;
 
   @BeforeEach
   public void setup() throws IOException {
-    graphService = spy(new GraphService(searcher, GraphConfig.DEFAULT));
+    MockitoAnnotations.openMocks(this);
+
+    // Load custom config from YAML file
+    Path configPath =
+        new File(
+                Objects.requireNonNull(
+                        getClass()
+                            .getClassLoader()
+                            .getResource("test-dependency-graph-config.yaml"))
+                    .getFile())
+            .toPath();
+    graphService = spy(new GraphService(traceFetcher, GraphConfig.load(configPath)));
+    objectMapper = new ObjectMapper();
   }
 
   @Test
   public void testGetSubgraphByTraceId_emptyResult() throws Exception {
-    String traceId = "test_trace_1";
+    String traceId = "test_trace_empty";
 
-    HttpResponse response = graphService.getSubgraph(traceId);
+    when(traceFetcher.getSpansByTraceId(
+            anyString(),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(Collections.emptyList());
+
+    HttpResponse response = graphService.getSubgraph(traceId, Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.OK, aggregatedResponse.status());
-    assertEquals("[]", aggregatedResponse.contentUtf8());
+
+    // Verify it's valid JSON with nodes and edges arrays
+    assertEquals("{}", aggregatedResponse.contentUtf8());
+  }
+
+  @Test
+  public void testGetSubgraphByTraceId_withComplexHierarchy() throws Exception {
+    String traceId = "test_trace_complex";
+
+    // Create a complex span hierarchy:
+    // root (API Gateway)
+    //   ├── child1 (Auth Service)
+    //   ├── child2 (User Service)
+    //   │   ├── grandchild1 (Database)
+    //   │   └── grandchild2 (Cache Service)
+    //   └── child3 (Notification Service)
+    //       └── grandchild3 (Email Service)
+    List<com.slack.astra.zipkinApi.ZipkinSpanResponse> testSpans =
+        List.of(
+            // Root span - API Gateway
+            TestUtils.createSpanWithTags(
+                "root",
+                traceId,
+                null,
+                Map.of(
+                    "kube.app", "api-gateway",
+                    "kube.namespace", "prod",
+                    "kube.operation", "http.request",
+                    "resource", "/api/users/profile")),
+
+            // First level children
+            TestUtils.createSpanWithTags(
+                "child1",
+                traceId,
+                "root",
+                Map.of(
+                    "kube.app", "auth-service",
+                    "kube.namespace", "prod",
+                    "kube.operation", "http.request",
+                    "resource", "/api/auth/validate")),
+            TestUtils.createSpanWithTags(
+                "child2",
+                traceId,
+                "root",
+                Map.of(
+                    "kube.app", "user-service",
+                    "kube.namespace", "prod",
+                    "kube.operation", "user.fetch",
+                    "resource", "getUserProfile")),
+            TestUtils.createSpanWithTags(
+                "child3",
+                traceId,
+                "root",
+                Map.of(
+                    "kube.app", "notification-service",
+                    "kube.namespace", "prod",
+                    "kube.operation", "notify.send",
+                    "resource", "sendNotification")),
+
+            // Second level children (grandchildren)
+            TestUtils.createSpanWithTags(
+                "grandchild1",
+                traceId,
+                "child2",
+                Map.of(
+                    "kube.app", "postgres-db",
+                    "kube.namespace", "prod",
+                    "kube.operation", "db.query",
+                    "resource", "SELECT * FROM users WHERE id = ?")),
+            TestUtils.createSpanWithTags(
+                "grandchild2",
+                traceId,
+                "child2",
+                Map.of(
+                    "kube.app", "redis-cache",
+                    "kube.namespace", "prod",
+                    "kube.operation", "cache.get",
+                    "resource", "user:profile:12345")),
+            TestUtils.createSpanWithTags(
+                "grandchild3",
+                traceId,
+                "child3",
+                Map.of(
+                    "kube.app", "email-service",
+                    "kube.namespace", "prod",
+                    "kube.operation", "email.send",
+                    "resource", "sendEmail")));
+
+    when(traceFetcher.getSpansByTraceId(
+            anyString(),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(testSpans);
+
+    HttpResponse response = graphService.getSubgraph(traceId, Optional.empty());
+    AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
+
+    assertEquals(HttpStatus.OK, aggregatedResponse.status());
+
+    // Verify it's valid JSON with proper structure
+    String content = aggregatedResponse.contentUtf8();
+    JsonNode jsonNode = objectMapper.readTree(content);
+
+    // Verify structure
+    assertTrue(jsonNode.has("nodes"));
+    assertTrue(jsonNode.has("edges"));
+
+    // Verify data content
+    JsonNode nodes = jsonNode.get("nodes");
+    JsonNode edges = jsonNode.get("edges");
+
+    assertEquals(7, nodes.size(), "Should have 7 nodes (1 root + 3 children + 3 grandchildren)");
+    assertEquals(
+        6,
+        edges.size(),
+        "Should have 6 edges (3 root->child + 2 child2->grandchild + 1 child3->grandchild)");
+
+    // Verify all nodes have required fields
+    for (JsonNode node : nodes) {
+      assertTrue(node.has("id"));
+      assertTrue(node.has("metadata"));
+
+      JsonNode metadata = node.get("metadata");
+      assertTrue(metadata.has("app"));
+      assertTrue(metadata.has("namespace"));
+      assertTrue(metadata.has("operation"));
+      assertTrue(metadata.has("resource"));
+    }
+
+    // Verify all edges have required fields
+    for (JsonNode edge : edges) {
+      assertTrue(edge.has("sourceNodeId"));
+      assertTrue(edge.has("targetNodeId"));
+    }
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -67,7 +67,14 @@ public class GraphServiceTest {
     assertEquals(HttpStatus.OK, aggregatedResponse.status());
 
     // Verify it's valid JSON with nodes and edges arrays
-    assertEquals("{}", aggregatedResponse.contentUtf8());
+    String content = aggregatedResponse.contentUtf8();
+    JsonNode jsonNode = objectMapper.readTree(content);
+
+    assertTrue(jsonNode.has("subgraph"));
+    assertTrue(jsonNode.has("traceFetchTimeMs"));
+    assertTrue(jsonNode.has("subgraphBuildTimeMs"));
+
+    assertTrue(jsonNode.get("subgraph").isEmpty());
   }
 
   @Test
@@ -172,12 +179,17 @@ public class GraphServiceTest {
     JsonNode jsonNode = objectMapper.readTree(content);
 
     // Verify structure
-    assertTrue(jsonNode.has("nodes"));
-    assertTrue(jsonNode.has("edges"));
+    assertTrue(jsonNode.has("subgraph"));
+    assertTrue(jsonNode.has("traceFetchTimeMs"));
+    assertTrue(jsonNode.has("subgraphBuildTimeMs"));
+
+    JsonNode subgraph = jsonNode.get("subgraph");
+    assertTrue(subgraph.has("nodes"));
+    assertTrue(subgraph.has("edges"));
 
     // Verify data content
-    JsonNode nodes = jsonNode.get("nodes");
-    JsonNode edges = jsonNode.get("edges");
+    JsonNode nodes = subgraph.get("nodes");
+    JsonNode edges = subgraph.get("edges");
 
     assertEquals(7, nodes.size(), "Should have 7 nodes (1 root + 3 children + 3 grandchildren)");
     assertEquals(


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.
This PR pulls in all the pieces from the `GraphConfig`,  `GraphBuilder` and `TraceFetcher` to return a subgraph for a particular trace id. 

The output will be a `Graph` that has a list of nodes (with their metadata) and a list of connections between them (the edges).

### Testing

```
 ▲ ~ curl -X GET 'http://localhost:8081/api/v1/trace/hyZ2sIqSoy11I1sfH5VvqQ==/subgraph?maxSpans=2' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   455  100   455    0     0   1659      0 --:--:-- --:--:-- --:--:--  1654
{
  "subgraph": {
    "nodes": [
      {
        "id": "cb9290991532684db51497b5b10c9b5cddee8d0b2a9d03bf3aa57cf194186a13",
        "metadata": {
          "app": "viaduct-shard-27-production",
          "namespace": "viaduct-production",
          "resource": "viaduct.response.resume"
        }
      },
      {
        "id": "b5aae0daffeb2488664f7bca48579a77fc254b53e6e51c830015b44c35cf01ab",
        "metadata": {
          "app": "viaduct-shard-1-production",
          "namespace": "viaduct-production",
          "resource": "viaduct.response.resume"
        }
      }
    ]
  },
  "subgraphBuildTimeMs": 0,
  "traceFetchTimeMs": 16
}


}
 ▲ ~ curl -X GET 'http://localhost:8081/api/v1/trace/hyZ2sIqSoy11I1sfH5VvqQ==/subgraph' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 50482  100 50482    0     0    97k      0 --:--:-- --:--:-- --:--:--   98k
{
  "subgraph": {
    "edges": [
      {
        "metadata": {
          "operation": "http.request"
        },
        "sourceNodeId": "ec79aa23539e8e3affdfb2fc03bf1d69e6b98b75b815f567a660cefd0ad82f24",
        "targetNodeId": "ec79aa23539e8e3affdfb2fc03bf1d69e6b98b75b815f567a660cefd0ad82f24"
      },
      {
        "metadata": {
          "operation": "himejiro-production.himejiro-production.svc.ea1.us.a:10379/*"
        },
        "sourceNodeId": "e44652d8e982bd99a8a5ced74f527c475583313da7223310dcafec6f1fa47369",
        "targetNodeId": "4bf08e24c99ea54a7554469926db00574ee93434ee79911d63e1a4d4f8891eb9"
      },
      {
        "metadata": {
          "operation": "graphql.deserialize"
        },
        "sourceNodeId": "b112888b123feaa0f7ca98e9739ec5e59826ffc8da6bd12511b1729eb5ef7737",
        "targetNodeId": "a366b750db8b4e1c5abf2a95037bee0cdb42e0ae6a1f1bcba6503cf2bc992ab0"
      },
      {
        "metadata": {
          "operation": "viaduct.response.resume"
        },
        "sourceNodeId": "9e7d2b9a654465528013a6870dd9088929618fc2a4790610799ee198fc651856",
        "targetNodeId": "b6187ac725920b68ac99df10462b250e5353dce4c2883ecc83e8c689f42d099b"
      },
...
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
