### PR TITLE
add edge metadata support

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/Edge.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/Edge.java
@@ -2,8 +2,10 @@ package com.slack.astra.graphApi;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.SortedMap;
+
 // Represents a directed connection between two Nodes.
-public record Edge(String sourceNodeId, String targetNodeId) {
+public record Edge(String sourceNodeId, String targetNodeId, SortedMap<String, String> metadata) {
   public Edge {
     checkNotNull(sourceNodeId, "sourceNodeId cannot be null");
     checkNotNull(targetNodeId, "targetNodeId cannot be null");

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -52,8 +52,8 @@ public class GraphBuilder {
             .filter(span -> span.getId() != null)
             .collect(Collectors.toMap(ZipkinSpanResponse::getId, this::createChildNodeFromSpan));
 
-    // Second pass: build mapping between parentNodeId -> list of childNodeIds
-    Map<String, List<String>> parentNodeIdToChildNodeIds =
+    // Second pass: build unique edges
+    Set<Edge> edges =
         spans.stream()
             .filter(span -> span.getId() != null && span.getParentId() != null)
             .map(
@@ -61,13 +61,11 @@ public class GraphBuilder {
                   Node parentNode = spanIdToNode.get(span.getParentId());
                   Node childNode = spanIdToNode.get(span.getId());
 
-                  /*
-                  Currently, we're dropping edges where the parent or child is missing. There might be cases where we
-                  want to retain one-sided edges for diagnostic purposes or attach warnings/errors to the graph itself,
-                  in which case this logic will need updating.
-                  */
                   if (parentNode != null && childNode != null) {
-                    return Map.entry(parentNode.getId(), childNode.getId());
+                    return new Edge(
+                        parentNode.getId(),
+                        childNode.getId(),
+                        config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE));
                   } else {
                     LOG.warn(
                         "Missing parent or child node for parentSpanId={} and childSpanId={}",
@@ -77,13 +75,8 @@ public class GraphBuilder {
                   }
                 })
             .filter(Objects::nonNull)
-            .collect(
-                Collectors.groupingBy(
-                    Map.Entry::getKey,
-                    Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+            .collect(Collectors.toSet());
 
-    // Create edges from parent-child relationships
-    Set<Edge> edges = buildEdges(parentNodeIdToChildNodeIds);
     // Dedupe nodes
     Set<Node> nodes = new HashSet<>(spanIdToNode.values());
 
@@ -98,23 +91,6 @@ public class GraphBuilder {
    * @return Node with metadata extracted from the span
    */
   private Node createChildNodeFromSpan(ZipkinSpanResponse span) {
-    return new Node(config.createMetadataFromSpan(span));
-  }
-
-  /**
-   * Builds edges representing parent-child relationships between nodes.
-   *
-   * <p>Creates edges by connecting parent nodes to their child nodes, establishing the dependency
-   * relationships in the service graph.
-   *
-   * @param parentNodeIdToChildNodeIds parentNodeIds and their list of childNodeIds
-   * @return Set of edges representing service dependencies
-   */
-  private Set<Edge> buildEdges(Map<String, List<String>> parentNodeIdToChildNodeIds) {
-    return parentNodeIdToChildNodeIds.entrySet().stream()
-        .flatMap(
-            entry ->
-                entry.getValue().stream().map(childNodeId -> new Edge(entry.getKey(), childNodeId)))
-        .collect(Collectors.toSet());
+    return new Node(config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE));
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.slf4j.Logger;
@@ -20,7 +21,12 @@ import org.slf4j.LoggerFactory;
 public final class GraphConfig {
   private static final Logger LOG = LoggerFactory.getLogger(GraphConfig.class);
 
-  public static final GraphConfig DEFAULT = new GraphConfig(Map.of());
+  public static final GraphConfig DEFAULT = new GraphConfig(Map.of(), Map.of());
+
+  public enum EntityType {
+    NODE,
+    EDGE
+  }
 
   /**
    * Represents how a single logical field on a node should be mapped to span tags.
@@ -88,17 +94,33 @@ public final class GraphConfig {
     }
   }
 
-  // Holds the entire mapping for logical field names to their configuration of defaults and rules.
+  // Holds the entire mapping for logical field names to their configuration of defaults and rules
+  // for nodes.
   private final Map<String, TagConfig> nodeMetadataTagMapping;
+  // Holds the entire mapping for logical field names to their configuration of defaults and rules
+  // for nodes.
+  private final Map<String, TagConfig> edgeMetadataTagMapping;
 
   @JsonCreator
   public GraphConfig(
-      @JsonProperty("node_metadata_tag_mapping") Map<String, TagConfig> nodeMetadataTagMapping) {
-    this.nodeMetadataTagMapping = Map.copyOf(nodeMetadataTagMapping);
+      @JsonProperty("node_metadata_tag_mapping") Map<String, TagConfig> nodeMetadataTagMapping,
+      @JsonProperty("edge_metadata_tag_mapping") Map<String, TagConfig> edgeMetadataTagMapping) {
+    this.nodeMetadataTagMapping =
+        (nodeMetadataTagMapping == null)
+            ? Collections.emptyMap()
+            : Map.copyOf(nodeMetadataTagMapping);
+    this.edgeMetadataTagMapping =
+        (edgeMetadataTagMapping == null)
+            ? Collections.emptyMap()
+            : Map.copyOf(edgeMetadataTagMapping);
   }
 
   public Map<String, TagConfig> getNodeMetadataTagMapping() {
     return nodeMetadataTagMapping;
+  }
+
+  public Map<String, TagConfig> getEdgeMetadataTagMapping() {
+    return edgeMetadataTagMapping;
   }
 
   /**
@@ -141,23 +163,33 @@ public final class GraphConfig {
   }
 
   /**
-   * Creates metadata for a child node from a span, using either default behavior or configured
-   * mapping.
+   * Creates metadata for a graph entity (node or edge) from a span, using either default behavior
+   * or configured mapping.
    *
    * @param span ZipkinSpanResponse containing the span data
-   * @return SortedMap containing the metadata for the child node
+   * @return SortedMap containing the metadata for the requested entity
    */
-  public SortedMap<String, String> createMetadataFromSpan(ZipkinSpanResponse span) {
+  public SortedMap<String, String> createMetadataFromSpan(
+      ZipkinSpanResponse span, EntityType entityType) {
     SortedMap<String, String> metadata = new TreeMap<>();
 
     if (this == DEFAULT) {
-      // Default behavior: use service name from remote endpoint
-      metadata.put("service", span.getRemoteEndpoint().getServiceName());
+      // We only care about default behavior for a node, edge metadata is optional.
+      if (entityType == EntityType.NODE) {
+        // use service name from remote endpoint
+        metadata.put("service", span.getRemoteEndpoint().getServiceName());
+      }
     } else {
-      // Use configured tag mapping
       Map<String, String> tags = span.getTags();
-      for (String key : this.nodeMetadataTagMapping.keySet()) {
-        metadata.put(key, resolve(tags, key));
+
+      // Use configured tag mapping
+      Set<String> keys = this.nodeMetadataTagMapping.keySet();
+      if (entityType == EntityType.EDGE) {
+        keys = this.edgeMetadataTagMapping.keySet();
+      }
+
+      for (String key : keys) {
+        metadata.put(key, resolve(tags, key, entityType));
       }
     }
 
@@ -178,8 +210,11 @@ public final class GraphConfig {
    * @param logicalField the node metadata field to resolve.
    * @return String the value of the logical metadata field after applying all GraphConfig rules.
    */
-  public String resolve(Map<String, String> tags, String logicalField) {
+  public String resolve(Map<String, String> tags, String logicalField, EntityType entityType) {
     TagConfig baseCfg = nodeMetadataTagMapping.get(logicalField);
+    if (entityType == EntityType.EDGE) {
+      baseCfg = edgeMetadataTagMapping.get(logicalField);
+    }
 
     // If the config doesn't define this logical field, just return from raw tags or fallback.
     if (baseCfg == null) {

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -183,10 +183,11 @@ public final class GraphConfig {
       Map<String, String> tags = span.getTags();
 
       // Use configured tag mapping
-      Set<String> keys = this.nodeMetadataTagMapping.keySet();
-      if (entityType == EntityType.EDGE) {
-        keys = this.edgeMetadataTagMapping.keySet();
-      }
+      Set<String> keys =
+          switch (entityType) {
+            case EDGE -> this.edgeMetadataTagMapping.keySet();
+            case NODE -> this.nodeMetadataTagMapping.keySet();
+          };
 
       for (String key : keys) {
         metadata.put(key, resolve(tags, key, entityType));
@@ -211,10 +212,11 @@ public final class GraphConfig {
    * @return String the value of the logical metadata field after applying all GraphConfig rules.
    */
   public String resolve(Map<String, String> tags, String logicalField, EntityType entityType) {
-    TagConfig baseCfg = nodeMetadataTagMapping.get(logicalField);
-    if (entityType == EntityType.EDGE) {
-      baseCfg = edgeMetadataTagMapping.get(logicalField);
-    }
+    TagConfig baseCfg =
+        switch (entityType) {
+          case EDGE -> this.edgeMetadataTagMapping.get(logicalField);
+          case NODE -> this.nodeMetadataTagMapping.get(logicalField);
+        };
 
     // If the config doesn't define this logical field, just return from raw tags or fallback.
     if (baseCfg == null) {

--- a/astra/src/test/java/com/slack/astra/graphApi/EdgeTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/EdgeTest.java
@@ -3,6 +3,8 @@ package com.slack.astra.graphApi;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
+import java.util.Map;
+import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
 
 public class EdgeTest {
@@ -10,22 +12,31 @@ public class EdgeTest {
   @Test
   void builder_sourceNull_throwsNullPointerException() {
     assertThatExceptionOfType(NullPointerException.class)
-        .isThrownBy(() -> new Edge(null, "target"))
+        .isThrownBy(() -> new Edge(null, "target", null))
         .withMessage("sourceNodeId cannot be null");
   }
 
   @Test
   void builder_targetNull_throwsNullPointerException() {
     assertThatExceptionOfType(NullPointerException.class)
-        .isThrownBy(() -> new Edge("source", null))
+        .isThrownBy(() -> new Edge("source", null, null))
         .withMessage("targetNodeId cannot be null");
   }
 
   @Test
   void build_withValidSourceAndTarget_succeeds() {
-    Edge e = new Edge("source", "target");
+    Edge e = new Edge("source", "target", null);
 
     assertThat(e.sourceNodeId()).isEqualTo("source");
     assertThat(e.targetNodeId()).isEqualTo("target");
+  }
+
+  @Test
+  void build_withValidSourceTargetAndMetadata_succeeds() {
+    Edge e = new Edge("source", "target", new TreeMap<>(Map.of("operation", "default")));
+
+    assertThat(e.sourceNodeId()).isEqualTo("source");
+    assertThat(e.targetNodeId()).isEqualTo("target");
+    assertThat(e.metadata()).isNotEmpty();
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -59,7 +59,7 @@ public class GraphBuilderTest {
                     "app1",
                     "kube.namespace",
                     "ns1",
-                    "kube.operation",
+                    "operation_name",
                     "op1",
                     "resource",
                     "res1")));
@@ -70,17 +70,16 @@ public class GraphBuilderTest {
     Node node = graph.nodes().getFirst();
 
     // Verify the node ID matches the expected hash
-    SortedMap<String, String> expectedMetadata =
+    SortedMap<String, String> expectedNodeMetadata =
         new TreeMap<>(
             Map.of(
                 "app", "app1",
                 "namespace", "ns1",
-                "operation", "op1",
                 "resource", "res1"));
-    String expectedId = Node.generateIdFromMetadata(expectedMetadata);
+    String expectedId = Node.generateIdFromMetadata(expectedNodeMetadata);
 
     assertThat(node.getId()).isEqualTo(expectedId);
-    assertThat(node.getMetadata()).isEqualTo(expectedMetadata);
+    assertThat(node.getMetadata()).isEqualTo(expectedNodeMetadata);
 
     assertThat(graph.edges()).isEmpty();
   }
@@ -119,7 +118,6 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "app1",
                 "namespace", "ns1",
-                "operation", "op1",
                 "resource", "res1"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
@@ -128,12 +126,14 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "app2",
                 "namespace", "ns2",
-                "operation", "op2",
                 "resource", "res2"));
+
+    SortedMap<String, String> edgeMetadata = new TreeMap<>(Map.of("operation", "op2"));
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
     Edge edge = graph.edges().iterator().next();
     assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
     assertThat(edge.targetNodeId()).isEqualTo(expectedChildId);
+    assertThat(edge.metadata()).isEqualTo(edgeMetadata);
   }
 
   @Test
@@ -194,7 +194,6 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "unknown_app",
                 "namespace", "unknown_namespace",
-                "operation", "unknown_operation",
                 "resource", "unknown_resource"));
     String expectedId = Node.generateIdFromMetadata(expectedMetadata);
 
@@ -327,7 +326,6 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "app1",
                 "namespace", "ns1",
-                "operation", "op1",
                 "resource", "res1"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
@@ -336,7 +334,6 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "app2",
                 "namespace", "ns2",
-                "operation", "op2",
                 "resource", "res2"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
@@ -345,7 +342,6 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "app3",
                 "namespace", "ns3",
-                "operation", "op3",
                 "resource", "res3"));
     String expectedChild2Id = Node.generateIdFromMetadata(child2Metadata);
 
@@ -353,6 +349,10 @@ public class GraphBuilderTest {
     List<Edge> edges = graph.edges();
     assertThat(edges.stream().allMatch(edge -> edge.sourceNodeId().equals(expectedParentId)))
         .isTrue();
+
+    // metadata of the edges
+    assertThat(edges.get(0).metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op2")));
+    assertThat(edges.get(1).metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op3")));
 
     // verify different children
     List<String> childIds = List.of(edges.stream().map(Edge::targetNodeId).toArray(String[]::new));
@@ -401,13 +401,14 @@ public class GraphBuilderTest {
 
     // should have only 1 edge despite multiple spans creating the same parent-child relationship
     assertThat(graph.edges()).hasSize(1);
+    assertThat(graph.edges().get(0).metadata())
+        .isEqualTo(new TreeMap<>(Map.of("operation", "op2")));
 
     SortedMap<String, String> parentMetadata =
         new TreeMap<>(
             Map.of(
                 "app", "app1",
                 "namespace", "ns1",
-                "operation", "op1",
                 "resource", "res1"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
@@ -416,7 +417,6 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "app2",
                 "namespace", "ns2",
-                "operation", "op2",
                 "resource", "res2"));
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
 
@@ -483,7 +483,6 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "root_app",
                 "namespace", "root_ns",
-                "operation", "root_op",
                 "resource", "root_res"));
     String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
 
@@ -492,7 +491,6 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "child1_app",
                 "namespace", "child1_ns",
-                "operation", "child1_op",
                 "resource", "child1_res"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
@@ -501,7 +499,6 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "child2_app",
                 "namespace", "child2_ns",
-                "operation", "child2_op",
                 "resource", "child2_res"));
     String expectedChild2Id = Node.generateIdFromMetadata(child2Metadata);
 
@@ -510,32 +507,31 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "gc_app",
                 "namespace", "gc_ns",
-                "operation", "gc_op",
                 "resource", "gc_res"));
     String expectedGrandchildId = Node.generateIdFromMetadata(grandchildMetadata);
 
     List<Edge> edges = graph.edges();
 
-    // root -> child1
     assertThat(edges)
         .anyMatch(
             edge ->
                 edge.sourceNodeId().equals(expectedRootId)
-                    && edge.targetNodeId().equals(expectedChild1Id));
+                    && edge.targetNodeId().equals(expectedChild1Id)
+                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "child1_op"))));
 
-    // root -> child2
     assertThat(edges)
         .anyMatch(
             edge ->
                 edge.sourceNodeId().equals(expectedRootId)
-                    && edge.targetNodeId().equals(expectedChild2Id));
+                    && edge.targetNodeId().equals(expectedChild2Id)
+                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "child2_op"))));
 
-    // child1 -> grandchild
     assertThat(edges)
         .anyMatch(
             edge ->
                 edge.sourceNodeId().equals(expectedChild1Id)
-                    && edge.targetNodeId().equals(expectedGrandchildId));
+                    && edge.targetNodeId().equals(expectedGrandchildId)
+                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "gc_op"))));
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -95,7 +95,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app1",
                     "kube.namespace", "ns1",
-                    "kube.operation", "op1",
+                    "operation_name", "op1",
                     "resource", "res1")),
             TestUtils.createSpanWithTags(
                 "child1",
@@ -104,7 +104,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app2",
                     "kube.namespace", "ns2",
-                    "kube.operation", "op2",
+                    "operation_name", "op2",
                     "resource", "res2")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans);
@@ -147,7 +147,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app1",
                     "kube.namespace", "ns1",
-                    "kube.operation", "http.request",
+                    "operation_name", "http.request",
                     "resource", "original_resource",
                     "tag.operation.canonical_path", "/api/users")));
 
@@ -169,7 +169,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app1",
                     "kube.namespace", "ns1",
-                    "kube.operation", "http.request",
+                    "operation_name", "http.request",
                     "resource", "original_resource")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans);
@@ -213,7 +213,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app1",
                     "kube.namespace", "ns1",
-                    "kube.operation", "op1",
+                    "operation_name", "op1",
                     "resource", "res1")),
             // invalid span
             TestUtils.createSpanWithTags(
@@ -223,7 +223,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app2",
                     "kube.namespace", "ns2",
-                    "kube.operation", "op2",
+                    "operation_name", "op2",
                     "resource", "res2")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans);
@@ -244,7 +244,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app1",
                     "kube.namespace", "ns1",
-                    "kube.operation", "op1",
+                    "operation_name", "op1",
                     "resource", "res1")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans);
@@ -265,7 +265,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app1",
                     "kube.namespace", "ns1",
-                    "kube.operation", "op1",
+                    "operation_name", "op1",
                     "resource", "res1")),
             TestUtils.createSpanWithTags(
                 "span2",
@@ -274,7 +274,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app1",
                     "kube.namespace", "ns1",
-                    "kube.operation", "op1",
+                    "operation_name", "op1",
                     "resource", "res1")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans);
@@ -295,7 +295,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app1",
                     "kube.namespace", "ns1",
-                    "kube.operation", "op1",
+                    "operation_name", "op1",
                     "resource", "res1")),
             TestUtils.createSpanWithTags(
                 "child1",
@@ -304,7 +304,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app2",
                     "kube.namespace", "ns2",
-                    "kube.operation", "op2",
+                    "operation_name", "op2",
                     "resource", "res2")),
             TestUtils.createSpanWithTags(
                 "child2",
@@ -313,7 +313,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app3",
                     "kube.namespace", "ns3",
-                    "kube.operation", "op3",
+                    "operation_name", "op3",
                     "resource", "res3")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans);
@@ -370,7 +370,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app1",
                     "kube.namespace", "ns1",
-                    "kube.operation", "op1",
+                    "operation_name", "op1",
                     "resource", "res1")),
             // two different child spans that reference the same parent
             TestUtils.createSpanWithTags(
@@ -380,7 +380,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app2",
                     "kube.namespace", "ns2",
-                    "kube.operation", "op2",
+                    "operation_name", "op2",
                     "resource", "res2")),
             // second span with same child node ID but different span ID - should create deduplicate
             // edge
@@ -391,7 +391,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "app2",
                     "kube.namespace", "ns2",
-                    "kube.operation", "op2",
+                    "operation_name", "op2",
                     "resource", "res2")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans);
@@ -437,7 +437,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "root_app",
                     "kube.namespace", "root_ns",
-                    "kube.operation", "root_op",
+                    "operation_name", "root_op",
                     "resource", "root_res")),
             // first level children
             TestUtils.createSpanWithTags(
@@ -447,7 +447,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "child1_app",
                     "kube.namespace", "child1_ns",
-                    "kube.operation", "child1_op",
+                    "operation_name", "child1_op",
                     "resource", "child1_res")),
             TestUtils.createSpanWithTags(
                 "child2",
@@ -456,7 +456,7 @@ public class GraphBuilderTest {
                 Map.of(
                     "kube.app", "child2_app",
                     "kube.namespace", "child2_ns",
-                    "kube.operation", "child2_op",
+                    "operation_name", "child2_op",
                     "resource", "child2_res")),
             // second level child
             TestUtils.createSpanWithTags(
@@ -468,7 +468,7 @@ public class GraphBuilderTest {
                     "gc_app",
                     "kube.namespace",
                     "gc_ns",
-                    "kube.operation",
+                    "operation_name",
                     "gc_op",
                     "resource",
                     "gc_res")));

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -17,21 +17,29 @@ public class GraphConfigTest {
   public void testLoadValidYamlConfig(@TempDir Path tempDir) throws IOException {
     String yamlContent =
         """
-        node_metadata_tag_mapping:
-          service:
-            default_key: service.name
-            default_value: unknown_service
-            rules:
-              - field: cluster.name
-                value: prod
-                override_key: prod.service.name
-              - field: cluster.name
-                value: staging
-                override_key: test.service.name
-          cluster:
-            default_key: cluster.name
-            default_value: unknown_cluster
-        """;
+              node_metadata_tag_mapping:
+                service:
+                  default_key: service.name
+                  default_value: unknown_service
+                  rules:
+                    - field: cluster.name
+                      value: prod
+                      override_key: prod.service.name
+                    - field: cluster.name
+                      value: staging
+                      override_key: test.service.name
+                cluster:
+                  default_key: cluster.name
+                  default_value: unknown_cluster
+              edge_metadata_tag_mapping:
+                operation:
+                  default_key: operation_name
+                  default_value: unknown_operation
+                  rules:
+                    - field: cluster.name
+                      value: prod
+                      override_key: operation.prod
+              """;
 
     Path configFile = tempDir.resolve("test-config.yaml");
     Files.writeString(configFile, yamlContent);
@@ -40,6 +48,7 @@ public class GraphConfigTest {
 
     assertThat(config).isNotNull();
     assertThat(config.getNodeMetadataTagMapping()).hasSize(2);
+    assertThat(config.getEdgeMetadataTagMapping()).hasSize(1);
 
     GraphConfig.TagConfig serviceConfig = config.getNodeMetadataTagMapping().get("service");
     assertThat(serviceConfig.getDefaultKey()).isEqualTo("service.name");
@@ -60,6 +69,12 @@ public class GraphConfigTest {
     assertThat(clusterConfig.getDefaultKey()).isEqualTo("cluster.name");
     assertThat(clusterConfig.getDefaultValue()).isEqualTo("unknown_cluster");
     assertThat(clusterConfig.getRules()).hasSize(0);
+
+    GraphConfig.TagConfig connectionTypeConfig =
+        config.getEdgeMetadataTagMapping().get("operation");
+    assertThat(connectionTypeConfig.getDefaultKey()).isEqualTo("operation_name");
+    assertThat(connectionTypeConfig.getDefaultValue()).isEqualTo("unknown_operation");
+    assertThat(connectionTypeConfig.getRules()).hasSize(1);
   }
 
   @Test
@@ -101,11 +116,20 @@ public class GraphConfigTest {
                namespace:
                  default_key: namespace.name
                  default_value: unknown_namespace
+             edge_metadata_tag_mapping:
+               operation:
+                 default_key: operation_name
+                 default_value: unknown_operation
              """);
     Map<String, String> tags = new HashMap<>();
 
-    String result = config.resolve(tags, "app");
+    // Node
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("unknown_app");
+
+    // Edge
+    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    assertThat(result).isEqualTo("unknown_operation");
   }
 
   @Test
@@ -120,10 +144,19 @@ public class GraphConfigTest {
                 namespace:
                   default_key: namespace.name
                   default_value: unknown_namespace
+              edge_metadata_tag_mapping:
+               operation:
+                 default_key: operation_name
+                 default_value: unknown_operation
               """);
     Map<String, String> tags = Map.of("some.tag", "some-value");
 
-    String result = config.resolve(tags, "some_field");
+    // Node
+    String result = config.resolve(tags, "some_field", GraphConfig.EntityType.NODE);
+    assertThat(result).isEqualTo("unknown_some_field");
+
+    // Edge
+    result = config.resolve(tags, "some_field", GraphConfig.EntityType.EDGE);
     assertThat(result).isEqualTo("unknown_some_field");
   }
 
@@ -146,13 +179,33 @@ public class GraphConfigTest {
                 namespace:
                   default_key: namespace.name
                   default_value: unknown_namespace
+              edge_metadata_tag_mapping:
+                operation:
+                  default_key: operation_name
+                  default_value: unknown_operation
+                  rules:
+                    - field: namespace.name
+                      value: prod-ns
+                      override_key: operation.prod
               """);
     Map<String, String> tags =
         Map.of(
-            "app.name", "my-app", "namespace.name", "prod-ns", "prod.app.name", "my-app-in-prod");
+            "app.name",
+            "my-app",
+            "namespace.name",
+            "prod-ns",
+            "prod.app.name",
+            "my-app-in-prod",
+            "operation.prod",
+            "prod_operation");
 
-    String result = config.resolve(tags, "app");
+    // Node
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app-in-prod");
+
+    // Edge
+    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    assertThat(result).isEqualTo("prod_operation");
   }
 
   @Test
@@ -174,11 +227,26 @@ public class GraphConfigTest {
                 namespace:
                   default_key: namespace.name
                   default_value: unknown_namespace
+              edge_metadata_tag_mapping:
+                operation:
+                  default_key: operation_name
+                  default_value: unknown_operation
+                  rules:
+                    - field: namespace.name
+                      value: prod-ns
+                      override_key: operation.prod
               """);
-    Map<String, String> tags = Map.of("app.name", "my-app", "namespace.name", "prod-ns");
+    Map<String, String> tags =
+        Map.of(
+            "app.name", "my-app", "namespace.name", "prod-ns", "operation_name", "some_operation");
 
-    String result = config.resolve(tags, "app");
+    // Node
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app");
+
+    // Edge
+    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    assertThat(result).isEqualTo("some_operation");
   }
 
   @Test
@@ -200,14 +268,26 @@ public class GraphConfigTest {
                 namespace:
                   default_key: namespace.name
                   default_value: unknown_namespace
+              edge_metadata_tag_mapping:
+                operation:
+                  default_key: operation_name
+                  default_value: unknown_operation
+                  rules:
+                    - field: namespace.name
+                      value: prod-ns
+                      override_key: operation.prod
               """);
     Map<String, String> tags =
         Map.of(
-            "app.name", "my-app",
-            "namespace.name", "dev-ns");
+            "app.name", "my-app", "namespace.name", "dev-ns", "operation_name", "some_operation");
 
-    String result = config.resolve(tags, "app");
+    // Node
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app");
+
+    // Edge
+    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    assertThat(result).isEqualTo("some_operation");
   }
 
   @Test
@@ -229,17 +309,44 @@ public class GraphConfigTest {
                 namespace:
                   default_key: namespace.name
                   default_value: unknown_namespace
+              edge_metadata_tag_mapping:
+                operation:
+                  default_key: operation_name
+                  default_value: unknown_operation
+                  rules:
+                    - field: namespace.name
+                      value: prod-ns
+                      override_key: operation.prod
+                    - field: cluster.name
+                      value: east
+                      override_key: operation.east
               """);
     Map<String, String> tags =
         Map.of(
-            "app.name", "my-app",
-            "namespace.name", "prod-ns",
-            "cluster.name", "east",
-            "prod.app.name", "my-app-in-prod",
-            "east.app.name", "my-app-east");
+            "app.name",
+            "my-app",
+            "namespace.name",
+            "prod-ns",
+            "cluster.name",
+            "east",
+            "prod.app.name",
+            "my-app-in-prod",
+            "east.app.name",
+            "my-app-east",
+            "operation_name",
+            "some_operation",
+            "operation.prod",
+            "operation_prod",
+            "operation.east",
+            "operation_east");
 
-    String result = config.resolve(tags, "app");
+    // Node
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app-east");
+
+    // Edge
+    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    assertThat(result).isEqualTo("operation_east");
   }
 
   @Test
@@ -261,30 +368,54 @@ public class GraphConfigTest {
                 namespace:
                   default_key: namespace.name
                   default_value: unknown_namespace
+              edge_metadata_tag_mapping:
+                operation:
+                  default_key: operation_name
+                  default_value: unknown_operation
+                  rules:
+                    - field: namespace.name
+                      value: prod-ns
+                      override_key: operation.prod
+                    - field: cluster.name
+                      value: east
+                      override_key: operation_east
               """);
     Map<String, String> tags =
         Map.of(
-            "app.name", "my-app",
-            "namespace.name", "dev-ns",
-            "cluster.name", "west");
+            "app.name",
+            "my-app",
+            "namespace.name",
+            "dev-ns",
+            "cluster.name",
+            "west",
+            "operation_name",
+            "some_operation",
+            "operation.prod",
+            "operation_prod");
 
-    String result = config.resolve(tags, "app");
+    // Node
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app");
+
+    // Edge
+    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    assertThat(result).isEqualTo("some_operation");
   }
 
   @Test
-  public void testCreateMetadataFromSpan_defaultConfig_usesRemoteEndpointServiceName() {
+  public void testCreateNodeMetadataFromSpan_defaultConfig_usesRemoteEndpointServiceName() {
     GraphConfig config = GraphConfig.DEFAULT;
     ZipkinSpanResponse span =
         TestUtils.createSpanWithTags("span1", "trace1", null, Map.of("some.tag", "some-value"));
 
-    SortedMap<String, String> metadata = config.createMetadataFromSpan(span);
+    SortedMap<String, String> metadata =
+        config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE);
     assertThat(metadata).hasSize(1);
     assertThat(metadata.get("service")).isEqualTo("default-service");
   }
 
   @Test
-  public void testCreateMetadataFromSpan_customConfig_usesTagMapping() throws IOException {
+  public void testCreatNodeMetadataFromSpan_customConfig_usesTagMapping() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
@@ -307,11 +438,44 @@ public class GraphConfigTest {
             "resource.name", "my-resource");
     ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
-    SortedMap<String, String> metadata = config.createMetadataFromSpan(span);
+    SortedMap<String, String> metadata =
+        config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE);
 
     assertThat(metadata).hasSize(3);
     assertThat(metadata.get("app")).isEqualTo("my-app");
     assertThat(metadata.get("namespace")).isEqualTo("my-namespace");
     assertThat(metadata.get("resource")).isEqualTo("my-resource");
+  }
+
+  @Test
+  public void testCreateEdgeMetadataFromSpan_defaultConfig_isEmpty() {
+    GraphConfig config = GraphConfig.DEFAULT;
+    ZipkinSpanResponse span =
+        TestUtils.createSpanWithTags("span1", "trace1", null, Map.of("some.tag", "some-value"));
+
+    SortedMap<String, String> metadata =
+        config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE);
+    assertThat(metadata).isEmpty();
+  }
+
+  @Test
+  public void testCreatEdgeMetadataFromSpan_customConfig_usesTagMapping() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                  edge_metadata_tag_mapping:
+                    operation:
+                      default_key: operation_name
+                      default_value: unknown_operation
+                  """);
+
+    Map<String, String> tags = Map.of("operation_name", "some_operation");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
+
+    SortedMap<String, String> metadata =
+        config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE);
+
+    assertThat(metadata).hasSize(1);
+    assertThat(metadata.get("operation")).isEqualTo("some_operation");
   }
 }

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -2,18 +2,20 @@ node_metadata_tag_mapping:
   app:
     default_key: kube.app
     default_value: unknown_app
+    rules: []
   namespace:
     default_key: kube.namespace
     default_value: unknown_namespace
+    rules: []
   resource:
     default_key: resource
     default_value: unknown_resource
     rules:
-      - field: kube.operation
+      - field: operation_name
         value: http.request
         override_key: tag.operation.canonical_path
 edge_metadata_tag_mapping:
   operation:
-    default_key: kube.operation
+    default_key: operation_name
     default_value: unknown_operation
     rules: []

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -5,9 +5,6 @@ node_metadata_tag_mapping:
   namespace:
     default_key: kube.namespace
     default_value: unknown_namespace
-  operation:
-    default_key: kube.operation
-    default_value: unknown_operation
   resource:
     default_key: resource
     default_value: unknown_resource
@@ -15,3 +12,8 @@ node_metadata_tag_mapping:
       - field: kube.operation
         value: http.request
         override_key: tag.operation.canonical_path
+edge_metadata_tag_mapping:
+  operation:
+    default_key: kube.operation
+    default_value: unknown_operation
+    rules: []


### PR DESCRIPTION
###  Summary

Similar to node metadata, add support for the edge entity to hold metadata. 

- Updates `GraphConfig` to take an `edge_metadata_tag_mapping` config entry. Modifies the `resolve` method to handle tag resolution based on entity type `NODE` or `EDGE`
- Simplifies `GraphBuilder` logic to build edges directly from the `spanIdToNode` map in step 2 rather than creating an intermediate `parentIdToChildNodeId` map and building edges as a third additional step.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
