### PR TITLE
fix graph building logic and complete /subgraph endpoint

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -178,7 +178,8 @@ public class GraphBuilder {
    * child relationships are processed together. This ensures complete coverage of that node’s
    * downstream relationships, including any cycles.
    *
-   * <p>The traversal is iterative (using a stack) and guards against infinite loops via visited sets.
+   * <p>The traversal is iterative (using a stack) and guards against infinite loops via visited
+   * sets.
    *
    * @param startSpan The span to start traversal from
    * @param spanIdsToProcess Set of span IDs that match an optional filter

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.SortedMap;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,176 +88,137 @@ public class GraphBuilder {
    */
   public Graph buildFromSpans(List<ZipkinSpanResponse> spans, Optional<Filter> filter) {
     // Build all lookup structures
-    Map<String, ZipkinSpanResponse> spanIdToSpans = new HashMap<>(); // Lookup span by span ID
-    Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans =
-        new HashMap<>(); // Lookup children for a parent span
-    Map<String, String> spanIdToNodeId = new HashMap<>(); // Span ID to its logical node ID
-    Map<String, List<String>> spansByNodeId =
-        new HashMap<>(); // All spans belonging to a logical node
+    Map<String, ZipkinSpanResponse> spanIdToSpan = new HashMap<>(); // Lookup a span by span ID
+    Map<String, Node> spanIdToNode = new HashMap<>(); // Lookup a span's logical node by span ID
+    Map<String, Node> nodeIdToNode = new HashMap<>(); // Lookup a node by node ID
 
-    for (ZipkinSpanResponse span : spans) {
-      if (span.getId() == null) {
-        continue;
-      }
-      spanIdToSpans.put(span.getId(), span);
+    // Convert spans to nodes, creating logical groupings.
+    // Multiple spans may map to the same logical node if their metadata is identical.
+    spans.stream()
+        .filter(span -> span.getId() != null)
+        .forEach(
+            span -> {
+              spanIdToSpan.put(span.getId(), span);
 
-      String parentId = span.getParentId();
-      if (parentId != null) {
-        parentSpanIdToChildSpans.computeIfAbsent(parentId, k -> new ArrayList<>()).add(span);
-      }
+              Node node =
+                  new Node(config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE));
+              spanIdToNode.put(span.getId(), node);
+              nodeIdToNode.putIfAbsent(node.getId(), node);
+            });
 
-      // Build mapping of logical nodes to all its representing span IDs
-      spanIdToNodeId.putIfAbsent(span.getId(), getNodeId(span));
-      spansByNodeId
-          .computeIfAbsent(spanIdToNodeId.get(span.getId()), k -> new ArrayList<>())
-          .add(span.getId());
-    }
+    // Build parent-child relationships at the node level
+    Map<String, List<Map.Entry<String, SortedMap<String, String>>>> parentNodeIdToChildNodeIds =
+        buildParentChildConnections(spans, spanIdToNode);
 
-    Set<Edge> edges = new HashSet<>();
-    Set<Node> nodes = new HashSet<>();
-    buildFilteredGraph(
-        filter,
-        edges,
-        nodes,
-        parentSpanIdToChildSpans,
-        spanIdToSpans,
-        spanIdToNodeId,
-        spansByNodeId);
-
-    return new Graph(new ArrayList<>(nodes), new ArrayList<>(edges));
-  }
-
-  /**
-   * Builds a filtered graph by creating edges between filtered spans.
-   *
-   * <p>This method processes all filtered spans and for each one, finds its transitive matching
-   * children (filtered spans reachable through any number of non-filtered intermediate spans) and
-   * creates edges between them. This approach minimizes duplicate traversal work compared to
-   * starting a DFS from each filtered span independently.
-   *
-   * @param filter Optional filter to apply when building the graph. If empty or null, returns every
-   *     connection.
-   * @param edges Output set to collect distinct edges between matching spans
-   * @param nodes Output set to collect distinct nodes
-   * @param parentSpanIdToChildSpans Map from parent span ID to list of child spans
-   * @param spanIdToSpans Map from span ID to its full span
-   */
-  private void buildFilteredGraph(
-      Optional<Filter> filter,
-      Set<Edge> edges,
-      Set<Node> nodes,
-      Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans,
-      Map<String, ZipkinSpanResponse> spanIdToSpans,
-      Map<String, String> spanIdToNodeId,
-      Map<String, List<String>> spansByNodeId) {
-    Map<String, ZipkinSpanResponse> spansToProcess =
-        // Collect all spans matching the filter if it exists
+    // Determine which nodes to include based on the filter if provided, otherwise include all nodes
+    Set<String> nodesToProcess =
         filter
             .map(
                 f ->
-                    spanIdToSpans.values().stream()
-                        .filter(f::matches)
-                        .collect(Collectors.toMap(ZipkinSpanResponse::getId, Function.identity())))
-            .orElse(spanIdToSpans); // No filter, build graph with all edges.
+                    spanIdToNode.keySet().stream()
+                        .filter(spanId -> f.matches(spanIdToSpan.get(spanId)))
+                        .map(spanId -> spanIdToNode.get(spanId).getId())
+                        .collect(Collectors.toSet()))
+            .orElseGet(() -> new HashSet<>(nodeIdToNode.keySet()));
 
-    spansToProcess
-        .values()
-        .forEach(
-            span -> {
-              // Find all descendant spans, may skip through non-matching
-              // intermediate spans if a filter exists
-              collectTransitiveChildren(
-                      span,
-                      spansToProcess.keySet(),
-                      parentSpanIdToChildSpans,
-                      spansByNodeId,
-                      spanIdToNodeId)
-                  // Create an edge from parent to each transitive child
-                  .forEach(
-                      childSpanId ->
-                          createDependency(nodes, edges, span, spansToProcess.get(childSpanId)));
-            });
+    return traverseAndBuildGraph(nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds);
   }
 
   /**
-   * Collects all filtered spans that are transitive children of a given starting span.
+   * Builds a map of parent-child relationships at the node level.
    *
-   * <p>A transitive child is defined as a filtered span that can be reached from the start span by
-   * traversing through any number of non-filtered intermediate spans.
+   * <p>This method aggregates span relationships into node relationships. Multiple spans may
+   * represent the same logical node, so this aggregation is crucial for handling siblings. For
+   * example, if span S1 and S2 both map to node A, and S1 has child S3 (node B) while S2 has child
+   * S4 (node C), the result will be: node A -> [node B, node C].
    *
-   * <p>This method treats all spans representing the same logical node as equivalent. When one span
-   * for a node is processed, all of its sibling spans (those sharing the same node ID) and their
-   * child relationships are processed together. This ensures complete coverage of that node’s
-   * downstream relationships, including any cycles.
+   * <p>Edge metadata is preserved from the original span connection, representing the actual traced
+   * operation that created the relationship.
    *
-   * <p>The traversal is iterative (using a stack) and guards against infinite loops via visited
-   * sets.
-   *
-   * @param startSpan The span to start traversal from
-   * @param spanIdsToProcess Set of span IDs that match an optional filter
-   * @param parentSpanIdToChildSpans Map from parent span ID to list of child spans
-   * @param spansByNodeId Map of a logical node to all its representative spans
-   * @param spanIdToNodeId Map from span ID to its logical node ID
-   * @return List of span IDs for all transitive matching children
+   * @param spans List of all spans to process
+   * @param spanIdToNode Map from span ID to its logical node representation
+   * @return Map from parent node ID to list of (child node ID, edge metadata) pairs
    */
-  private List<String> collectTransitiveChildren(
-      ZipkinSpanResponse startSpan,
-      Set<String> spanIdsToProcess,
-      Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans,
-      Map<String, List<String>> spansByNodeId,
-      Map<String, String> spanIdToNodeId) {
-    List<String> results = new ArrayList<>();
-    Deque<String> work = new ArrayDeque<>();
-    Set<String> visitedSpans = new HashSet<>(); // Tracks individual spans to prevent cycles
-    Set<String> visitedNodes = new HashSet<>(); // Tracks logical nodes to avoid redundant traversal
+  private Map<String, List<Map.Entry<String, SortedMap<String, String>>>>
+      buildParentChildConnections(List<ZipkinSpanResponse> spans, Map<String, Node> spanIdToNode) {
 
-    work.push(startSpan.getId());
-    visitedSpans.add(startSpan.getId());
+    Map<String, List<Map.Entry<String, SortedMap<String, String>>>> parentNodeIdToChildNodeIds =
+        new HashMap<>();
 
-    while (!work.isEmpty()) {
-      String spanId = work.pop();
-      String nodeId = spanIdToNodeId.get(spanId);
+    for (ZipkinSpanResponse span : spans) {
+      if (span.getId() == null || span.getParentId() == null) continue;
 
-      if (!visitedNodes.add(nodeId)) continue;
+      Node parent = spanIdToNode.get(span.getParentId());
+      Node child = spanIdToNode.get(span.getId());
+      if (parent == null || child == null) continue;
 
-      for (String siblingSpanId : spansByNodeId.getOrDefault(nodeId, List.of(spanId))) {
-        for (ZipkinSpanResponse child :
-            parentSpanIdToChildSpans.getOrDefault(siblingSpanId, List.of())) {
+      // Extract edge metadata from the span that created this connection
+      SortedMap<String, String> edgeMetadata =
+          config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE);
 
-          if (!visitedSpans.add(child.getId())) continue;
+      parentNodeIdToChildNodeIds
+          .computeIfAbsent(parent.getId(), k -> new ArrayList<>())
+          .add(Map.entry(child.getId(), edgeMetadata));
+    }
+    return parentNodeIdToChildNodeIds;
+  }
 
-          if (spanIdsToProcess.contains(child.getId())) {
-            // Found a filtered child - add to results and stop traversing this branch
-            // because the child will be handled in its own iteration
-            results.add(child.getId());
+  /**
+   * Traverses the node graph to build the final filtered graph with transitive edges.
+   *
+   * <p>For each filtered node, this method performs a depth-first traversal to find all filtered
+   * descendant nodes, skipping through non-filtered intermediate nodes. When a filtered descendant
+   * is found, an edge is created directly from the starting filtered node to the descendant,
+   * preserving the edge metadata from the original connection path.
+   *
+   * <p>Example: If we have Root (filtered) -> Intermediate (not filtered) -> Leaf (filtered), this
+   * will create a direct edge: Root -> Leaf, skipping the intermediate node.
+   *
+   * @param nodesToProcess Set of node IDs that match the filter (or all nodes if no filter)
+   * @param nodeIdToNode Map from node ID to Node object
+   * @param parentNodeIdToChildNodeIds Map of parent-child relationships with edge metadata
+   * @return Graph containing only filtered nodes and their transitive connections
+   */
+  private Graph traverseAndBuildGraph(
+      Set<String> nodesToProcess,
+      Map<String, Node> nodeIdToNode,
+      Map<String, List<Map.Entry<String, SortedMap<String, String>>>> parentNodeIdToChildNodeIds) {
+
+    Set<Node> nodes = new HashSet<>();
+    Set<Edge> edges = new HashSet<>();
+
+    // Process each filtered node as a potential parent
+    for (String parentNodeId : nodesToProcess) {
+      Deque<String> work = new ArrayDeque<>();
+      Set<String> visitedNodes = new HashSet<>();
+
+      work.push(parentNodeId);
+
+      while (!work.isEmpty()) {
+        String currentNodeId = work.pop();
+        if (!visitedNodes.add(currentNodeId)) continue;
+
+        List<Map.Entry<String, SortedMap<String, String>>> children =
+            parentNodeIdToChildNodeIds.getOrDefault(currentNodeId, List.of());
+
+        for (Map.Entry<String, SortedMap<String, String>> child : children) {
+          String childNodeId = child.getKey();
+
+          if (nodesToProcess.contains(childNodeId)) {
+            // Found a filtered child - create edge from starting parent to this child.
+            // This creates the "transitive" edge, skipping any intermediate nodes when filtering.
+            // Don't traverse past this child - it will be processed in its own iteration.
+            nodes.add(nodeIdToNode.get(parentNodeId));
+            nodes.add(nodeIdToNode.get(childNodeId));
+            edges.add(new Edge(parentNodeId, childNodeId, child.getValue()));
           } else {
-            // Non-filtered intermediate span - continue traversing through it
-            work.push(child.getId());
+            // Non-filtered intermediate node - continue traversing through it
+            work.push(child.getKey());
           }
         }
       }
     }
 
-    return results;
-  }
-
-  private void createDependency(
-      Set<Node> nodes, Set<Edge> edges, ZipkinSpanResponse parent, ZipkinSpanResponse child) {
-    Node source = new Node(config.createMetadataFromSpan(parent, GraphConfig.EntityType.NODE));
-    Node target = new Node(config.createMetadataFromSpan(child, GraphConfig.EntityType.NODE));
-
-    nodes.add(source);
-    nodes.add(target);
-
-    edges.add(
-        new Edge(
-            source.getId(),
-            target.getId(),
-            config.createMetadataFromSpan(child, GraphConfig.EntityType.EDGE)));
-  }
-
-  private String getNodeId(ZipkinSpanResponse span) {
-    return Node.generateIdFromMetadata(
-        config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE));
+    return new Graph(new ArrayList<>(nodes), new ArrayList<>(edges));
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -143,7 +143,6 @@ public class GraphBuilder {
               node ->
                   dfsFilter(
                       node,
-                      node.id(),
                       filter.get(),
                       edges,
                       nodes,
@@ -176,9 +175,9 @@ public class GraphBuilder {
    * State object for iterative DFS traversal.
    *
    * @param node The current span node being processed
-   * @param lastViableNodeId ID of the most recent node that matched the filter
+   * @param lastAncestorNodeId ID of the most recent ancestor that matched the filter
    */
-  private record DfsState(SpanNode node, String lastViableNodeId) {}
+  private record DfsState(SpanNode node, String lastAncestorNodeId) {}
 
   /**
    * Performs iterative DFS to find edges between nodes matching the filter.
@@ -188,10 +187,9 @@ public class GraphBuilder {
    * appear in the final graph - their children are connected directly to the last matching
    * ancestor.
    *
-   * <p>Uses an explicit stack instead of recursion to avoid stack overflow with deep trace graphs.
+   * <p>Uses an explicit stack instead of recursion to avoid issues with deep trace graphs.
    *
    * @param startNode The node to start traversal from
-   * @param initialLastViableNodeId ID of the starting viable node (usually the startNode's ID)
    * @param filter Filter to determine which nodes should appear in the final graph
    * @param edges Output set to collect edges between matching nodes
    * @param nodes Output set to collect matching nodes
@@ -200,41 +198,35 @@ public class GraphBuilder {
    */
   private void dfsFilter(
       SpanNode startNode,
-      String initialLastViableNodeId,
       Filter filter,
       Set<Edge> edges,
       Set<Node> nodes,
       Map<String, SpanNode> spanIdToSpanNodes,
       Map<String, List<SpanNode>> parentSpanIdToChildSpanNodes) {
-    // Shared visited set for this DFS traversal
     Set<String> visited = new HashSet<>();
-
-    // Use explicit stack for iterative DFS to avoid stack overflow with deep traces
     Deque<DfsState> stack = new ArrayDeque<>();
-    stack.push(new DfsState(startNode, initialLastViableNodeId));
+
+    stack.push(new DfsState(startNode, startNode.id()));
 
     while (!stack.isEmpty()) {
       DfsState state = stack.pop();
       SpanNode node = state.node();
-      String lastViableNodeId = state.lastViableNodeId();
 
-      // Skip if already visited (prevents cycles and redundant work)
+      // Skip if already visited
       if (visited.contains(node.id())) {
         continue;
       }
-
       visited.add(node.id());
 
-      // Update the "viable" node - if current node matches filter, it becomes the new viable
-      // ancestor
-      String currentViableNodeId = filter.matches(node) ? node.id() : lastViableNodeId;
+      // If the current node matches filter, it becomes the new ancestor
+      String currentAncestorNodeId = filter.matches(node) ? node.id() : state.lastAncestorNodeId();
 
       // Process all children of the current node
       List<SpanNode> children = parentSpanIdToChildSpanNodes.getOrDefault(node.id(), List.of());
       for (SpanNode child : children) {
-        if (filter.matches(child) && currentViableNodeId != null) {
-          // Child matches filter - create edge from current viable node to this child
-          SpanNode parent = spanIdToSpanNodes.get(currentViableNodeId);
+        if (filter.matches(child) && currentAncestorNodeId != null) {
+          // Child matches filter, create edge from current ancestor node to this child
+          SpanNode parent = spanIdToSpanNodes.get(currentAncestorNodeId);
           if (parent == null) {
             continue;
           }
@@ -246,12 +238,12 @@ public class GraphBuilder {
           nodes.add(target);
           edges.add(new Edge(source.getId(), target.getId(), child.edgeMetadata()));
 
-          // Continue exploration with child as the new viable node
+          // Continue exploration with child as the new ancestor node
           stack.push(new DfsState(child, child.id()));
         } else {
-          // Child doesn't match filter - traverse through it but keep current viable node
-          // This allows edges to skip over non-matching intermediate nodes
-          stack.push(new DfsState(child, currentViableNodeId));
+          // Child doesn't match filter, traverse through it but keep current ancestor node
+          // Skip over non-matching intermediate nodes
+          stack.push(new DfsState(child, currentAncestorNodeId));
         }
       }
     }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -90,6 +90,7 @@ public class GraphBuilder {
     Map<String, ZipkinSpanResponse> spanIdToSpan = new HashMap<>(); // Lookup a span by span ID
     Map<String, Node> spanIdToNode = new HashMap<>(); // Lookup a span's logical node by span ID
     Map<String, Node> nodeIdToNode = new HashMap<>(); // Lookup a node by node ID
+    Set<String> matchingSpanIds = new HashSet<>(); // Spans that match the given filter
 
     // Convert spans to nodes, creating logical groupings.
     // Multiple spans may map to the same logical node if their metadata is identical.
@@ -103,6 +104,11 @@ public class GraphBuilder {
                   new Node(config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE));
               spanIdToNode.put(span.getId(), node);
               nodeIdToNode.putIfAbsent(node.getId(), node);
+
+              // Add span to matching set if no filter exists or if filter matches
+              if (!filter.isPresent() || filter.get().matches(span)) {
+                matchingSpanIds.add(span.getId());
+              }
             });
 
     // Build parent-child relationships at the node level
@@ -111,16 +117,12 @@ public class GraphBuilder {
 
     // Determine which nodes to include based on the filter if provided, otherwise include all nodes
     Set<String> nodesToProcess =
-        filter
-            .map(
-                f ->
-                    spanIdToNode.keySet().stream()
-                        .filter(spanId -> f.matches(spanIdToSpan.get(spanId)))
-                        .map(spanId -> spanIdToNode.get(spanId).getId())
-                        .collect(Collectors.toSet()))
-            .orElseGet(() -> new HashSet<>(nodeIdToNode.keySet()));
+        matchingSpanIds.stream()
+            .map(spanId -> spanIdToNode.get(spanId).getId())
+            .collect(Collectors.toSet());
 
-    return traverseAndBuildGraph(filter, nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds);
+    return traverseAndBuildGraph(
+        matchingSpanIds, nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds);
   }
 
   /**
@@ -176,14 +178,15 @@ public class GraphBuilder {
    * <p>Example: If we have Root (filtered) -> Intermediate (not filtered) -> Leaf (filtered), this
    * will create a direct edge: Root -> Leaf, skipping the intermediate node.
    *
-   * @param filter Optional filter to apply when creating edges
+   * @param matchingSpanIds Pre-computed set of span IDs that match the filter (or all span IDs if
+   *     no filter)
    * @param nodesToProcess Set of node IDs that match the filter (or all nodes if no filter)
    * @param nodeIdToNode Map from node ID to Node object
    * @param parentNodeIdToChildNodeIds Map of parent-child relationships with their reference span
    * @return Graph containing only filtered nodes and their transitive connections
    */
   private Graph traverseAndBuildGraph(
-      Optional<Filter> filter,
+      Set<String> matchingSpanIds,
       Set<String> nodesToProcess,
       Map<String, Node> nodeIdToNode,
       Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds) {
@@ -208,11 +211,11 @@ public class GraphBuilder {
         for (Map.Entry<String, ZipkinSpanResponse> child : children) {
           String childNodeId = child.getKey();
           ZipkinSpanResponse refSpan = child.getValue();
-          if (!filter.isPresent() || filter.get().matches(refSpan)) {
+          if (matchingSpanIds.contains(refSpan.getId())) {
             // Skip the case where the ancestor is a direct parent of the same logical node ID
             if (parentNodeId.equals(childNodeId)) continue;
 
-            // Found a child that matches the filter when present, create edge
+            // Found a child that matches the filter, create edge
             // from starting parent to this child.
             // This creates the transitive edge, skipping any intermediate nodes.
             // Don't traverse past this child - it will be processed in its own iteration.

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -1,13 +1,17 @@
 package com.slack.astra.graphApi;
 
 import com.slack.astra.zipkinApi.ZipkinSpanResponse;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.SortedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,62 +39,187 @@ public class GraphBuilder {
     this.config = config;
   }
 
+  public record Filter(Map<String, String> options) {
+    public boolean matches(SpanNode node) {
+      for (Map.Entry<String, String> entry : this.options().entrySet()) {
+        if (!node.nodeMetadata().containsKey(entry.getKey())
+            && !node.edgeMetadata().containsKey(entry.getKey())) {
+          continue;
+        }
+
+        if (Objects.equals(node.nodeMetadata().get(entry.getKey()), entry.getValue())
+            || Objects.equals(node.edgeMetadata().get(entry.getKey()), entry.getValue())) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  }
+
+  public record SpanNode(
+      String id, SortedMap<String, String> nodeMetadata, SortedMap<String, String> edgeMetadata) {}
+
   /**
-   * Builds a dependency graph from a list of Zipkin spans.
+   * Builds a filtered dependency graph from a list of Zipkin spans.
    *
-   * <p>This method processes spans to create nodes (services) and edges (dependencies) representing
-   * the service communication graph. Each span becomes a node, and parent-child relationships
-   * between spans become edges in the graph. Logs warnings for any missing parent or child nodes.
+   * <p>This method processes spans to create nodes and edges representing service dependencies,
+   * filtered by the provided criteria. It starts DFS from every node matching the filter, creating
+   * edges between matching nodes while traversing through non-matching intermediate nodes.
    *
    * @param spans List of Zipkin spans to process
-   * @return Graph containing nodes and edges representing service dependencies
+   * @param filter Filter to apply when building the graph
+   * @return Graph containing nodes and edges representing filtered service dependencies
    */
-  public Graph buildFromSpans(List<ZipkinSpanResponse> spans) {
-    // First pass: build mapping between spanId -> Node
-    Map<String, Node> spanIdToNode =
-        spans.stream()
-            .filter(span -> span.getId() != null)
-            .collect(Collectors.toMap(ZipkinSpanResponse::getId, this::createChildNodeFromSpan));
+  public Graph buildFromSpans(List<ZipkinSpanResponse> spans, Optional<Filter> filter) {
+    Map<String, SpanNode> spanIdToSpanNodes = new HashMap<>();
+    Map<String, List<SpanNode>> parentSpanIdToChildSpanNodes = new HashMap<>();
 
-    // Second pass: build unique edges
-    Set<Edge> edges =
-        spans.stream()
-            .filter(span -> span.getId() != null && span.getParentId() != null)
-            .map(
-                span -> {
-                  Node parentNode = spanIdToNode.get(span.getParentId());
-                  Node childNode = spanIdToNode.get(span.getId());
+    for (ZipkinSpanResponse span : spans) {
+      if (span.getId() == null) {
+        continue;
+      }
 
-                  if (parentNode != null && childNode != null) {
-                    return new Edge(
-                        parentNode.getId(),
-                        childNode.getId(),
-                        config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE));
-                  } else {
-                    LOG.warn(
-                        "Missing parent or child node for parentSpanId={} and childSpanId={}",
-                        span.getParentId(),
-                        span.getId());
-                    return null;
-                  }
-                })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
+      SpanNode node =
+          new SpanNode(
+              span.getId(),
+              config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE),
+              config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE));
 
-    // Dedupe nodes
-    Set<Node> nodes = new HashSet<>(spanIdToNode.values());
+      spanIdToSpanNodes.put(span.getId(), node);
+
+      String parentId = span.getParentId();
+      if (parentId != null) {
+        parentSpanIdToChildSpanNodes.computeIfAbsent(parentId, k -> new ArrayList<>()).add(node);
+      }
+    }
+
+    Set<Edge> edges = new HashSet<>();
+    Set<Node> nodes = new HashSet<>();
+
+    if (filter.isPresent()) {
+      // Start DFS from every node matching the filter since there is no guarantee we have a single
+      // root in this trace.
+      spanIdToSpanNodes.values().stream()
+          .filter(node -> filter.get().matches(node))
+          .forEach(
+              node ->
+                  dfsFilter(
+                      node,
+                      node.id(),
+                      filter.get(),
+                      edges,
+                      nodes,
+                      spanIdToSpanNodes,
+                      parentSpanIdToChildSpanNodes));
+    } else {
+      // No filter - build graph with all edges and collect nodes along the way
+      spanIdToSpanNodes.values().stream()
+          .forEach(
+              node -> {
+                List<SpanNode> children =
+                    parentSpanIdToChildSpanNodes.getOrDefault(node.id(), List.of());
+                children.stream()
+                    .forEach(
+                        childNode -> {
+                          Node source = new Node(node.nodeMetadata());
+                          Node target = new Node(childNode.nodeMetadata());
+                          nodes.add(source);
+                          nodes.add(target);
+                          edges.add(
+                              new Edge(source.getId(), target.getId(), childNode.edgeMetadata()));
+                        });
+              });
+    }
 
     return new Graph(new ArrayList<>(nodes), new ArrayList<>(edges));
   }
 
   /**
-   * Creates a Node from a Zipkin span using configured metadata extraction. Calls out to the
-   * config's createMetadataFromSpan function to generate node metadata from a span.
+   * State object for iterative DFS traversal.
    *
-   * @param span The Zipkin span to convert to a node
-   * @return Node with metadata extracted from the span
+   * @param node The current span node being processed
+   * @param lastViableNodeId ID of the most recent node that matched the filter
    */
-  private Node createChildNodeFromSpan(ZipkinSpanResponse span) {
-    return new Node(config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE));
+  private record DfsState(SpanNode node, String lastViableNodeId) {}
+
+  /**
+   * Performs iterative DFS to find edges between nodes matching the filter.
+   *
+   * <p>This method explores the span tree starting from a given node, creating edges only between
+   * nodes that match the filter criteria. Non-matching intermediate nodes are traversed but don't
+   * appear in the final graph - their children are connected directly to the last matching
+   * ancestor.
+   *
+   * <p>Since span graphs are trees (each child has exactly one parent), a single shared visited set
+   * is sufficient to prevent cycles and redundant traversal.
+   *
+   * <p>Uses an explicit stack instead of recursion to avoid stack overflow with deep trace graphs.
+   *
+   * @param startNode The node to start traversal from
+   * @param initialLastViableNodeId ID of the starting viable node (usually the startNode's ID)
+   * @param filter Filter to determine which nodes should appear in the final graph
+   * @param edges Output set to collect edges between matching nodes
+   * @param nodes Output set to collect matching nodes
+   * @param spanIdToSpanNodes Lookup map from span ID to SpanNode
+   * @param parentSpanIdToChildSpanNodes Map from parent span ID to list of child SpanNodes
+   */
+  private void dfsFilter(
+      SpanNode startNode,
+      String initialLastViableNodeId,
+      Filter filter,
+      Set<Edge> edges,
+      Set<Node> nodes,
+      Map<String, SpanNode> spanIdToSpanNodes,
+      Map<String, List<SpanNode>> parentSpanIdToChildSpanNodes) {
+    // Shared visited set for this DFS traversal
+    Set<String> visited = new HashSet<>();
+
+    // Use explicit stack for iterative DFS to avoid stack overflow with deep traces
+    Deque<DfsState> stack = new ArrayDeque<>();
+    stack.push(new DfsState(startNode, initialLastViableNodeId));
+
+    while (!stack.isEmpty()) {
+      DfsState state = stack.pop();
+      SpanNode node = state.node();
+      String lastViableNodeId = state.lastViableNodeId();
+
+      // Skip if already visited (prevents cycles and redundant work)
+      if (visited.contains(node.id())) {
+        continue;
+      }
+
+      visited.add(node.id());
+
+      // Update the "viable" node - if current node matches filter, it becomes the new viable
+      // ancestor
+      String currentViableNodeId = filter.matches(node) ? node.id() : lastViableNodeId;
+
+      // Process all children of the current node
+      List<SpanNode> children = parentSpanIdToChildSpanNodes.getOrDefault(node.id(), List.of());
+      for (SpanNode child : children) {
+        if (filter.matches(child) && currentViableNodeId != null) {
+          // Child matches filter - create edge from current viable node to this child
+          SpanNode parent = spanIdToSpanNodes.get(currentViableNodeId);
+          if (parent == null) {
+            continue;
+          }
+
+          Node source = new Node(parent.nodeMetadata());
+          Node target = new Node(child.nodeMetadata());
+
+          nodes.add(source);
+          nodes.add(target);
+          edges.add(new Edge(source.getId(), target.getId(), child.edgeMetadata()));
+
+          // Continue exploration with child as the new viable node
+          stack.push(new DfsState(child, child.id()));
+        } else {
+          // Child doesn't match filter - traverse through it but keep current viable node
+          // This allows edges to skip over non-matching intermediate nodes
+          stack.push(new DfsState(child, currentViableNodeId));
+        }
+      }
+    }
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -94,7 +94,7 @@ public class GraphBuilder {
     // Convert spans to nodes, creating logical groupings.
     // Multiple spans may map to the same logical node if their metadata is identical.
     spans.stream()
-        .filter(span -> span.getId() != null)
+        .filter(span -> span.getId() != null && !span.getId().equals("-1"))
         .forEach(
             span -> {
               spanIdToSpan.put(span.getId(), span);
@@ -145,7 +145,10 @@ public class GraphBuilder {
         new HashMap<>();
 
     for (ZipkinSpanResponse span : spans) {
-      if (span.getId() == null || span.getParentId() == null) continue;
+      if (span.getId() == null
+          || span.getId().equals("-1")
+          || span.getParentId() == null
+          || span.getParentId().equals("-1")) continue;
 
       Node parent = spanIdToNode.get(span.getParentId());
       Node child = spanIdToNode.get(span.getId());

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -38,11 +38,40 @@ public class GraphBuilder {
     this.config = config;
   }
 
+  /**
+   * Filter for selecting nodes/edges in the graph based on metadata criteria.
+   *
+   * <p>The filter uses OR logic: a node matches if ANY of the filter criteria match. Each filter
+   * option is a field name (e.g., "operation", "service") mapped to a list of allowed values for
+   * that field.
+   *
+   * <p>Examples: {"operation": ["http.request"]} - matches nodes with operation="http.request"
+   * {"operation": ["http.request", "grpc.request"]} - matches nodes with either operation
+   * {"operation": ["http.request"], "service": ["api-gateway.prod"]} - matches nodes with
+   * operation="http.request" OR service="api-gateway.prod" {} or null - empty filter matches all
+   * nodes (no filtering)
+   *
+   * <p>The filter checks both node metadata and edge metadata. If a field exists in either, it can
+   * be used for filtering.
+   *
+   * @param options Map of field names to lists of allowed values. If null or empty, all nodes
+   *     match.
+   */
   public record Filter(Map<String, List<String>> options) {
     public boolean matches(SpanNode node) {
+      // Empty or null filter means no filtering - match all nodes
+      if (options == null || options.isEmpty()) {
+        return true;
+      }
+
       for (Map.Entry<String, List<String>> entry : this.options().entrySet()) {
         String fieldName = entry.getKey();
         List<String> allowedValues = entry.getValue();
+
+        // Skip if allowedValues is null or empty
+        if (allowedValues == null || allowedValues.isEmpty()) {
+          continue;
+        }
 
         // Get the actual value from node or edge metadata
         String actualValue = node.nodeMetadata().get(fieldName);
@@ -158,9 +187,6 @@ public class GraphBuilder {
    * nodes that match the filter criteria. Non-matching intermediate nodes are traversed but don't
    * appear in the final graph - their children are connected directly to the last matching
    * ancestor.
-   *
-   * <p>Since span graphs are trees (each child has exactly one parent), a single shared visited set
-   * is sufficient to prevent cycles and redundant traversal.
    *
    * <p>Uses an explicit stack instead of recursion to avoid stack overflow with deep trace graphs.
    *

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,7 +106,8 @@ public class GraphBuilder {
             });
 
     // Build parent-child relationships at the node level
-    Map<String, List<Map.Entry<String, SortedMap<String, String>>>> parentNodeIdToChildNodeIds =
+    // TODO: introduce a record Metadata class to abstract away SortedMap<String, String> references
+    Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds =
         buildParentChildConnections(spans, spanIdToNode);
 
     // Determine which nodes to include based on the filter if provided, otherwise include all nodes
@@ -121,7 +121,7 @@ public class GraphBuilder {
                         .collect(Collectors.toSet()))
             .orElseGet(() -> new HashSet<>(nodeIdToNode.keySet()));
 
-    return traverseAndBuildGraph(nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds);
+    return traverseAndBuildGraph(filter, nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds);
   }
 
   /**
@@ -139,10 +139,10 @@ public class GraphBuilder {
    * @param spanIdToNode Map from span ID to its logical node representation
    * @return Map from parent node ID to list of (child node ID, edge metadata) pairs
    */
-  private Map<String, List<Map.Entry<String, SortedMap<String, String>>>>
-      buildParentChildConnections(List<ZipkinSpanResponse> spans, Map<String, Node> spanIdToNode) {
+  private Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> buildParentChildConnections(
+      List<ZipkinSpanResponse> spans, Map<String, Node> spanIdToNode) {
 
-    Map<String, List<Map.Entry<String, SortedMap<String, String>>>> parentNodeIdToChildNodeIds =
+    Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds =
         new HashMap<>();
 
     for (ZipkinSpanResponse span : spans) {
@@ -152,13 +152,9 @@ public class GraphBuilder {
       Node child = spanIdToNode.get(span.getId());
       if (parent == null || child == null) continue;
 
-      // Extract edge metadata from the span that created this connection
-      SortedMap<String, String> edgeMetadata =
-          config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE);
-
       parentNodeIdToChildNodeIds
           .computeIfAbsent(parent.getId(), k -> new ArrayList<>())
-          .add(Map.entry(child.getId(), edgeMetadata));
+          .add(Map.entry(child.getId(), span));
     }
     return parentNodeIdToChildNodeIds;
   }
@@ -180,9 +176,10 @@ public class GraphBuilder {
    * @return Graph containing only filtered nodes and their transitive connections
    */
   private Graph traverseAndBuildGraph(
+      Optional<Filter> filter,
       Set<String> nodesToProcess,
       Map<String, Node> nodeIdToNode,
-      Map<String, List<Map.Entry<String, SortedMap<String, String>>>> parentNodeIdToChildNodeIds) {
+      Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds) {
 
     Set<Node> nodes = new HashSet<>();
     Set<Edge> edges = new HashSet<>();
@@ -198,22 +195,30 @@ public class GraphBuilder {
         String currentNodeId = work.pop();
         if (!visitedNodes.add(currentNodeId)) continue;
 
-        List<Map.Entry<String, SortedMap<String, String>>> children =
+        List<Map.Entry<String, ZipkinSpanResponse>> children =
             parentNodeIdToChildNodeIds.getOrDefault(currentNodeId, List.of());
 
-        for (Map.Entry<String, SortedMap<String, String>> child : children) {
+        for (Map.Entry<String, ZipkinSpanResponse> child : children) {
           String childNodeId = child.getKey();
+          ZipkinSpanResponse refSpan = child.getValue();
+          if (!filter.isPresent() || filter.get().matches(refSpan)) {
+            // Skip the case where the ancestor is a direct parent of the same logical node ID
+            if (parentNodeId.equals(childNodeId)) continue;
 
-          if (nodesToProcess.contains(childNodeId)) {
-            // Found a filtered child - create edge from starting parent to this child.
-            // This creates the "transitive" edge, skipping any intermediate nodes when filtering.
+            // Found a child that matches the filter when present, create edge from starting parent
+            // to this child.
+            // This creates the transitive edge, skipping any intermediate nodes when filtering.
             // Don't traverse past this child - it will be processed in its own iteration.
             nodes.add(nodeIdToNode.get(parentNodeId));
             nodes.add(nodeIdToNode.get(childNodeId));
-            edges.add(new Edge(parentNodeId, childNodeId, child.getValue()));
+            edges.add(
+                new Edge(
+                    parentNodeId,
+                    childNodeId,
+                    config.createMetadataFromSpan(refSpan, GraphConfig.EntityType.EDGE)));
           } else {
             // Non-filtered intermediate node - continue traversing through it
-            work.push(child.getKey());
+            work.push(childNodeId);
           }
         }
       }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -87,9 +87,9 @@ public class GraphBuilder {
    * Builds an (optionally filtered) dependency graph from a list of Zipkin spans.
    *
    * <p>This method processes spans to create nodes and edges representing operation dependencies,
-   * filtered by any specified criteria. If a filter is specified, it starts DFS from every span
-   * matching the filter, creating edges between matching spans while traversing through
-   * non-matching intermediate spans.
+   * filtered by any specified criteria. If a filter is specified, it collects all filtered spans
+   * first, then for each filtered span, finds its transitive matching children (filtered spans
+   * reachable through non-filtered intermediate spans) and creates edges between them.
    *
    * @param spans List of Zipkin spans to process
    * @param filter Optional filter to apply when building the graph. If empty or null, returns every
@@ -113,118 +113,131 @@ public class GraphBuilder {
     }
 
     Set<Edge> edges = new HashSet<>();
-    Set<Node> nodes = new HashSet<>();
+    Map<String, Node> nodeIdToNodes = new HashMap<>();
 
-    if (filter.isPresent()) {
-      // Start DFS from every node matching the filter since there is no guarantee of a single root
-      // in a trace.
-      spanIdToSpans.values().stream()
-          .filter(span -> filter.get().matches(span))
-          .forEach(
-              span ->
-                  dfsFilter(
-                      span, filter.get(), edges, nodes, spanIdToSpans, parentSpanIdToChildSpans));
-    } else {
-      // No filter, build graph with all edges and collect nodes along the way
-      spanIdToSpans.values().stream()
-          .forEach(
-              span -> {
-                List<ZipkinSpanResponse> children =
-                    parentSpanIdToChildSpans.getOrDefault(span.getId(), List.of());
-                children.stream()
-                    .forEach(childSpan -> this.createDependency(nodes, edges, span, childSpan));
-              });
-    }
-
-    return new Graph(new ArrayList<>(nodes), new ArrayList<>(edges));
+    buildFilteredGraph(filter, edges, nodeIdToNodes, parentSpanIdToChildSpans, spanIdToSpans);
+    return new Graph(new ArrayList<>(nodeIdToNodes.values()), new ArrayList<>(edges));
   }
 
   /**
-   * State object for iterative DFS traversal.
+   * Builds a filtered graph by creating edges between filtered spans.
    *
-   * @param span The current span being processed
-   * @param lastAncestorSpanId ID of the most recent ancestor that matched the filter
-   */
-  private record DFSState(ZipkinSpanResponse span, String lastAncestorSpanId) {}
-
-  /**
-   * Performs iterative DFS to find edges between spans matching the filter.
+   * <p>This method processes all filtered spans and for each one, finds its transitive matching
+   * children (filtered spans reachable through any number of non-filtered intermediate spans) and
+   * creates edges between them. This approach minimizes duplicate traversal work compared to
+   * starting a DFS from each filtered span independently.
    *
-   * <p>This method explores the span tree starting from a given span, creating edges only between
-   * spans that match the filter criteria. Non-matching intermediate spans are traversed but don't
-   * appear in the final graph - their children are connected directly to the last matching
-   * ancestor.
-   *
-   * <p>Uses an explicit stack instead of recursion to avoid issues with deep trace graphs.
-   *
-   * @param startSpan The span to start traversal from
-   * @param filter Filter to determine which nodes should appear in the final graph
+   * @param filter Map from span ID to spans that match the filter criteria
    * @param edges Output set to collect edges between matching spans
-   * @param nodes Output set to collect matching nodes
-   * @param spanIdToSpans Lookup map from span ID to spans
+   * @param nodeIdToNodes Output map to collect matching nodes
    * @param parentSpanIdToChildSpans Map from parent span ID to list of child spans
    */
-  private void dfsFilter(
-      ZipkinSpanResponse startSpan,
-      Filter filter,
+  private void buildFilteredGraph(
+      Optional<Filter> filter,
       Set<Edge> edges,
-      Set<Node> nodes,
-      Map<String, ZipkinSpanResponse> spanIdToSpans,
-      Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans) {
-    Set<String> visited = new HashSet<>();
-    Deque<DFSState> stack = new ArrayDeque<>();
-    stack.push(new DFSState(startSpan, startSpan.getId()));
+      Map<String, Node> nodeIdToNodes,
+      Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans,
+      Map<String, ZipkinSpanResponse> spanIdToSpans) {
+    Map<String, ZipkinSpanResponse> filteredSpanIdToSpans = new HashMap<>();
+    if (filter.isPresent()) {
+      // Collect all spans matching the filter
+      for (ZipkinSpanResponse span : spanIdToSpans.values()) {
+        if (filter.get().matches(span)) filteredSpanIdToSpans.put(span.getId(), span);
+      }
+    } else {
+      // No filter, build graph with all edges
+      // filteredSpanIdToSpans is read only after this point which is why a copy is not needed here.
+      filteredSpanIdToSpans = spanIdToSpans;
+    }
+
+    Map<String, List<String>> nodeIdToSpanIds = new HashMap<>();
+    for (ZipkinSpanResponse span : spanIdToSpans.values()) {
+      nodeIdToSpanIds.computeIfAbsent(getNodeId(span), k -> new ArrayList<>()).add(span.getId());
+    }
+
+    for (ZipkinSpanResponse parentSpan : filteredSpanIdToSpans.values()) {
+      List<String> childSpanIds =
+          collectTransitiveChildren(
+              parentSpan,
+              filteredSpanIdToSpans.keySet(),
+              parentSpanIdToChildSpans,
+              nodeIdToSpanIds,
+              spanIdToSpans);
+      for (String childSpanId : childSpanIds) {
+        addEdge(nodeIdToNodes, edges, parentSpan, filteredSpanIdToSpans.get(childSpanId));
+      }
+    }
+  }
+
+  /**
+   * Collects all filtered spans that are transitive children of a given span.
+   *
+   * <p>A transitive child is a filtered span that can be reached from the start span by traversing
+   * through any number of non-filtered intermediate spans. This method uses an iterative approach
+   * with a work queue to find all such children.
+   *
+   * @param startSpan The span to start traversal from
+   * @param filteredSpanIds Set of span IDs that match the filter
+   * @param parentSpanIdToChildSpans Map from parent span ID to list of child spans
+   * @return List of span IDs for all transitive matching children
+   */
+  private List<String> collectTransitiveChildren(
+      ZipkinSpanResponse startSpan,
+      Set<String> filteredSpanIds,
+      Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans,
+      Map<String, List<String>> nodeIdToSpanIds,
+      Map<String, ZipkinSpanResponse> spanIdToSpans) {
+    List<String> results = new ArrayList<>();
+    Deque<String> stack = new ArrayDeque<>();
+    Set<String> visitedSpans = new HashSet<>();
+    Set<String> visitedNodes = new HashSet<>();
+
+    stack.push(startSpan.getId());
+    visitedSpans.add(startSpan.getId());
 
     while (!stack.isEmpty()) {
-      DFSState state = stack.pop();
-      ZipkinSpanResponse node = state.span();
+      String spanId = stack.pop();
+      ZipkinSpanResponse span = spanIdToSpans.get(spanId);
+      if (span == null) continue;
 
-      // Skip if already visited
-      if (visited.contains(node.getId())) {
-        continue;
-      }
-      visited.add(node.getId());
+      String nodeId = getNodeId(span);
+      if (!visitedNodes.add(nodeId)) continue;
 
-      // If the current node matches filter, it becomes the new ancestor, otherwise keep the last
-      // one
-      String currentAncestorNodeId =
-          filter.matches(node) ? node.getId() : state.lastAncestorSpanId();
+      for (String siblingSpanId : nodeIdToSpanIds.getOrDefault(nodeId, List.of(spanId))) {
+        for (ZipkinSpanResponse child :
+            parentSpanIdToChildSpans.getOrDefault(siblingSpanId, List.of())) {
+          if (!visitedSpans.add(child.getId())) continue;
 
-      // Process all children of the current span
-      List<ZipkinSpanResponse> children =
-          parentSpanIdToChildSpans.getOrDefault(node.getId(), List.of());
-      for (ZipkinSpanResponse child : children) {
-        if (filter.matches(child) && currentAncestorNodeId != null) {
-          // Child matches filter, create edge from current ancestor to this child
-          ZipkinSpanResponse parent = spanIdToSpans.get(currentAncestorNodeId);
-          if (parent == null) {
-            continue;
+          if (filteredSpanIds.contains(child.getId())) {
+            results.add(child.getId());
+          } else {
+            stack.push(child.getId());
           }
-          this.createDependency(nodes, edges, parent, child);
-
-          // Continue exploration with child as the new ancestor
-          stack.push(new DFSState(child, child.getId()));
-        } else {
-          // Child doesn't match filter, traverse through it but keep current ancestor, skipping
-          // over non-matching intermediate spans.
-          stack.push(new DFSState(child, currentAncestorNodeId));
         }
       }
     }
+
+    return results;
   }
 
-  private void createDependency(
-      Set<Node> nodes, Set<Edge> edges, ZipkinSpanResponse parent, ZipkinSpanResponse child) {
+  private void addEdge(
+      Map<String, Node> nodeIdToNodes,
+      Set<Edge> edges,
+      ZipkinSpanResponse parent,
+      ZipkinSpanResponse child) {
     Node source = new Node(config.createMetadataFromSpan(parent, GraphConfig.EntityType.NODE));
     Node target = new Node(config.createMetadataFromSpan(child, GraphConfig.EntityType.NODE));
-
-    nodes.add(source);
-    nodes.add(target);
-
+    nodeIdToNodes.putIfAbsent(source.getId(), source);
+    nodeIdToNodes.putIfAbsent(target.getId(), target);
     edges.add(
         new Edge(
             source.getId(),
             target.getId(),
             config.createMetadataFromSpan(child, GraphConfig.EntityType.EDGE)));
+  }
+
+  private String getNodeId(ZipkinSpanResponse span) {
+    return Node.generateIdFromMetadata(
+        config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE));
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -106,7 +106,6 @@ public class GraphBuilder {
             });
 
     // Build parent-child relationships at the node level
-    // TODO: introduce a record Metadata class to abstract away SortedMap<String, String> references
     Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds =
         buildParentChildConnections(spans, spanIdToNode);
 
@@ -137,7 +136,7 @@ public class GraphBuilder {
    *
    * @param spans List of all spans to process
    * @param spanIdToNode Map from span ID to its logical node representation
-   * @return Map from parent node ID to list of (child node ID, edge metadata) pairs
+   * @return Map from parent node ID to list of (child node ID, reference span) pairs
    */
   private Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> buildParentChildConnections(
       List<ZipkinSpanResponse> spans, Map<String, Node> spanIdToNode) {
@@ -152,6 +151,10 @@ public class GraphBuilder {
       Node child = spanIdToNode.get(span.getId());
       if (parent == null || child == null) continue;
 
+      // Keep a reference to the span that produced this edge. This is used later during traversal
+      // to decide which edges to retain when a filter is applied. Without it, if the filter depends
+      // on span tags that also define edge metadata, we could end up creating incorrect or
+      // missing relationships.
       parentNodeIdToChildNodeIds
           .computeIfAbsent(parent.getId(), k -> new ArrayList<>())
           .add(Map.entry(child.getId(), span));
@@ -170,9 +173,10 @@ public class GraphBuilder {
    * <p>Example: If we have Root (filtered) -> Intermediate (not filtered) -> Leaf (filtered), this
    * will create a direct edge: Root -> Leaf, skipping the intermediate node.
    *
+   * @param filter Optional filter to apply when creating edges
    * @param nodesToProcess Set of node IDs that match the filter (or all nodes if no filter)
    * @param nodeIdToNode Map from node ID to Node object
-   * @param parentNodeIdToChildNodeIds Map of parent-child relationships with edge metadata
+   * @param parentNodeIdToChildNodeIds Map of parent-child relationships with their reference span
    * @return Graph containing only filtered nodes and their transitive connections
    */
   private Graph traverseAndBuildGraph(
@@ -205,9 +209,9 @@ public class GraphBuilder {
             // Skip the case where the ancestor is a direct parent of the same logical node ID
             if (parentNodeId.equals(childNodeId)) continue;
 
-            // Found a child that matches the filter when present, create edge from starting parent
-            // to this child.
-            // This creates the transitive edge, skipping any intermediate nodes when filtering.
+            // Found a child that matches the filter when present, create edge
+            // from starting parent to this child.
+            // This creates the transitive edge, skipping any intermediate nodes.
             // Don't traverse past this child - it will be processed in its own iteration.
             nodes.add(nodeIdToNode.get(parentNodeId));
             nodes.add(nodeIdToNode.get(childNodeId));

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,10 +115,10 @@ public class GraphBuilder {
     }
 
     Set<Edge> edges = new HashSet<>();
-    Map<String, Node> nodeIdToNodes = new HashMap<>();
+    Set<Node> nodes = new HashSet<>();
+    buildFilteredGraph(filter, edges, nodes, parentSpanIdToChildSpans, spanIdToSpans);
 
-    buildFilteredGraph(filter, edges, nodeIdToNodes, parentSpanIdToChildSpans, spanIdToSpans);
-    return new Graph(new ArrayList<>(nodeIdToNodes.values()), new ArrayList<>(edges));
+    return new Graph(new ArrayList<>(nodes), new ArrayList<>(edges));
   }
 
   /**
@@ -127,91 +129,115 @@ public class GraphBuilder {
    * creates edges between them. This approach minimizes duplicate traversal work compared to
    * starting a DFS from each filtered span independently.
    *
-   * @param filter Map from span ID to spans that match the filter criteria
-   * @param edges Output set to collect edges between matching spans
-   * @param nodeIdToNodes Output map to collect matching nodes
+   * @param filter Optional filter to apply when building the graph. If empty or null, returns every
+   *     connection.
+   * @param edges Output set to collect distinct edges between matching spans
+   * @param nodes Output set to collect distinct nodes
    * @param parentSpanIdToChildSpans Map from parent span ID to list of child spans
+   * @param spanIdToSpans Map from span ID to its full span
    */
   private void buildFilteredGraph(
       Optional<Filter> filter,
       Set<Edge> edges,
-      Map<String, Node> nodeIdToNodes,
+      Set<Node> nodes,
       Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans,
       Map<String, ZipkinSpanResponse> spanIdToSpans) {
-    Map<String, ZipkinSpanResponse> filteredSpanIdToSpans = new HashMap<>();
+    Map<String, ZipkinSpanResponse> spansToProcess = new HashMap<>();
     if (filter.isPresent()) {
       // Collect all spans matching the filter
-      for (ZipkinSpanResponse span : spanIdToSpans.values()) {
-        if (filter.get().matches(span)) filteredSpanIdToSpans.put(span.getId(), span);
-      }
+      spansToProcess =
+          spanIdToSpans.values().stream()
+              .filter(filter.get()::matches)
+              .collect(Collectors.toMap(ZipkinSpanResponse::getId, Function.identity()));
     } else {
-      // No filter, build graph with all edges
-      // filteredSpanIdToSpans is read only after this point which is why a copy is not needed here.
-      filteredSpanIdToSpans = spanIdToSpans;
+      // No filter, build graph with all edges.
+      // After this point, spansToProcess is read only, which is why a copy of spanIdToSpans is
+      // unnecessary
+      spansToProcess = spanIdToSpans;
     }
 
-    Map<String, List<String>> nodeIdToSpanIds = new HashMap<>();
-    for (ZipkinSpanResponse span : spanIdToSpans.values()) {
-      nodeIdToSpanIds.computeIfAbsent(getNodeId(span), k -> new ArrayList<>()).add(span.getId());
-    }
+    // Build mapping of logical nodes to all its representing span IDs
+    Map<String, List<String>> spansByNodeId =
+        spanIdToSpans.values().stream()
+            .collect(
+                Collectors.groupingBy(
+                    this::getNodeId,
+                    Collectors.mapping(ZipkinSpanResponse::getId, Collectors.toList())));
 
-    for (ZipkinSpanResponse parentSpan : filteredSpanIdToSpans.values()) {
+    for (ZipkinSpanResponse parentSpan : spansToProcess.values()) {
+      // Find all descendant spans (may skip through non-matching intermediate spans if a filter
+      // exists)
       List<String> childSpanIds =
           collectTransitiveChildren(
               parentSpan,
-              filteredSpanIdToSpans.keySet(),
+              spansToProcess.keySet(),
               parentSpanIdToChildSpans,
-              nodeIdToSpanIds,
+              spansByNodeId,
               spanIdToSpans);
+
+      // Create an edge from parent to each transitive child
       for (String childSpanId : childSpanIds) {
-        addEdge(nodeIdToNodes, edges, parentSpan, filteredSpanIdToSpans.get(childSpanId));
+        createDependency(nodes, edges, parentSpan, spansToProcess.get(childSpanId));
       }
     }
   }
 
   /**
-   * Collects all filtered spans that are transitive children of a given span.
+   * Collects all filtered spans that are transitive children of a given starting span.
    *
-   * <p>A transitive child is a filtered span that can be reached from the start span by traversing
-   * through any number of non-filtered intermediate spans. This method uses an iterative approach
-   * with a work queue to find all such children.
+   * <p>A transitive child is defined as a filtered span that can be reached from the start span by
+   * traversing through any number of non-filtered intermediate spans.
+   *
+   * <p>This method treats all spans representing the same logical node as equivalent. When one span
+   * for a node is processed, all of its sibling spans (those sharing the same node ID) and their
+   * child relationships are processed together. This ensures complete coverage of that node’s
+   * downstream relationships without redundant traversal.
+   *
+   * <p>The traversal is iterative (using a stack) and guards against cycles via visited sets.
    *
    * @param startSpan The span to start traversal from
-   * @param filteredSpanIds Set of span IDs that match the filter
+   * @param spanIdsToProcess Set of span IDs that match an optional filter
    * @param parentSpanIdToChildSpans Map from parent span ID to list of child spans
+   * @param spansByNodeId Map of a logical node to all its representative spans
+   * @param spanIdToSpans Map from span ID to its full span
    * @return List of span IDs for all transitive matching children
    */
   private List<String> collectTransitiveChildren(
       ZipkinSpanResponse startSpan,
-      Set<String> filteredSpanIds,
+      Set<String> spanIdsToProcess,
       Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans,
-      Map<String, List<String>> nodeIdToSpanIds,
+      Map<String, List<String>> spansByNodeId,
       Map<String, ZipkinSpanResponse> spanIdToSpans) {
     List<String> results = new ArrayList<>();
-    Deque<String> stack = new ArrayDeque<>();
-    Set<String> visitedSpans = new HashSet<>();
-    Set<String> visitedNodes = new HashSet<>();
+    Deque<String> work = new ArrayDeque<>();
+    Set<String> visitedSpans = new HashSet<>(); // Tracks individual spans to prevent cycles
+    Set<String> visitedNodes = new HashSet<>(); // Tracks logical nodes to avoid redundant traversal
 
-    stack.push(startSpan.getId());
+    work.push(startSpan.getId());
     visitedSpans.add(startSpan.getId());
 
-    while (!stack.isEmpty()) {
-      String spanId = stack.pop();
+    while (!work.isEmpty()) {
+      String spanId = work.pop();
       ZipkinSpanResponse span = spanIdToSpans.get(spanId);
-      if (span == null) continue;
 
+      if (span == null) continue;
       String nodeId = getNodeId(span);
+
       if (!visitedNodes.add(nodeId)) continue;
 
-      for (String siblingSpanId : nodeIdToSpanIds.getOrDefault(nodeId, List.of(spanId))) {
+      for (String siblingSpanId : spansByNodeId.getOrDefault(nodeId, List.of(spanId))) {
         for (ZipkinSpanResponse child :
             parentSpanIdToChildSpans.getOrDefault(siblingSpanId, List.of())) {
+
           if (!visitedSpans.add(child.getId())) continue;
 
-          if (filteredSpanIds.contains(child.getId())) {
+          if (spanIdsToProcess.contains(child.getId())) {
+            // Found a filtered child - add to results and stop traversing this branch
+            // because the child will be handled in its own iteration
             results.add(child.getId());
           } else {
-            stack.push(child.getId());
+            // Non-filtered intermediate span - continue traversing through it
+            work.push(child.getId());
           }
         }
       }
@@ -220,15 +246,14 @@ public class GraphBuilder {
     return results;
   }
 
-  private void addEdge(
-      Map<String, Node> nodeIdToNodes,
-      Set<Edge> edges,
-      ZipkinSpanResponse parent,
-      ZipkinSpanResponse child) {
+  private void createDependency(
+      Set<Node> nodes, Set<Edge> edges, ZipkinSpanResponse parent, ZipkinSpanResponse child) {
     Node source = new Node(config.createMetadataFromSpan(parent, GraphConfig.EntityType.NODE));
     Node target = new Node(config.createMetadataFromSpan(child, GraphConfig.EntityType.NODE));
-    nodeIdToNodes.putIfAbsent(source.getId(), source);
-    nodeIdToNodes.putIfAbsent(target.getId(), target);
+
+    nodes.add(source);
+    nodes.add(target);
+
     edges.add(
         new Edge(
             source.getId(),

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,11 +17,11 @@ import org.slf4j.LoggerFactory;
  * GraphBuilder constructs service dependency graphs from Zipkin span data.
  *
  * <p>This class processes distributed tracing spans to build a graph representation showing
- * relationships between services. It creates nodes representing services and edges representing
- * parent-child relationships between spans.
+ * relationships between operations. It creates nodes representing service operations and edges
+ * representing parent-child relationships between spans.
  *
- * <p>The builder supports configurable node metadata extraction through GraphConfig, allowing
- * customization of which span tags are used to populate node metadata.
+ * <p>The builder supports configurable node and edge metadata extraction through GraphConfig,
+ * allowing customization of which span tags are used to populate each entity's metadata.
  */
 public class GraphBuilder {
   private static final Logger LOG = LoggerFactory.getLogger(GraphBuilder.class);
@@ -41,25 +40,22 @@ public class GraphBuilder {
   /**
    * Filter for selecting nodes/edges in the graph based on metadata criteria.
    *
-   * <p>The filter uses OR logic: a node matches if ANY of the filter criteria match. Each filter
+   * <p>The filter uses OR logic: a span matches if ANY of the filter criteria match. Each filter
    * option is a field name (e.g., "operation", "service") mapped to a list of allowed values for
    * that field.
    *
-   * <p>Examples: {"operation": ["http.request"]} - matches nodes with operation="http.request"
-   * {"operation": ["http.request", "grpc.request"]} - matches nodes with either operation
-   * {"operation": ["http.request"], "service": ["api-gateway.prod"]} - matches nodes with
-   * operation="http.request" OR service="api-gateway.prod" {} or null - empty filter matches all
-   * nodes (no filtering)
+   * <p>Examples: {"operation": ["http.request"]} - matches spans with tag operation="http.request"
+   * {"operation": ["http.request", "grpc.request"]} - matches spans with either operation tag
+   * {"operation": ["http.request"], "kube.namespace": ["test-app-prod"]} - matches spans with
+   * operation="http.request" OR kube.namespace="test-app-prod" {} or null - empty filter matches
+   * all spans (no filtering)
    *
-   * <p>The filter checks both node metadata and edge metadata. If a field exists in either, it can
-   * be used for filtering.
-   *
-   * @param options Map of field names to lists of allowed values. If null or empty, all nodes
+   * @param options Map of field names to lists of allowed values. If null or empty, all spans
    *     match.
    */
   public record Filter(Map<String, List<String>> options) {
-    public boolean matches(SpanNode node) {
-      // Empty or null filter means no filtering - match all nodes
+    public boolean matches(ZipkinSpanResponse span) {
+      // Empty or null filter means match all spans
       if (options == null || options.isEmpty()) {
         return true;
       }
@@ -68,23 +64,16 @@ public class GraphBuilder {
         String fieldName = entry.getKey();
         List<String> allowedValues = entry.getValue();
 
-        // Skip if allowedValues is null or empty
         if (allowedValues == null || allowedValues.isEmpty()) {
           continue;
         }
 
-        // Get the actual value from node or edge metadata
-        String actualValue = node.nodeMetadata().get(fieldName);
-        if (actualValue == null) {
-          actualValue = node.edgeMetadata().get(fieldName);
-        }
-
-        // If field doesn't exist in either metadata, skip this filter option
+        String actualValue = span.getTags().get(fieldName);
         if (actualValue == null) {
           continue;
         }
 
-        // Check if actual value matches any of the allowed values
+        // Return true if ANY filter matches
         if (allowedValues.contains(actualValue)) {
           return true;
         }
@@ -94,40 +83,32 @@ public class GraphBuilder {
     }
   }
 
-  public record SpanNode(
-      String id, SortedMap<String, String> nodeMetadata, SortedMap<String, String> edgeMetadata) {}
-
   /**
-   * Builds a filtered dependency graph from a list of Zipkin spans.
+   * Builds an (optionally filtered) dependency graph from a list of Zipkin spans.
    *
-   * <p>This method processes spans to create nodes and edges representing service dependencies,
-   * filtered by the provided criteria. It starts DFS from every node matching the filter, creating
-   * edges between matching nodes while traversing through non-matching intermediate nodes.
+   * <p>This method processes spans to create nodes and edges representing operation dependencies,
+   * filtered by any specified criteria. If a filter is specified, it starts DFS from every span
+   * matching the filter, creating edges between matching spans while traversing through
+   * non-matching intermediate spans.
    *
    * @param spans List of Zipkin spans to process
-   * @param filter Filter to apply when building the graph
-   * @return Graph containing nodes and edges representing filtered service dependencies
+   * @param filter Optional filter to apply when building the graph. If empty or null, returns every
+   *     connection.
+   * @return Graph containing nodes and edges representing operation dependencies
    */
   public Graph buildFromSpans(List<ZipkinSpanResponse> spans, Optional<Filter> filter) {
-    Map<String, SpanNode> spanIdToSpanNodes = new HashMap<>();
-    Map<String, List<SpanNode>> parentSpanIdToChildSpanNodes = new HashMap<>();
+    Map<String, ZipkinSpanResponse> spanIdToSpans = new HashMap<>();
+    Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans = new HashMap<>();
 
     for (ZipkinSpanResponse span : spans) {
       if (span.getId() == null) {
         continue;
       }
-
-      SpanNode node =
-          new SpanNode(
-              span.getId(),
-              config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE),
-              config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE));
-
-      spanIdToSpanNodes.put(span.getId(), node);
+      spanIdToSpans.put(span.getId(), span);
 
       String parentId = span.getParentId();
       if (parentId != null) {
-        parentSpanIdToChildSpanNodes.computeIfAbsent(parentId, k -> new ArrayList<>()).add(node);
+        parentSpanIdToChildSpans.computeIfAbsent(parentId, k -> new ArrayList<>()).add(span);
       }
     }
 
@@ -135,36 +116,23 @@ public class GraphBuilder {
     Set<Node> nodes = new HashSet<>();
 
     if (filter.isPresent()) {
-      // Start DFS from every node matching the filter since there is no guarantee we have a single
-      // root in this trace.
-      spanIdToSpanNodes.values().stream()
-          .filter(node -> filter.get().matches(node))
+      // Start DFS from every node matching the filter since there is no guarantee of a single root
+      // in a trace.
+      spanIdToSpans.values().stream()
+          .filter(span -> filter.get().matches(span))
           .forEach(
-              node ->
+              span ->
                   dfsFilter(
-                      node,
-                      filter.get(),
-                      edges,
-                      nodes,
-                      spanIdToSpanNodes,
-                      parentSpanIdToChildSpanNodes));
+                      span, filter.get(), edges, nodes, spanIdToSpans, parentSpanIdToChildSpans));
     } else {
-      // No filter - build graph with all edges and collect nodes along the way
-      spanIdToSpanNodes.values().stream()
+      // No filter, build graph with all edges and collect nodes along the way
+      spanIdToSpans.values().stream()
           .forEach(
-              node -> {
-                List<SpanNode> children =
-                    parentSpanIdToChildSpanNodes.getOrDefault(node.id(), List.of());
+              span -> {
+                List<ZipkinSpanResponse> children =
+                    parentSpanIdToChildSpans.getOrDefault(span.getId(), List.of());
                 children.stream()
-                    .forEach(
-                        childNode -> {
-                          Node source = new Node(node.nodeMetadata());
-                          Node target = new Node(childNode.nodeMetadata());
-                          nodes.add(source);
-                          nodes.add(target);
-                          edges.add(
-                              new Edge(source.getId(), target.getId(), childNode.edgeMetadata()));
-                        });
+                    .forEach(childSpan -> this.createDependency(nodes, edges, span, childSpan));
               });
     }
 
@@ -174,78 +142,89 @@ public class GraphBuilder {
   /**
    * State object for iterative DFS traversal.
    *
-   * @param node The current span node being processed
-   * @param lastAncestorNodeId ID of the most recent ancestor that matched the filter
+   * @param span The current span being processed
+   * @param lastAncestorSpanId ID of the most recent ancestor that matched the filter
    */
-  private record DfsState(SpanNode node, String lastAncestorNodeId) {}
+  private record DFSState(ZipkinSpanResponse span, String lastAncestorSpanId) {}
 
   /**
-   * Performs iterative DFS to find edges between nodes matching the filter.
+   * Performs iterative DFS to find edges between spans matching the filter.
    *
-   * <p>This method explores the span tree starting from a given node, creating edges only between
-   * nodes that match the filter criteria. Non-matching intermediate nodes are traversed but don't
+   * <p>This method explores the span tree starting from a given span, creating edges only between
+   * spans that match the filter criteria. Non-matching intermediate spans are traversed but don't
    * appear in the final graph - their children are connected directly to the last matching
    * ancestor.
    *
    * <p>Uses an explicit stack instead of recursion to avoid issues with deep trace graphs.
    *
-   * @param startNode The node to start traversal from
+   * @param startSpan The span to start traversal from
    * @param filter Filter to determine which nodes should appear in the final graph
-   * @param edges Output set to collect edges between matching nodes
+   * @param edges Output set to collect edges between matching spans
    * @param nodes Output set to collect matching nodes
-   * @param spanIdToSpanNodes Lookup map from span ID to SpanNode
-   * @param parentSpanIdToChildSpanNodes Map from parent span ID to list of child SpanNodes
+   * @param spanIdToSpans Lookup map from span ID to spans
+   * @param parentSpanIdToChildSpans Map from parent span ID to list of child spans
    */
   private void dfsFilter(
-      SpanNode startNode,
+      ZipkinSpanResponse startSpan,
       Filter filter,
       Set<Edge> edges,
       Set<Node> nodes,
-      Map<String, SpanNode> spanIdToSpanNodes,
-      Map<String, List<SpanNode>> parentSpanIdToChildSpanNodes) {
+      Map<String, ZipkinSpanResponse> spanIdToSpans,
+      Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans) {
     Set<String> visited = new HashSet<>();
-    Deque<DfsState> stack = new ArrayDeque<>();
-
-    stack.push(new DfsState(startNode, startNode.id()));
+    Deque<DFSState> stack = new ArrayDeque<>();
+    stack.push(new DFSState(startSpan, startSpan.getId()));
 
     while (!stack.isEmpty()) {
-      DfsState state = stack.pop();
-      SpanNode node = state.node();
+      DFSState state = stack.pop();
+      ZipkinSpanResponse node = state.span();
 
       // Skip if already visited
-      if (visited.contains(node.id())) {
+      if (visited.contains(node.getId())) {
         continue;
       }
-      visited.add(node.id());
+      visited.add(node.getId());
 
-      // If the current node matches filter, it becomes the new ancestor
-      String currentAncestorNodeId = filter.matches(node) ? node.id() : state.lastAncestorNodeId();
+      // If the current node matches filter, it becomes the new ancestor, otherwise keep the last
+      // one
+      String currentAncestorNodeId =
+          filter.matches(node) ? node.getId() : state.lastAncestorSpanId();
 
-      // Process all children of the current node
-      List<SpanNode> children = parentSpanIdToChildSpanNodes.getOrDefault(node.id(), List.of());
-      for (SpanNode child : children) {
+      // Process all children of the current span
+      List<ZipkinSpanResponse> children =
+          parentSpanIdToChildSpans.getOrDefault(node.getId(), List.of());
+      for (ZipkinSpanResponse child : children) {
         if (filter.matches(child) && currentAncestorNodeId != null) {
-          // Child matches filter, create edge from current ancestor node to this child
-          SpanNode parent = spanIdToSpanNodes.get(currentAncestorNodeId);
+          // Child matches filter, create edge from current ancestor to this child
+          ZipkinSpanResponse parent = spanIdToSpans.get(currentAncestorNodeId);
           if (parent == null) {
             continue;
           }
+          this.createDependency(nodes, edges, parent, child);
 
-          Node source = new Node(parent.nodeMetadata());
-          Node target = new Node(child.nodeMetadata());
-
-          nodes.add(source);
-          nodes.add(target);
-          edges.add(new Edge(source.getId(), target.getId(), child.edgeMetadata()));
-
-          // Continue exploration with child as the new ancestor node
-          stack.push(new DfsState(child, child.id()));
+          // Continue exploration with child as the new ancestor
+          stack.push(new DFSState(child, child.getId()));
         } else {
-          // Child doesn't match filter, traverse through it but keep current ancestor node
-          // Skip over non-matching intermediate nodes
-          stack.push(new DfsState(child, currentAncestorNodeId));
+          // Child doesn't match filter, traverse through it but keep current ancestor, skipping
+          // over non-matching intermediate spans.
+          stack.push(new DFSState(child, currentAncestorNodeId));
         }
       }
     }
+  }
+
+  private void createDependency(
+      Set<Node> nodes, Set<Edge> edges, ZipkinSpanResponse parent, ZipkinSpanResponse child) {
+    Node source = new Node(config.createMetadataFromSpan(parent, GraphConfig.EntityType.NODE));
+    Node target = new Node(config.createMetadataFromSpan(child, GraphConfig.EntityType.NODE));
+
+    nodes.add(source);
+    nodes.add(target);
+
+    edges.add(
+        new Edge(
+            source.getId(),
+            target.getId(),
+            config.createMetadataFromSpan(child, GraphConfig.EntityType.EDGE)));
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -62,26 +62,14 @@ public class GraphBuilder {
         return true;
       }
 
-      for (Map.Entry<String, List<String>> entry : this.options().entrySet()) {
-        String fieldName = entry.getKey();
-        List<String> allowedValues = entry.getValue();
-
-        if (allowedValues == null || allowedValues.isEmpty()) {
-          continue;
-        }
-
-        String actualValue = span.getTags().get(fieldName);
-        if (actualValue == null) {
-          continue;
-        }
-
-        // Return true if ANY filter matches
-        if (allowedValues.contains(actualValue)) {
-          return true;
-        }
-      }
-
-      return false;
+      // Returns true if ANY filter matches
+      return options.entrySet().stream()
+          .filter(entry -> entry.getValue() != null && !entry.getValue().isEmpty())
+          .anyMatch(
+              entry -> {
+                String actualValue = span.getTags().get(entry.getKey());
+                return actualValue != null && entry.getValue().contains(actualValue);
+              });
     }
   }
 
@@ -142,19 +130,15 @@ public class GraphBuilder {
       Set<Node> nodes,
       Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans,
       Map<String, ZipkinSpanResponse> spanIdToSpans) {
-    Map<String, ZipkinSpanResponse> spansToProcess = new HashMap<>();
-    if (filter.isPresent()) {
-      // Collect all spans matching the filter
-      spansToProcess =
-          spanIdToSpans.values().stream()
-              .filter(filter.get()::matches)
-              .collect(Collectors.toMap(ZipkinSpanResponse::getId, Function.identity()));
-    } else {
-      // No filter, build graph with all edges.
-      // After this point, spansToProcess is read only, which is why a copy of spanIdToSpans is
-      // unnecessary
-      spansToProcess = spanIdToSpans;
-    }
+    Map<String, ZipkinSpanResponse> spansToProcess =
+        // Collect all spans matching the filter if it exists
+        filter
+            .map(
+                f ->
+                    spanIdToSpans.values().stream()
+                        .filter(f::matches)
+                        .collect(Collectors.toMap(ZipkinSpanResponse::getId, Function.identity())))
+            .orElse(spanIdToSpans); // No filter, build graph with all edges.
 
     // Build mapping of logical nodes to all its representing span IDs
     Map<String, List<String>> spansByNodeId =
@@ -164,22 +148,23 @@ public class GraphBuilder {
                     this::getNodeId,
                     Collectors.mapping(ZipkinSpanResponse::getId, Collectors.toList())));
 
-    for (ZipkinSpanResponse parentSpan : spansToProcess.values()) {
-      // Find all descendant spans (may skip through non-matching intermediate spans if a filter
-      // exists)
-      List<String> childSpanIds =
-          collectTransitiveChildren(
-              parentSpan,
-              spansToProcess.keySet(),
-              parentSpanIdToChildSpans,
-              spansByNodeId,
-              spanIdToSpans);
-
-      // Create an edge from parent to each transitive child
-      for (String childSpanId : childSpanIds) {
-        createDependency(nodes, edges, parentSpan, spansToProcess.get(childSpanId));
-      }
-    }
+    spansToProcess
+        .values()
+        .forEach(
+            span -> {
+              // Find all descendant spans, may skip through non-matching
+              // intermediate spans if a filter exists
+              collectTransitiveChildren(
+                      span,
+                      spansToProcess.keySet(),
+                      parentSpanIdToChildSpans,
+                      spansByNodeId,
+                      spanIdToSpans)
+                  // Create an edge from parent to each transitive child
+                  .forEach(
+                      childSpanId ->
+                          createDependency(nodes, edges, span, spansToProcess.get(childSpanId)));
+            });
   }
 
   /**
@@ -191,9 +176,9 @@ public class GraphBuilder {
    * <p>This method treats all spans representing the same logical node as equivalent. When one span
    * for a node is processed, all of its sibling spans (those sharing the same node ID) and their
    * child relationships are processed together. This ensures complete coverage of that node’s
-   * downstream relationships without redundant traversal.
+   * downstream relationships, including any cycles.
    *
-   * <p>The traversal is iterative (using a stack) and guards against cycles via visited sets.
+   * <p>The traversal is iterative (using a stack) and guards against infinite loops via visited sets.
    *
    * @param startSpan The span to start traversal from
    * @param spanIdsToProcess Set of span IDs that match an optional filter
@@ -219,8 +204,6 @@ public class GraphBuilder {
     while (!work.isEmpty()) {
       String spanId = work.pop();
       ZipkinSpanResponse span = spanIdToSpans.get(spanId);
-
-      if (span == null) continue;
       String nodeId = getNodeId(span);
 
       if (!visitedNodes.add(nodeId)) continue;

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -87,8 +87,13 @@ public class GraphBuilder {
    * @return Graph containing nodes and edges representing operation dependencies
    */
   public Graph buildFromSpans(List<ZipkinSpanResponse> spans, Optional<Filter> filter) {
-    Map<String, ZipkinSpanResponse> spanIdToSpans = new HashMap<>();
-    Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans = new HashMap<>();
+    // Build all lookup structures
+    Map<String, ZipkinSpanResponse> spanIdToSpans = new HashMap<>(); // Lookup span by span ID
+    Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans =
+        new HashMap<>(); // Lookup children for a parent span
+    Map<String, String> spanIdToNodeId = new HashMap<>(); // Span ID to its logical node ID
+    Map<String, List<String>> spansByNodeId =
+        new HashMap<>(); // All spans belonging to a logical node
 
     for (ZipkinSpanResponse span : spans) {
       if (span.getId() == null) {
@@ -100,11 +105,24 @@ public class GraphBuilder {
       if (parentId != null) {
         parentSpanIdToChildSpans.computeIfAbsent(parentId, k -> new ArrayList<>()).add(span);
       }
+
+      // Build mapping of logical nodes to all its representing span IDs
+      spanIdToNodeId.putIfAbsent(span.getId(), getNodeId(span));
+      spansByNodeId
+          .computeIfAbsent(spanIdToNodeId.get(span.getId()), k -> new ArrayList<>())
+          .add(span.getId());
     }
 
     Set<Edge> edges = new HashSet<>();
     Set<Node> nodes = new HashSet<>();
-    buildFilteredGraph(filter, edges, nodes, parentSpanIdToChildSpans, spanIdToSpans);
+    buildFilteredGraph(
+        filter,
+        edges,
+        nodes,
+        parentSpanIdToChildSpans,
+        spanIdToSpans,
+        spanIdToNodeId,
+        spansByNodeId);
 
     return new Graph(new ArrayList<>(nodes), new ArrayList<>(edges));
   }
@@ -129,7 +147,9 @@ public class GraphBuilder {
       Set<Edge> edges,
       Set<Node> nodes,
       Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans,
-      Map<String, ZipkinSpanResponse> spanIdToSpans) {
+      Map<String, ZipkinSpanResponse> spanIdToSpans,
+      Map<String, String> spanIdToNodeId,
+      Map<String, List<String>> spansByNodeId) {
     Map<String, ZipkinSpanResponse> spansToProcess =
         // Collect all spans matching the filter if it exists
         filter
@@ -139,14 +159,6 @@ public class GraphBuilder {
                         .filter(f::matches)
                         .collect(Collectors.toMap(ZipkinSpanResponse::getId, Function.identity())))
             .orElse(spanIdToSpans); // No filter, build graph with all edges.
-
-    // Build mapping of logical nodes to all its representing span IDs
-    Map<String, List<String>> spansByNodeId =
-        spanIdToSpans.values().stream()
-            .collect(
-                Collectors.groupingBy(
-                    this::getNodeId,
-                    Collectors.mapping(ZipkinSpanResponse::getId, Collectors.toList())));
 
     spansToProcess
         .values()
@@ -159,7 +171,7 @@ public class GraphBuilder {
                       spansToProcess.keySet(),
                       parentSpanIdToChildSpans,
                       spansByNodeId,
-                      spanIdToSpans)
+                      spanIdToNodeId)
                   // Create an edge from parent to each transitive child
                   .forEach(
                       childSpanId ->
@@ -185,7 +197,7 @@ public class GraphBuilder {
    * @param spanIdsToProcess Set of span IDs that match an optional filter
    * @param parentSpanIdToChildSpans Map from parent span ID to list of child spans
    * @param spansByNodeId Map of a logical node to all its representative spans
-   * @param spanIdToSpans Map from span ID to its full span
+   * @param spanIdToNodeId Map from span ID to its logical node ID
    * @return List of span IDs for all transitive matching children
    */
   private List<String> collectTransitiveChildren(
@@ -193,7 +205,7 @@ public class GraphBuilder {
       Set<String> spanIdsToProcess,
       Map<String, List<ZipkinSpanResponse>> parentSpanIdToChildSpans,
       Map<String, List<String>> spansByNodeId,
-      Map<String, ZipkinSpanResponse> spanIdToSpans) {
+      Map<String, String> spanIdToNodeId) {
     List<String> results = new ArrayList<>();
     Deque<String> work = new ArrayDeque<>();
     Set<String> visitedSpans = new HashSet<>(); // Tracks individual spans to prevent cycles
@@ -204,8 +216,7 @@ public class GraphBuilder {
 
     while (!work.isEmpty()) {
       String spanId = work.pop();
-      ZipkinSpanResponse span = spanIdToSpans.get(spanId);
-      String nodeId = getNodeId(span);
+      String nodeId = spanIdToNodeId.get(spanId);
 
       if (!visitedNodes.add(nodeId)) continue;
 

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
@@ -39,16 +38,25 @@ public class GraphBuilder {
     this.config = config;
   }
 
-  public record Filter(Map<String, String> options) {
+  public record Filter(Map<String, List<String>> options) {
     public boolean matches(SpanNode node) {
-      for (Map.Entry<String, String> entry : this.options().entrySet()) {
-        if (!node.nodeMetadata().containsKey(entry.getKey())
-            && !node.edgeMetadata().containsKey(entry.getKey())) {
+      for (Map.Entry<String, List<String>> entry : this.options().entrySet()) {
+        String fieldName = entry.getKey();
+        List<String> allowedValues = entry.getValue();
+
+        // Get the actual value from node or edge metadata
+        String actualValue = node.nodeMetadata().get(fieldName);
+        if (actualValue == null) {
+          actualValue = node.edgeMetadata().get(fieldName);
+        }
+
+        // If field doesn't exist in either metadata, skip this filter option
+        if (actualValue == null) {
           continue;
         }
 
-        if (Objects.equals(node.nodeMetadata().get(entry.getKey()), entry.getValue())
-            || Objects.equals(node.edgeMetadata().get(entry.getKey()), entry.getValue())) {
+        // Check if actual value matches any of the allowed values
+        if (allowedValues.contains(actualValue)) {
           return true;
         }
       }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -267,8 +267,6 @@ public final class GraphConfig {
     if (values.size() > 1 && baseCfg.getKeyDelimiter() != null) {
       return String.join(baseCfg.getKeyDelimiter(), values);
     }
-
-    // Single value - return as is
     return values.get(0);
   }
 

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -70,15 +70,21 @@ public final class GraphConfig {
     private final String field;
     private final String value;
     private final String overrideKey;
+    private final String delimiter;
+    private final Integer part;
 
     @JsonCreator
     public RuleConfig(
         @JsonProperty("field") String field,
         @JsonProperty("value") String value,
-        @JsonProperty("override_key") String overrideKey) {
+        @JsonProperty("override_key") String overrideKey,
+        @JsonProperty("delimiter") String delimiter,
+        @JsonProperty("part") Integer part) {
       this.field = field;
       this.value = value;
       this.overrideKey = overrideKey;
+      this.delimiter = delimiter;
+      this.part = part;
     }
 
     public String getField() {
@@ -91,6 +97,14 @@ public final class GraphConfig {
 
     public String getOverrideKey() {
       return overrideKey;
+    }
+
+    public String getDelimiter() {
+      return delimiter;
+    }
+
+    public Integer getPart() {
+      return part;
     }
   }
 
@@ -203,7 +217,9 @@ public final class GraphConfig {
    * <p>Steps: 1. Look up the TagConfig for this logical field (e.g. "resource"). 2. Default to
    * using its defaultKey + defaultValue. 3. If rules are defined: - Iterate through each rule in
    * reverse order. - If a rule's field/value condition matches, switch keyToUse to overrideKey. 4.
-   * Finally, look up the chosen key in tags. If missing, fall back to defaultValue.
+   * Finally, look up the chosen key in tags. If missing, fall back to defaultValue. 5. If the
+   * matching rule has delimiter and part configured, split the value and extract the specified
+   * part.
    *
    * <p>Note: This logic does not currently support multiple field matches for a single rule.
    *
@@ -225,18 +241,32 @@ public final class GraphConfig {
 
     // Later rules override earlier ones, so start from the back of the list and use the first one
     // that matches.
-    String keyToUse =
+    RuleConfig matchingRule =
         baseCfg.getRules().reversed().stream()
             .filter(
                 rule ->
                     rule.getValue()
                         .equals(tags.getOrDefault(rule.getField(), "unknown_" + rule.getField())))
-            .map(RuleConfig::getOverrideKey)
-            .filter(tags::containsKey)
+            .filter(rule -> tags.containsKey(rule.getOverrideKey()))
             .findFirst()
-            .orElse(baseCfg.getDefaultKey());
+            .orElse(null);
 
-    return tags.getOrDefault(keyToUse, baseCfg.getDefaultValue());
+    String keyToUse =
+        matchingRule != null ? matchingRule.getOverrideKey() : baseCfg.getDefaultKey();
+    String value = tags.getOrDefault(keyToUse, baseCfg.getDefaultValue());
+
+    // If a rule matched and has delimiter/part configuration, split and extract the part
+    if (matchingRule != null
+        && matchingRule.getDelimiter() != null
+        && matchingRule.getPart() != null) {
+      String[] parts = value.split(java.util.regex.Pattern.quote(matchingRule.getDelimiter()));
+      int partIndex = matchingRule.getPart();
+      if (partIndex >= 0 && partIndex < parts.length) {
+        value = parts[partIndex];
+      }
+    }
+
+    return value;
   }
 
   @Override

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -31,30 +31,39 @@ public final class GraphConfig {
   /**
    * Represents how a single logical field on a node should be mapped to span tags.
    *
-   * <p>Each field has: - a default key to look up in tags - a default fallback value if the key
-   * isn’t found - an optional list of rules that can override the default key
+   * <p>Each field has: - default key (can be a list) to look up in tags (combined with delimiter if
+   * multiple) - a default fallback value if the keys aren't found - an optional delimiter for
+   * combining multiple key values - an optional list of rules that can override the default key
    */
   public static final class TagConfig {
-    private final String defaultKey;
+    private final List<String> defaultKey;
     private final String defaultValue;
+    private final String keyDelimiter;
     private final List<RuleConfig> rules;
 
     @JsonCreator
     public TagConfig(
-        @JsonProperty("default_key") String defaultKey,
+        @JsonProperty("default_key") List<String> defaultKey,
         @JsonProperty("default_value") String defaultValue,
+        @JsonProperty("key_delimiter") String keyDelimiter,
         @JsonProperty("rules") List<RuleConfig> rules) {
-      this.defaultKey = defaultKey;
+      this.defaultKey = (defaultKey == null) ? Collections.emptyList() : List.copyOf(defaultKey);
       this.defaultValue = defaultValue;
+      // Set default keyDelimiter to "." if null or empty
+      this.keyDelimiter = (keyDelimiter == null || keyDelimiter.isEmpty()) ? "." : keyDelimiter;
       this.rules = (rules == null) ? Collections.emptyList() : List.copyOf(rules);
     }
 
-    public String getDefaultKey() {
+    public List<String> getDefaultKey() {
       return defaultKey;
     }
 
     public String getDefaultValue() {
       return defaultValue;
+    }
+
+    public String getKeyDelimiter() {
+      return keyDelimiter;
     }
 
     public List<RuleConfig> getRules() {
@@ -69,22 +78,16 @@ public final class GraphConfig {
   public static class RuleConfig {
     private final String field;
     private final String value;
-    private final String overrideKey;
-    private final String delimiter;
-    private final Integer part;
+    private final List<String> overrideKey;
 
     @JsonCreator
     public RuleConfig(
         @JsonProperty("field") String field,
         @JsonProperty("value") String value,
-        @JsonProperty("override_key") String overrideKey,
-        @JsonProperty("delimiter") String delimiter,
-        @JsonProperty("part") Integer part) {
+        @JsonProperty("override_key") List<String> overrideKey) {
       this.field = field;
       this.value = value;
-      this.overrideKey = overrideKey;
-      this.delimiter = delimiter;
-      this.part = part;
+      this.overrideKey = (overrideKey == null) ? Collections.emptyList() : List.copyOf(overrideKey);
     }
 
     public String getField() {
@@ -95,16 +98,8 @@ public final class GraphConfig {
       return value;
     }
 
-    public String getOverrideKey() {
+    public List<String> getOverrideKey() {
       return overrideKey;
-    }
-
-    public String getDelimiter() {
-      return delimiter;
-    }
-
-    public Integer getPart() {
-      return part;
     }
   }
 
@@ -214,12 +209,11 @@ public final class GraphConfig {
   /**
    * Resolves the actual tag value for a given logical field, using the provided span tags.
    *
-   * <p>Steps: 1. Look up the TagConfig for this logical field (e.g. "resource"). 2. Default to
-   * using its defaultKey + defaultValue. 3. If rules are defined: - Iterate through each rule in
-   * reverse order. - If a rule's field/value condition matches, switch keyToUse to overrideKey. 4.
-   * Finally, look up the chosen key in tags. If missing, fall back to defaultValue. 5. If the
-   * matching rule has delimiter and part configured, split the value and extract the specified
-   * part.
+   * <p>Steps: 1. Look up the TagConfig for this logical field (e.g. "resource"). 2. Check if any
+   * rules match: - Iterate through each rule in reverse order. - If a rule's field/value condition
+   * matches, use the overrideKey to look up the value. 3. If no rule matches, use the defaultKey: -
+   * Look up each keyPart from defaultKey list in the tags map. - Combine the values with the
+   * delimiter if multiple parts are present. - If any part is missing, fall back to defaultValue.
    *
    * <p>Note: This logic does not currently support multiple field matches for a single rule.
    *
@@ -247,26 +241,35 @@ public final class GraphConfig {
                 rule ->
                     rule.getValue()
                         .equals(tags.getOrDefault(rule.getField(), "unknown_" + rule.getField())))
-            .filter(rule -> tags.containsKey(rule.getOverrideKey()))
             .findFirst()
             .orElse(null);
 
-    String keyToUse =
+    // Determine which key to use (override or default)
+    List<String> keyToUse =
         matchingRule != null ? matchingRule.getOverrideKey() : baseCfg.getDefaultKey();
-    String value = tags.getOrDefault(keyToUse, baseCfg.getDefaultValue());
 
-    // If a rule matched and has delimiter/part configuration, split and extract the part
-    if (matchingRule != null
-        && matchingRule.getDelimiter() != null
-        && matchingRule.getPart() != null) {
-      String[] parts = value.split(java.util.regex.Pattern.quote(matchingRule.getDelimiter()));
-      int partIndex = matchingRule.getPart();
-      if (partIndex >= 0 && partIndex < parts.length) {
-        value = parts[partIndex];
-      }
+    if (keyToUse == null || keyToUse.isEmpty()) {
+      return baseCfg.getDefaultValue();
     }
 
-    return value;
+    // Collect values for all parts in a key
+    List<String> values = new java.util.ArrayList<>();
+    for (String keyPart : keyToUse) {
+      String value = tags.get(keyPart);
+      if (value == null) {
+        // If any key is missing, return the default value
+        return baseCfg.getDefaultValue();
+      }
+      values.add(value);
+    }
+
+    // Combine values with delimiter if present and multiple keys exist
+    if (values.size() > 1 && baseCfg.getKeyDelimiter() != null) {
+      return String.join(baseCfg.getKeyDelimiter(), values);
+    }
+
+    // Single value - return as is
+    return values.get(0);
   }
 
   @Override

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -8,10 +8,14 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
-import com.slack.astra.server.AstraQueryServiceBase;
+import com.slack.astra.zipkinApi.TraceFetcher;
+import com.slack.astra.zipkinApi.ZipkinSpanResponse;
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,8 +24,8 @@ import org.slf4j.LoggerFactory;
 */
 public class GraphService {
   private static final Logger LOG = LoggerFactory.getLogger(GraphService.class);
-  private final AstraQueryServiceBase searcher;
-  private final GraphConfig graphConfig;
+  private final TraceFetcher traceFetcher;
+  private final GraphBuilder graphBuilder;
 
   private static final ObjectMapper objectMapper =
       JsonMapper.builder()
@@ -31,17 +35,38 @@ public class GraphService {
           .serializationInclusion(JsonInclude.Include.NON_EMPTY)
           .build();
 
-  public GraphService(AstraQueryServiceBase searcher, GraphConfig graphConfig) {
-    this.searcher = searcher;
-    this.graphConfig = graphConfig;
+  public GraphService(TraceFetcher traceFetcher, GraphConfig graphConfig) {
+    this.traceFetcher = traceFetcher;
+    this.graphBuilder = new GraphBuilder(graphConfig);
 
-    LOG.info("Started GraphService with config: {}", this.graphConfig);
+    LOG.info("Started GraphService with GraphBuilder config: {}", graphConfig);
   }
+
+  private record SubgraphResponse(
+      Graph subgraph, long traceFetchTimeMs, long subgraphBuildTimeMs) {}
 
   @Get
   @Path("/api/v1/trace/{traceId}/subgraph")
-  public HttpResponse getSubgraph(@Param("traceId") String traceId) throws IOException {
-    String output = "[]";
+  public HttpResponse getSubgraph(
+      @Param("traceId") String traceId,
+      @Param("buildFilter") Optional<GraphBuilder.Filter> buildFilter,
+      @Param("maxSpans") Optional<Integer> maxSpans,
+      @Header("X-User-Request") Optional<Boolean> userRequest)
+      throws IOException {
+    long start = System.currentTimeMillis();
+    List<ZipkinSpanResponse> trace =
+        this.traceFetcher.getSpansByTraceId(
+            traceId, Optional.empty(), Optional.empty(), maxSpans, userRequest, Optional.empty());
+    long end = System.currentTimeMillis();
+    long traceFetchTime = end - start;
+
+    start = System.currentTimeMillis();
+    Graph subgraph = this.graphBuilder.buildFromSpans(trace, buildFilter);
+    end = System.currentTimeMillis();
+    long subgraphBuildTime = end - start;
+
+    SubgraphResponse response = new SubgraphResponse(subgraph, traceFetchTime, subgraphBuildTime);
+    String output = objectMapper.writeValueAsString(response);
     return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -1,6 +1,7 @@
 package com.slack.astra.graphApi;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -15,6 +16,7 @@ import com.slack.astra.zipkinApi.TraceFetcher;
 import com.slack.astra.zipkinApi.ZipkinSpanResponse;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,10 +51,28 @@ public class GraphService {
   @Path("/api/v1/trace/{traceId}/subgraph")
   public HttpResponse getSubgraph(
       @Param("traceId") String traceId,
-      @Param("buildFilter") Optional<GraphBuilder.Filter> buildFilter,
+      @Param("buildFilter") Optional<String> buildFilterJson,
       @Param("maxSpans") Optional<Integer> maxSpans,
       @Header("X-User-Request") Optional<Boolean> userRequest)
       throws IOException {
+    // Parse the filter from JSON string if provided
+    Optional<GraphBuilder.Filter> buildFilter = Optional.empty();
+    if (buildFilterJson.isPresent()) {
+      try {
+        // Parse JSON as Map<String, List<String>> and create Filter
+        TypeReference<Map<String, List<String>>> typeRef = new TypeReference<>() {};
+        Map<String, List<String>> filterMap =
+            objectMapper.readValue(buildFilterJson.get(), typeRef);
+        buildFilter = Optional.of(new GraphBuilder.Filter(filterMap));
+      } catch (Exception e) {
+        LOG.error("Failed to parse buildFilter JSON: {}", buildFilterJson.get(), e);
+        return HttpResponse.of(
+            HttpStatus.BAD_REQUEST,
+            MediaType.PLAIN_TEXT_UTF_8,
+            "Invalid buildFilter JSON: " + e.getMessage());
+      }
+    }
+
     long start = System.currentTimeMillis();
     List<ZipkinSpanResponse> trace =
         this.traceFetcher.getSpansByTraceId(

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -85,7 +85,14 @@ public class GraphService {
     Timer.Sample traceFetchSample = Timer.start(meterRegistry);
     List<ZipkinSpanResponse> trace =
         this.traceFetcher.getSpansByTraceId(
-            traceId, Optional.empty(), Optional.empty(), maxSpans, userRequest, Optional.empty());
+            traceId,
+            Optional.empty(),
+            Optional.empty(),
+            maxSpans,
+            userRequest,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
     long traceFetchTimeMilli = traceFetchSample.stop(traceFetchTimer) / 1_000_000;
 
     Timer.Sample graphBuildSample = Timer.start(meterRegistry);

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -59,7 +59,7 @@ public class GraphService {
     Optional<GraphBuilder.Filter> buildFilter = Optional.empty();
     if (buildFilterJson.isPresent()) {
       try {
-        // Parse JSON as Map<String, List<String>> and create Filter
+        // Parse JSON as Map<String, List<String>> and create GraphConfig.Filter
         TypeReference<Map<String, List<String>>> typeRef = new TypeReference<>() {};
         Map<String, List<String>> filterMap =
             objectMapper.readValue(buildFilterJson.get(), typeRef);

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -14,6 +14,8 @@ import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
 import com.slack.astra.zipkinApi.TraceFetcher;
 import com.slack.astra.zipkinApi.ZipkinSpanResponse;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +30,9 @@ public class GraphService {
   private static final Logger LOG = LoggerFactory.getLogger(GraphService.class);
   private final TraceFetcher traceFetcher;
   private final GraphBuilder graphBuilder;
+  private final MeterRegistry meterRegistry;
+  private final Timer traceFetchTimer;
+  private final Timer graphBuildTimer;
 
   private static final ObjectMapper objectMapper =
       JsonMapper.builder()
@@ -37,9 +42,13 @@ public class GraphService {
           .serializationInclusion(JsonInclude.Include.NON_EMPTY)
           .build();
 
-  public GraphService(TraceFetcher traceFetcher, GraphConfig graphConfig) {
+  public GraphService(
+      TraceFetcher traceFetcher, GraphConfig graphConfig, MeterRegistry meterRegistry) {
     this.traceFetcher = traceFetcher;
     this.graphBuilder = new GraphBuilder(graphConfig);
+    this.meterRegistry = meterRegistry;
+    this.traceFetchTimer = meterRegistry.timer("astra_graph_service_trace_fetch");
+    this.graphBuildTimer = meterRegistry.timer("astra_graph_service_graph_build");
 
     LOG.info("Started GraphService with GraphBuilder config: {}", graphConfig);
   }
@@ -73,19 +82,18 @@ public class GraphService {
       }
     }
 
-    long start = System.currentTimeMillis();
+    Timer.Sample traceFetchSample = Timer.start(meterRegistry);
     List<ZipkinSpanResponse> trace =
         this.traceFetcher.getSpansByTraceId(
             traceId, Optional.empty(), Optional.empty(), maxSpans, userRequest, Optional.empty());
-    long end = System.currentTimeMillis();
-    long traceFetchTime = end - start;
+    long traceFetchTimeMilli = traceFetchSample.stop(traceFetchTimer) / 1_000_000;
 
-    start = System.currentTimeMillis();
+    Timer.Sample graphBuildSample = Timer.start(meterRegistry);
     Graph subgraph = this.graphBuilder.buildFromSpans(trace, buildFilter);
-    end = System.currentTimeMillis();
-    long subgraphBuildTime = end - start;
+    long subgraphBuildTimeMilli = graphBuildSample.stop(graphBuildTimer) / 1_000_000;
 
-    SubgraphResponse response = new SubgraphResponse(subgraph, traceFetchTime, subgraphBuildTime);
+    SubgraphResponse response =
+        new SubgraphResponse(subgraph, traceFetchTimeMilli, subgraphBuildTimeMilli);
     String output = objectMapper.writeValueAsString(response);
     return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
   }

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -266,7 +266,7 @@ public class Astra {
               .withTracing(astraConfig.getTracingConfig())
               .withAnnotatedService(new ElasticsearchApiService(astraDistributedQueryService))
               .withAnnotatedService(new ZipkinService(tf))
-              .withAnnotatedService(new GraphService(tf, graphConfig))
+              .withAnnotatedService(new GraphService(tf, graphConfig, meterRegistry))
               .withGrpcService(astraDistributedQueryService)
               .build();
       services.add(armeriaService);

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -266,7 +266,7 @@ public class Astra {
               .withTracing(astraConfig.getTracingConfig())
               .withAnnotatedService(new ElasticsearchApiService(astraDistributedQueryService))
               .withAnnotatedService(new ZipkinService(tf))
-              .withAnnotatedService(new GraphService(astraDistributedQueryService, graphConfig))
+              .withAnnotatedService(new GraphService(tf, graphConfig))
               .withGrpcService(astraDistributedQueryService)
               .build();
       services.add(armeriaService);

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -428,7 +428,7 @@ public class GraphBuilderTest {
 
     // Filter to only include nodes with operation "http.request"
     GraphBuilder.Filter filter =
-        new GraphBuilder.Filter(Map.of("operation", List.of("http.request")));
+        new GraphBuilder.Filter(Map.of("operation_name", List.of("http.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should only include parent1 and child1 nodes (both match filter and have edge between them)
@@ -508,7 +508,7 @@ public class GraphBuilderTest {
 
     // Filter to only include nodes with operation "http.request"
     GraphBuilder.Filter filter =
-        new GraphBuilder.Filter(Map.of("operation", List.of("http.request")));
+        new GraphBuilder.Filter(Map.of("operation_name", List.of("http.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should include root and grandchild nodes, skipping intermediate child1
@@ -561,7 +561,7 @@ public class GraphBuilderTest {
 
     // Filter that doesn't match any nodes
     GraphBuilder.Filter filter =
-        new GraphBuilder.Filter(Map.of("operation", List.of("nonexistent.operation")));
+        new GraphBuilder.Filter(Map.of("operation_name", List.of("nonexistent.operation")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     assertThat(graph.nodes()).isEmpty();
@@ -629,7 +629,7 @@ public class GraphBuilderTest {
 
     // Filter to only include nodes with operation "http.request"
     GraphBuilder.Filter filter =
-        new GraphBuilder.Filter(Map.of("operation", List.of("http.request")));
+        new GraphBuilder.Filter(Map.of("operation_name", List.of("http.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should include all 3 nodes since they all match
@@ -782,7 +782,7 @@ public class GraphBuilderTest {
 
     // Filter to only include nodes with operation "http.request"
     GraphBuilder.Filter filter =
-        new GraphBuilder.Filter(Map.of("operation", List.of("http.request")));
+        new GraphBuilder.Filter(Map.of("operation_name", List.of("http.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should include 4 matching nodes from both disconnected subtrees
@@ -889,7 +889,7 @@ public class GraphBuilderTest {
 
     // Filter with two options: matches nodes with either http.request OR grpc.request
     GraphBuilder.Filter filter =
-        new GraphBuilder.Filter(Map.of("operation", List.of("http.request", "grpc.request")));
+        new GraphBuilder.Filter(Map.of("operation_name", List.of("http.request", "grpc.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should include parent1 and child1 (both match at least one filter option)

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -2,7 +2,6 @@ package com.slack.astra.graphApi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.slack.astra.zipkinApi.ZipkinEndpointResponse;
 import com.slack.astra.zipkinApi.ZipkinSpanResponse;
 import java.io.File;
 import java.io.IOException;
@@ -11,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,47 +40,9 @@ public class GraphBuilderTest {
   @Test
   void buildFromSpans_emptyList_returnsEmptyGraph() {
     List<ZipkinSpanResponse> spans = new ArrayList<>();
-    Graph graph = defaultGraphBuilder.buildFromSpans(spans);
+    Graph graph = defaultGraphBuilder.buildFromSpans(spans, Optional.empty());
 
     assertThat(graph.nodes()).isEmpty();
-    assertThat(graph.edges()).isEmpty();
-  }
-
-  @Test
-  void buildFromSpans_singleSpanWithoutParent_createsSingleNodeWithoutEdges() {
-    List<ZipkinSpanResponse> spans =
-        List.of(
-            TestUtils.createSpanWithTags(
-                "span1",
-                "trace1",
-                null,
-                Map.of(
-                    "kube.app",
-                    "app1",
-                    "kube.namespace",
-                    "ns1",
-                    "operation_name",
-                    "op1",
-                    "resource",
-                    "res1")));
-
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
-
-    assertThat(graph.nodes()).hasSize(1);
-    Node node = graph.nodes().getFirst();
-
-    // Verify the node ID matches the expected hash
-    SortedMap<String, String> expectedNodeMetadata =
-        new TreeMap<>(
-            Map.of(
-                "app", "app1",
-                "namespace", "ns1",
-                "resource", "res1"));
-    String expectedId = Node.generateIdFromMetadata(expectedNodeMetadata);
-
-    assertThat(node.getId()).isEqualTo(expectedId);
-    assertThat(node.getMetadata()).isEqualTo(expectedNodeMetadata);
-
     assertThat(graph.edges()).isEmpty();
   }
 
@@ -102,12 +64,18 @@ public class GraphBuilderTest {
                 "trace1",
                 "parent1",
                 Map.of(
-                    "kube.app", "app2",
-                    "kube.namespace", "ns2",
-                    "operation_name", "op2",
-                    "resource", "res2")));
+                    "kube.app",
+                    "app2",
+                    "kube.namespace",
+                    "ns2",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "res2",
+                    "tag.http.target.canonical_path",
+                    "/v2/res2")));
 
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 
     assertThat(graph.nodes()).hasSize(2);
     assertThat(graph.edges()).hasSize(1);
@@ -126,79 +94,15 @@ public class GraphBuilderTest {
             Map.of(
                 "app", "app2",
                 "namespace", "ns2",
-                "resource", "res2"));
+                "resource", "/v2/res2"));
 
-    SortedMap<String, String> edgeMetadata = new TreeMap<>(Map.of("operation", "op2"));
+    // uses canonical path as resource
+    SortedMap<String, String> edgeMetadata = new TreeMap<>(Map.of("operation", "http.request"));
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
     Edge edge = graph.edges().iterator().next();
     assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
     assertThat(edge.targetNodeId()).isEqualTo(expectedChildId);
     assertThat(edge.metadata()).isEqualTo(edgeMetadata);
-  }
-
-  @Test
-  void buildFromSpans_httpRequestSpan_usesCanonicalPathAsResource() {
-    List<ZipkinSpanResponse> spans =
-        List.of(
-            TestUtils.createSpanWithTags(
-                "span1",
-                "trace1",
-                null,
-                Map.of(
-                    "kube.app", "app1",
-                    "kube.namespace", "ns1",
-                    "operation_name", "http.request",
-                    "resource", "original_resource",
-                    "tag.operation.canonical_path", "/api/users")));
-
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
-
-    assertThat(graph.nodes()).hasSize(1);
-    Node node = graph.nodes().getFirst();
-    assertThat(node.getMetadata().get("resource")).isEqualTo("/api/users");
-  }
-
-  @Test
-  void buildFromSpans_httpRequestSpanWithoutCanonicalPath_usesOriginalResource() {
-    List<ZipkinSpanResponse> spans =
-        List.of(
-            TestUtils.createSpanWithTags(
-                "span1",
-                "trace1",
-                null,
-                Map.of(
-                    "kube.app", "app1",
-                    "kube.namespace", "ns1",
-                    "operation_name", "http.request",
-                    "resource", "original_resource")));
-
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
-
-    assertThat(graph.nodes()).hasSize(1);
-    Node node = graph.nodes().getFirst();
-    assertThat(node.getMetadata().get("resource")).isEqualTo("original_resource");
-  }
-
-  @Test
-  void buildFromSpans_missingTags_usesDefaultValues() {
-    List<ZipkinSpanResponse> spans =
-        List.of(TestUtils.createSpanWithTags("span1", "trace1", null, Map.of()));
-
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
-
-    assertThat(graph.nodes()).hasSize(1);
-    Node node = graph.nodes().getFirst();
-
-    SortedMap<String, String> expectedMetadata =
-        new TreeMap<>(
-            Map.of(
-                "app", "unknown_app",
-                "namespace", "unknown_namespace",
-                "resource", "unknown_resource"));
-    String expectedId = Node.generateIdFromMetadata(expectedMetadata);
-
-    assertThat(node.getMetadata()).isEqualTo(expectedMetadata);
-    assertThat(node.getId()).isEqualTo(expectedId);
   }
 
   @Test
@@ -226,62 +130,11 @@ public class GraphBuilderTest {
                     "operation_name", "op2",
                     "resource", "res2")));
 
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 
-    assertThat(graph.nodes()).hasSize(1);
-    Node node = graph.nodes().getFirst();
-    assertThat(node.getMetadata().get("app")).isEqualTo("app1");
-  }
-
-  @Test
-  void buildFromSpans_childSpanWithNonExistentParent_createsChildNodeWithoutEdge() {
-    List<ZipkinSpanResponse> spans =
-        List.of(
-            TestUtils.createSpanWithTags(
-                "child1",
-                "trace1",
-                "nonexistent_parent",
-                Map.of(
-                    "kube.app", "app1",
-                    "kube.namespace", "ns1",
-                    "operation_name", "op1",
-                    "resource", "res1")));
-
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
-
-    assertThat(graph.nodes()).hasSize(1);
-    assertThat(graph.edges()).isEmpty();
-  }
-
-  @Test
-  void buildFromSpans_duplicateNodes_deduplicatesNodes() {
-    List<ZipkinSpanResponse> spans =
-        List.of(
-            // two spans that would create the same node
-            TestUtils.createSpanWithTags(
-                "span1",
-                "trace1",
-                null,
-                Map.of(
-                    "kube.app", "app1",
-                    "kube.namespace", "ns1",
-                    "operation_name", "op1",
-                    "resource", "res1")),
-            TestUtils.createSpanWithTags(
-                "span2",
-                "trace1",
-                null,
-                Map.of(
-                    "kube.app", "app1",
-                    "kube.namespace", "ns1",
-                    "operation_name", "op1",
-                    "resource", "res1")));
-
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
-
-    // should only have one unique node
-    assertThat(graph.nodes()).hasSize(1);
-    assertThat(graph.edges()).isEmpty();
+    assertThat(graph.edges()).hasSize(0);
+    // No nodes because there are no edges
+    assertThat(graph.nodes()).hasSize(0);
   }
 
   @Test
@@ -316,7 +169,7 @@ public class GraphBuilderTest {
                     "operation_name", "op3",
                     "resource", "res3")));
 
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 
     assertThat(graph.nodes()).hasSize(3);
     assertThat(graph.edges()).hasSize(2);
@@ -394,7 +247,7 @@ public class GraphBuilderTest {
                     "operation_name", "op2",
                     "resource", "res2")));
 
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 
     // should have 2 nodes (parent and child - child nodes are deduplicated)
     assertThat(graph.nodes()).hasSize(2);
@@ -473,7 +326,7 @@ public class GraphBuilderTest {
                     "resource",
                     "gc_res")));
 
-    Graph graph = configuredGraphBuilder.buildFromSpans(spans);
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 
     assertThat(graph.nodes()).hasSize(4);
     assertThat(graph.edges()).hasSize(3);
@@ -535,21 +388,441 @@ public class GraphBuilderTest {
   }
 
   @Test
-  void buildFromSpans_defaultConfig_usesRemoteEndpointServiceName() {
-    List<ZipkinSpanResponse> spans = new ArrayList<>();
-    ZipkinSpanResponse span = new ZipkinSpanResponse("span1", "trace1");
+  void buildFromSpans_withFilter_includesOnlyMatchingNodesWithEdges() {
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            TestUtils.createSpanWithTags(
+                "parent1",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "app1",
+                    "kube.namespace", "ns1",
+                    "operation_name", "http.request",
+                    "resource", "res1")),
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "ns2",
+                    "operation_name", "http.request",
+                    "resource", "res2")),
+            TestUtils.createSpanWithTags(
+                "child2",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app3",
+                    "kube.namespace", "ns3",
+                    "operation_name", "op3",
+                    "resource", "res3")));
 
-    ZipkinEndpointResponse remoteEndpoint = new ZipkinEndpointResponse();
-    remoteEndpoint.setServiceName("test-service");
-    span.setRemoteEndpoint(remoteEndpoint);
-    span.setTags(Map.of());
+    // Filter to only include nodes with operation "http.request"
+    GraphBuilder.Filter filter = new GraphBuilder.Filter(Map.of("operation", "http.request"));
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
-    spans.add(span);
+    // Should only include parent1 and child1 nodes (both match filter and have edge between them)
+    assertThat(graph.nodes()).hasSize(2);
+    assertThat(graph.edges()).hasSize(1);
 
-    Graph graph = defaultGraphBuilder.buildFromSpans(spans);
+    SortedMap<String, String> parentMetadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "app1",
+                "namespace", "ns1",
+                "resource", "res1"));
+    String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
-    assertThat(graph.nodes()).hasSize(1);
-    Node node = graph.nodes().getFirst();
-    assertThat(node.getMetadata().get("service")).isEqualTo("test-service");
+    SortedMap<String, String> child1Metadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "app2",
+                "namespace", "ns2",
+                "resource", "res2"));
+    String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
+
+    Edge edge = graph.edges().get(0);
+    assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
+    assertThat(edge.targetNodeId()).isEqualTo(expectedChild1Id);
+    assertThat(edge.metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "http.request")));
+  }
+
+  @Test
+  void buildFromSpans_withFilter_skipsIntermediateNonMatchingNodes() {
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            // root - operation: http.request
+            TestUtils.createSpanWithTags(
+                "root",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "root_app",
+                    "kube.namespace", "root_ns",
+                    "operation_name", "http.request",
+                    "resource", "root_res")),
+            // intermediate child - operation: op2 (doesn't match filter)
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "root",
+                Map.of(
+                    "kube.app", "child1_app",
+                    "kube.namespace", "child1_ns",
+                    "operation_name", "op2",
+                    "resource", "child1_res")),
+            // grandchild - operation: http.request (matches filter)
+            TestUtils.createSpanWithTags(
+                "grandchild",
+                "trace1",
+                "child1",
+                Map.of(
+                    "kube.app", "gc_app",
+                    "kube.namespace", "gc_ns",
+                    "operation_name", "http.request",
+                    "resource", "gc_res")));
+
+    // Filter to only include nodes with operation "http.request"
+    GraphBuilder.Filter filter = new GraphBuilder.Filter(Map.of("operation", "http.request"));
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
+
+    // Should include root and grandchild nodes, skipping intermediate child1
+    assertThat(graph.nodes()).hasSize(2);
+    assertThat(graph.edges()).hasSize(1);
+
+    SortedMap<String, String> rootMetadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "root_app",
+                "namespace", "root_ns",
+                "resource", "root_res"));
+    String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
+
+    SortedMap<String, String> grandchildMetadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "gc_app",
+                "namespace", "gc_ns",
+                "resource", "gc_res"));
+    String expectedGrandchildId = Node.generateIdFromMetadata(grandchildMetadata);
+
+    // Should have edge directly from root to grandchild (skipping intermediate)
+    Edge edge = graph.edges().get(0);
+    assertThat(edge.sourceNodeId()).isEqualTo(expectedRootId);
+    assertThat(edge.targetNodeId()).isEqualTo(expectedGrandchildId);
+    assertThat(edge.metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "http.request")));
+  }
+
+  @Test
+  void buildFromSpans_withFilter_noMatchingNodes_returnsEmptyGraph() {
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            TestUtils.createSpanWithTags(
+                "parent1",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "app1",
+                    "kube.namespace", "ns1",
+                    "operation_name", "op1",
+                    "resource", "res1")),
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "ns2",
+                    "operation_name", "op2",
+                    "resource", "res2")));
+
+    // Filter that doesn't match any nodes
+    GraphBuilder.Filter filter =
+        new GraphBuilder.Filter(Map.of("operation", "nonexistent.operation"));
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
+
+    assertThat(graph.nodes()).isEmpty();
+    assertThat(graph.edges()).isEmpty();
+  }
+
+  @Test
+  void buildFromSpans_withFilter_multipleMatchingPaths() {
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            // root - http.request
+            TestUtils.createSpanWithTags(
+                "root",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "root_app",
+                    "kube.namespace", "root_ns",
+                    "operation_name", "http.request",
+                    "resource", "root_res")),
+            // child1 - http.request
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "root",
+                Map.of(
+                    "kube.app", "child1_app",
+                    "kube.namespace", "child1_ns",
+                    "operation_name", "http.request",
+                    "resource", "child1_res")),
+            // child2 - http.request
+            TestUtils.createSpanWithTags(
+                "child2",
+                "trace1",
+                "root",
+                Map.of(
+                    "kube.app", "child2_app",
+                    "kube.namespace", "child2_ns",
+                    "operation_name", "http.request",
+                    "resource", "child2_res")));
+
+    // Filter to only include nodes with operation "http.request"
+    GraphBuilder.Filter filter = new GraphBuilder.Filter(Map.of("operation", "http.request"));
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
+
+    // Should include all 3 nodes since they all match
+    assertThat(graph.nodes()).hasSize(3);
+    // Should have 2 edges: root->child1 and root->child2
+    assertThat(graph.edges()).hasSize(2);
+
+    SortedMap<String, String> rootMetadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "root_app",
+                "namespace", "root_ns",
+                "resource", "root_res"));
+    String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
+
+    // Both edges should originate from root
+    assertThat(graph.edges().stream().allMatch(edge -> edge.sourceNodeId().equals(expectedRootId)))
+        .isTrue();
+  }
+
+  @Test
+  void buildFromSpans_withFilter_multipleDisconnectedSubtreesWithDifferentDepths() {
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            // First subtree: intermediate1 (parent missing) -> child1 -> grandchild1
+            TestUtils.createSpanWithTags(
+                "intermediate1",
+                "trace1",
+                "missingParent1", // parent doesn't exist in span list
+                Map.of(
+                    "kube.app", "int1_app",
+                    "kube.namespace", "int1_ns",
+                    "operation_name", "op1",
+                    "resource", "int1_res")),
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "intermediate1",
+                Map.of(
+                    "kube.app", "child1_app",
+                    "kube.namespace", "child1_ns",
+                    "operation_name", "http.request",
+                    "resource", "child1_res")),
+            TestUtils.createSpanWithTags(
+                "grandchild1",
+                "trace1",
+                "child1",
+                Map.of(
+                    "kube.app", "gc1_app",
+                    "kube.namespace", "gc1_ns",
+                    "operation_name", "http.request",
+                    "resource", "gc1_res")),
+            // Second subtree: non-matching nodes -> matching -> more non-matching -> matching leaf
+            // intermediate2a (parent missing) -> intermediate2b -> intermediate2c -> matching1 ->
+            // intermediate2d -> intermediate2e -> matching2
+            TestUtils.createSpanWithTags(
+                "intermediate2a",
+                "trace1",
+                "missingParent2", // parent doesn't exist in span list
+                Map.of(
+                    "kube.app", "int2a_app",
+                    "kube.namespace", "int2a_ns",
+                    "operation_name", "op2a",
+                    "resource", "int2a_res")),
+            TestUtils.createSpanWithTags(
+                "intermediate2b",
+                "trace1",
+                "intermediate2a",
+                Map.of(
+                    "kube.app", "int2b_app",
+                    "kube.namespace", "int2b_ns",
+                    "operation_name", "op2b",
+                    "resource", "int2b_res")),
+            TestUtils.createSpanWithTags(
+                "intermediate2c",
+                "trace1",
+                "intermediate2b",
+                Map.of(
+                    "kube.app", "int2c_app",
+                    "kube.namespace", "int2c_ns",
+                    "operation_name", "op2c",
+                    "resource", "int2c_res")),
+            TestUtils.createSpanWithTags(
+                "matching1",
+                "trace1",
+                "intermediate2c",
+                Map.of(
+                    "kube.app", "match1_app",
+                    "kube.namespace", "match1_ns",
+                    "operation_name", "http.request",
+                    "resource", "match1_res")),
+            TestUtils.createSpanWithTags(
+                "intermediate2d",
+                "trace1",
+                "matching1",
+                Map.of(
+                    "kube.app", "int2d_app",
+                    "kube.namespace", "int2d_ns",
+                    "operation_name", "op2d",
+                    "resource", "int2d_res")),
+            TestUtils.createSpanWithTags(
+                "intermediate2e",
+                "trace1",
+                "intermediate2d",
+                Map.of(
+                    "kube.app", "int2e_app",
+                    "kube.namespace", "int2e_ns",
+                    "operation_name", "op2e",
+                    "resource", "int2e_res")),
+            TestUtils.createSpanWithTags(
+                "matching2",
+                "trace1",
+                "intermediate2e",
+                Map.of(
+                    "kube.app", "match2_app",
+                    "kube.namespace", "match2_ns",
+                    "operation_name", "http.request",
+                    "resource", "match2_res")));
+
+    // Filter to only include nodes with operation "http.request"
+    GraphBuilder.Filter filter = new GraphBuilder.Filter(Map.of("operation", "http.request"));
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
+
+    // Should include 4 matching nodes from both disconnected subtrees
+    assertThat(graph.nodes()).hasSize(4);
+    // Should have 2 edges: child1->grandchild1 and matching2->leaf2 (skipping multiple non-matching
+    // nodes)
+    assertThat(graph.edges()).hasSize(2);
+
+    SortedMap<String, String> child1Metadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "child1_app",
+                "namespace", "child1_ns",
+                "resource", "child1_res"));
+    String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
+
+    SortedMap<String, String> grandchild1Metadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "gc1_app",
+                "namespace", "gc1_ns",
+                "resource", "gc1_res"));
+    String expectedGrandchild1Id = Node.generateIdFromMetadata(grandchild1Metadata);
+
+    SortedMap<String, String> matching1Metadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "match1_app",
+                "namespace", "match1_ns",
+                "resource", "match1_res"));
+    String expectedMatching1Id = Node.generateIdFromMetadata(matching1Metadata);
+
+    SortedMap<String, String> matching2Metadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "match2_app",
+                "namespace", "match2_ns",
+                "resource", "match2_res"));
+    String expectedMatching2Id = Node.generateIdFromMetadata(matching2Metadata);
+
+    // Verify both disconnected edges exist
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedChild1Id)
+                    && edge.targetNodeId().equals(expectedGrandchild1Id));
+
+    // This edge should skip multiple non-matching intermediate nodes
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedMatching1Id)
+                    && edge.targetNodeId().equals(expectedMatching2Id));
+  }
+
+  @Test
+  void buildFromSpans_withMultipleFilterOptions_matchesAnyOption() {
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            // Parent with operation: http.request
+            TestUtils.createSpanWithTags(
+                "parent1",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "app1",
+                    "kube.namespace", "ns1",
+                    "operation_name", "http.request",
+                    "resource", "res1")),
+            // Child with operation: grpc.request (different operation, but same namespace)
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "ns1",
+                    "operation_name", "grpc.request",
+                    "resource", "res2")),
+            // Grandchild with operation: other (doesn't match either filter option)
+            TestUtils.createSpanWithTags(
+                "grandchild1",
+                "trace1",
+                "child1",
+                Map.of(
+                    "kube.app", "app3",
+                    "kube.namespace", "ns3",
+                    "operation_name", "other.operation",
+                    "resource", "res3")));
+
+    // Filter with two options: matches nodes with either http.request OR grpc.request
+    GraphBuilder.Filter filter =
+        new GraphBuilder.Filter(Map.of("operation", "http.request", "namespace", "ns1"));
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
+
+    // Should include parent1 and child1 (both match at least one filter option)
+    assertThat(graph.nodes()).hasSize(2);
+    assertThat(graph.edges()).hasSize(1);
+
+    SortedMap<String, String> parentMetadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "app1",
+                "namespace", "ns1",
+                "resource", "res1"));
+    String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
+
+    SortedMap<String, String> childMetadata =
+        new TreeMap<>(
+            Map.of(
+                "app", "app2",
+                "namespace", "ns1",
+                "resource", "res2"));
+    String expectedChildId = Node.generateIdFromMetadata(childMetadata);
+
+    Edge edge = graph.edges().get(0);
+    assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
+    assertThat(edge.targetNodeId()).isEqualTo(expectedChildId);
+    assertThat(edge.metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "grpc.request")));
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -73,7 +73,9 @@ public class GraphBuilderTest {
                     "resource",
                     "res2",
                     "tag.http.target.canonical_path",
-                    "/v2/res2")));
+                    "/v2/res2",
+                    "tag.http.target.host",
+                    "app2.ns2")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 
@@ -84,16 +86,14 @@ public class GraphBuilderTest {
     SortedMap<String, String> parentMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "app1",
-                "namespace", "ns1",
+                "service", "app1.ns1",
                 "resource", "res1"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> childMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "app2",
-                "namespace", "ns2",
+                "service", "app2.ns2",
                 "resource", "/v2/res2"));
 
     // uses canonical path as resource
@@ -177,24 +177,21 @@ public class GraphBuilderTest {
     SortedMap<String, String> parentMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "app1",
-                "namespace", "ns1",
+                "service", "app1.ns1",
                 "resource", "res1"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> child1Metadata =
         new TreeMap<>(
             Map.of(
-                "app", "app2",
-                "namespace", "ns2",
+                "service", "app2.ns2",
                 "resource", "res2"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
     SortedMap<String, String> child2Metadata =
         new TreeMap<>(
             Map.of(
-                "app", "app3",
-                "namespace", "ns3",
+                "service", "app3.ns3",
                 "resource", "res3"));
     String expectedChild2Id = Node.generateIdFromMetadata(child2Metadata);
 
@@ -260,16 +257,14 @@ public class GraphBuilderTest {
     SortedMap<String, String> parentMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "app1",
-                "namespace", "ns1",
+                "service", "app1.ns1",
                 "resource", "res1"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> childMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "app2",
-                "namespace", "ns2",
+                "service", "app2.ns2",
                 "resource", "res2"));
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
 
@@ -334,32 +329,28 @@ public class GraphBuilderTest {
     SortedMap<String, String> rootMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "root_app",
-                "namespace", "root_ns",
+                "service", "root_app.root_ns",
                 "resource", "root_res"));
     String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
 
     SortedMap<String, String> child1Metadata =
         new TreeMap<>(
             Map.of(
-                "app", "child1_app",
-                "namespace", "child1_ns",
+                "service", "child1_app.child1_ns",
                 "resource", "child1_res"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
     SortedMap<String, String> child2Metadata =
         new TreeMap<>(
             Map.of(
-                "app", "child2_app",
-                "namespace", "child2_ns",
+                "service", "child2_app.child2_ns",
                 "resource", "child2_res"));
     String expectedChild2Id = Node.generateIdFromMetadata(child2Metadata);
 
     SortedMap<String, String> grandchildMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "gc_app",
-                "namespace", "gc_ns",
+                "service", "gc_app.gc_ns",
                 "resource", "gc_res"));
     String expectedGrandchildId = Node.generateIdFromMetadata(grandchildMetadata);
 
@@ -396,19 +387,35 @@ public class GraphBuilderTest {
                 "trace1",
                 null,
                 Map.of(
-                    "kube.app", "app1",
-                    "kube.namespace", "ns1",
-                    "operation_name", "http.request",
-                    "resource", "res1")),
+                    "kube.app",
+                    "app1",
+                    "kube.namespace",
+                    "ns1",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "res1",
+                    "tag.http.target.canonical_path",
+                    "/v2/target1",
+                    "tag.http.target.host",
+                    "target_app1.target_ns1")),
             TestUtils.createSpanWithTags(
                 "child1",
                 "trace1",
                 "parent1",
                 Map.of(
-                    "kube.app", "app2",
-                    "kube.namespace", "ns2",
-                    "operation_name", "http.request",
-                    "resource", "res2")),
+                    "kube.app",
+                    "app2",
+                    "kube.namespace",
+                    "ns2",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "res2",
+                    "tag.http.target.canonical_path",
+                    "/v2/target2",
+                    "tag.http.target.host",
+                    "target_app2.target_ns2")),
             TestUtils.createSpanWithTags(
                 "child2",
                 "trace1",
@@ -420,7 +427,8 @@ public class GraphBuilderTest {
                     "resource", "res3")));
 
     // Filter to only include nodes with operation "http.request"
-    GraphBuilder.Filter filter = new GraphBuilder.Filter(Map.of("operation", "http.request"));
+    GraphBuilder.Filter filter =
+        new GraphBuilder.Filter(Map.of("operation", List.of("http.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should only include parent1 and child1 nodes (both match filter and have edge between them)
@@ -430,17 +438,15 @@ public class GraphBuilderTest {
     SortedMap<String, String> parentMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "app1",
-                "namespace", "ns1",
-                "resource", "res1"));
+                "service", "target_app1.target_ns1",
+                "resource", "/v2/target1"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> child1Metadata =
         new TreeMap<>(
             Map.of(
-                "app", "app2",
-                "namespace", "ns2",
-                "resource", "res2"));
+                "service", "target_app2.target_ns2",
+                "resource", "/v2/target2"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
     Edge edge = graph.edges().get(0);
@@ -459,10 +465,18 @@ public class GraphBuilderTest {
                 "trace1",
                 null,
                 Map.of(
-                    "kube.app", "root_app",
-                    "kube.namespace", "root_ns",
-                    "operation_name", "http.request",
-                    "resource", "root_res")),
+                    "kube.app",
+                    "root_app",
+                    "kube.namespace",
+                    "root_ns",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "root_res",
+                    "tag.http.target.canonical_path",
+                    "/v2/target1",
+                    "tag.http.target.host",
+                    "target_app1.target_ns1")),
             // intermediate child - operation: op2 (doesn't match filter)
             TestUtils.createSpanWithTags(
                 "child1",
@@ -479,13 +493,22 @@ public class GraphBuilderTest {
                 "trace1",
                 "child1",
                 Map.of(
-                    "kube.app", "gc_app",
-                    "kube.namespace", "gc_ns",
-                    "operation_name", "http.request",
-                    "resource", "gc_res")));
+                    "kube.app",
+                    "gc_app",
+                    "kube.namespace",
+                    "gc_ns",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "gc_res",
+                    "tag.http.target.canonical_path",
+                    "/v2/target2",
+                    "tag.http.target.host",
+                    "target_app2.target_ns2")));
 
     // Filter to only include nodes with operation "http.request"
-    GraphBuilder.Filter filter = new GraphBuilder.Filter(Map.of("operation", "http.request"));
+    GraphBuilder.Filter filter =
+        new GraphBuilder.Filter(Map.of("operation", List.of("http.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should include root and grandchild nodes, skipping intermediate child1
@@ -495,17 +518,15 @@ public class GraphBuilderTest {
     SortedMap<String, String> rootMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "root_app",
-                "namespace", "root_ns",
-                "resource", "root_res"));
+                "service", "target_app1.target_ns1",
+                "resource", "/v2/target1"));
     String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
 
     SortedMap<String, String> grandchildMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "gc_app",
-                "namespace", "gc_ns",
-                "resource", "gc_res"));
+                "service", "target_app2.target_ns2",
+                "resource", "/v2/target2"));
     String expectedGrandchildId = Node.generateIdFromMetadata(grandchildMetadata);
 
     // Should have edge directly from root to grandchild (skipping intermediate)
@@ -540,7 +561,7 @@ public class GraphBuilderTest {
 
     // Filter that doesn't match any nodes
     GraphBuilder.Filter filter =
-        new GraphBuilder.Filter(Map.of("operation", "nonexistent.operation"));
+        new GraphBuilder.Filter(Map.of("operation", List.of("nonexistent.operation")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     assertThat(graph.nodes()).isEmpty();
@@ -557,33 +578,58 @@ public class GraphBuilderTest {
                 "trace1",
                 null,
                 Map.of(
-                    "kube.app", "root_app",
-                    "kube.namespace", "root_ns",
-                    "operation_name", "http.request",
-                    "resource", "root_res")),
+                    "kube.app",
+                    "root_app",
+                    "kube.namespace",
+                    "root_ns",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "root_res",
+                    "tag.http.target.canonical_path",
+                    "/v2/target1",
+                    "tag.http.target.host",
+                    "target_app1.target_ns1")),
             // child1 - http.request
             TestUtils.createSpanWithTags(
                 "child1",
                 "trace1",
                 "root",
                 Map.of(
-                    "kube.app", "child1_app",
-                    "kube.namespace", "child1_ns",
-                    "operation_name", "http.request",
-                    "resource", "child1_res")),
+                    "kube.app",
+                    "child1_app",
+                    "kube.namespace",
+                    "child1_ns",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "child1_res",
+                    "tag.http.target.canonical_path",
+                    "/v2/target2",
+                    "tag.http.target.host",
+                    "target_app2.target_app2")),
             // child2 - http.request
             TestUtils.createSpanWithTags(
                 "child2",
                 "trace1",
                 "root",
                 Map.of(
-                    "kube.app", "child2_app",
-                    "kube.namespace", "child2_ns",
-                    "operation_name", "http.request",
-                    "resource", "child2_res")));
+                    "kube.app",
+                    "child2_app",
+                    "kube.namespace",
+                    "child2_ns",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "child2_res",
+                    "tag.http.target.canonical_path",
+                    "/v2/target3",
+                    "tag.http.target.host",
+                    "target_app3.target+_ns3")));
 
     // Filter to only include nodes with operation "http.request"
-    GraphBuilder.Filter filter = new GraphBuilder.Filter(Map.of("operation", "http.request"));
+    GraphBuilder.Filter filter =
+        new GraphBuilder.Filter(Map.of("operation", List.of("http.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should include all 3 nodes since they all match
@@ -594,9 +640,8 @@ public class GraphBuilderTest {
     SortedMap<String, String> rootMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "root_app",
-                "namespace", "root_ns",
-                "resource", "root_res"));
+                "service", "target_app1.target_ns1",
+                "resource", "/v2/target1"));
     String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
 
     // Both edges should originate from root
@@ -623,19 +668,35 @@ public class GraphBuilderTest {
                 "trace1",
                 "intermediate1",
                 Map.of(
-                    "kube.app", "child1_app",
-                    "kube.namespace", "child1_ns",
-                    "operation_name", "http.request",
-                    "resource", "child1_res")),
+                    "kube.app",
+                    "child1_app",
+                    "kube.namespace",
+                    "child1_ns",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "child1_res",
+                    "tag.http.target.canonical_path",
+                    "/v2/target1",
+                    "tag.http.target.host",
+                    "target_app1.target_ns1")),
             TestUtils.createSpanWithTags(
                 "grandchild1",
                 "trace1",
                 "child1",
                 Map.of(
-                    "kube.app", "gc1_app",
-                    "kube.namespace", "gc1_ns",
-                    "operation_name", "http.request",
-                    "resource", "gc1_res")),
+                    "kube.app",
+                    "gc1_app",
+                    "kube.namespace",
+                    "gc1_ns",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "gc1_res",
+                    "tag.http.target.canonical_path",
+                    "/v2/target2",
+                    "tag.http.target.host",
+                    "target_app2.target_ns2")),
             // Second subtree: non-matching nodes -> matching -> more non-matching -> matching leaf
             // intermediate2a (parent missing) -> intermediate2b -> intermediate2c -> matching1 ->
             // intermediate2d -> intermediate2e -> matching2
@@ -671,10 +732,18 @@ public class GraphBuilderTest {
                 "trace1",
                 "intermediate2c",
                 Map.of(
-                    "kube.app", "match1_app",
-                    "kube.namespace", "match1_ns",
-                    "operation_name", "http.request",
-                    "resource", "match1_res")),
+                    "kube.app",
+                    "match1_app",
+                    "kube.namespace",
+                    "match1_ns",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "match1_res",
+                    "tag.http.target.canonical_path",
+                    "/v2/target3",
+                    "tag.http.target.host",
+                    "target_app3.target_ns3")),
             TestUtils.createSpanWithTags(
                 "intermediate2d",
                 "trace1",
@@ -698,13 +767,22 @@ public class GraphBuilderTest {
                 "trace1",
                 "intermediate2e",
                 Map.of(
-                    "kube.app", "match2_app",
-                    "kube.namespace", "match2_ns",
-                    "operation_name", "http.request",
-                    "resource", "match2_res")));
+                    "kube.app",
+                    "match2_app",
+                    "kube.namespace",
+                    "match2_ns",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "match2_res",
+                    "tag.http.target.canonical_path",
+                    "/v2/target4",
+                    "tag.http.target.host",
+                    "target_app4.target_ns4")));
 
     // Filter to only include nodes with operation "http.request"
-    GraphBuilder.Filter filter = new GraphBuilder.Filter(Map.of("operation", "http.request"));
+    GraphBuilder.Filter filter =
+        new GraphBuilder.Filter(Map.of("operation", List.of("http.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should include 4 matching nodes from both disconnected subtrees
@@ -716,33 +794,29 @@ public class GraphBuilderTest {
     SortedMap<String, String> child1Metadata =
         new TreeMap<>(
             Map.of(
-                "app", "child1_app",
-                "namespace", "child1_ns",
-                "resource", "child1_res"));
+                "service", "target_app1.target_ns1",
+                "resource", "/v2/target1"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
     SortedMap<String, String> grandchild1Metadata =
         new TreeMap<>(
             Map.of(
-                "app", "gc1_app",
-                "namespace", "gc1_ns",
-                "resource", "gc1_res"));
+                "service", "target_app2.target_ns2",
+                "resource", "/v2/target2"));
     String expectedGrandchild1Id = Node.generateIdFromMetadata(grandchild1Metadata);
 
     SortedMap<String, String> matching1Metadata =
         new TreeMap<>(
             Map.of(
-                "app", "match1_app",
-                "namespace", "match1_ns",
-                "resource", "match1_res"));
+                "service", "target_app3.target_ns3",
+                "resource", "/v2/target3"));
     String expectedMatching1Id = Node.generateIdFromMetadata(matching1Metadata);
 
     SortedMap<String, String> matching2Metadata =
         new TreeMap<>(
             Map.of(
-                "app", "match2_app",
-                "namespace", "match2_ns",
-                "resource", "match2_res"));
+                "service", "target_app4.target_ns4",
+                "resource", "/v2/target4"));
     String expectedMatching2Id = Node.generateIdFromMetadata(matching2Metadata);
 
     // Verify both disconnected edges exist
@@ -770,20 +844,38 @@ public class GraphBuilderTest {
                 "trace1",
                 null,
                 Map.of(
-                    "kube.app", "app1",
-                    "kube.namespace", "ns1",
-                    "operation_name", "http.request",
-                    "resource", "res1")),
-            // Child with operation: grpc.request (different operation, but same namespace)
+                    "kube.app",
+                    "app1",
+                    "kube.namespace",
+                    "ns1",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "res1",
+                    "tag.http.target.canonical_path",
+                    "/v2/target1",
+                    "tag.http.target.host",
+                    "target_app1.target_ns1")),
+            // Child with operation: grpc.request
             TestUtils.createSpanWithTags(
                 "child1",
                 "trace1",
                 "parent1",
+                // this should use the default key since there are no rules for grpc.request
+                // operations
                 Map.of(
-                    "kube.app", "app2",
-                    "kube.namespace", "ns1",
-                    "operation_name", "grpc.request",
-                    "resource", "res2")),
+                    "kube.app",
+                    "app2",
+                    "kube.namespace",
+                    "ns2",
+                    "operation_name",
+                    "grpc.request",
+                    "resource",
+                    "res2",
+                    "tag.http.target.canonical_path",
+                    "/v2/target2",
+                    "tag.http.target.host",
+                    "target_app2.target_ns2")),
             // Grandchild with operation: other (doesn't match either filter option)
             TestUtils.createSpanWithTags(
                 "grandchild1",
@@ -797,7 +889,7 @@ public class GraphBuilderTest {
 
     // Filter with two options: matches nodes with either http.request OR grpc.request
     GraphBuilder.Filter filter =
-        new GraphBuilder.Filter(Map.of("operation", "http.request", "namespace", "ns1"));
+        new GraphBuilder.Filter(Map.of("operation", List.of("http.request", "grpc.request")));
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
 
     // Should include parent1 and child1 (both match at least one filter option)
@@ -807,16 +899,14 @@ public class GraphBuilderTest {
     SortedMap<String, String> parentMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "app1",
-                "namespace", "ns1",
-                "resource", "res1"));
+                "service", "target_app1.target_ns1",
+                "resource", "/v2/target1"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> childMetadata =
         new TreeMap<>(
             Map.of(
-                "app", "app2",
-                "namespace", "ns1",
+                "service", "app2.ns2",
                 "resource", "res2"));
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
 

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -915,4 +915,45 @@ public class GraphBuilderTest {
     assertThat(edge.targetNodeId()).isEqualTo(expectedChildId);
     assertThat(edge.metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "grpc.request")));
   }
+
+  @Test
+  void buildFromSpans_withEmptyFilter_returnsAllNodes() {
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            TestUtils.createSpanWithTags(
+                "parent1",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "app1",
+                    "kube.namespace", "ns1",
+                    "operation_name", "op1",
+                    "resource", "res1")),
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "ns2",
+                    "operation_name", "op2",
+                    "resource", "res2")),
+            TestUtils.createSpanWithTags(
+                "child2",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app3",
+                    "kube.namespace", "ns3",
+                    "operation_name", "op3",
+                    "resource", "res3")));
+
+    // Empty filter - should match all nodes
+    GraphBuilder.Filter emptyFilter = new GraphBuilder.Filter(Map.of());
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(emptyFilter));
+
+    // Should include all nodes and edges (same as no filter)
+    assertThat(graph.nodes()).hasSize(3);
+    assertThat(graph.edges()).hasSize(2);
+  }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -1377,7 +1377,7 @@ public class GraphBuilderTest {
   }
 
   @Test
-  void buildFromSpans_selfLoopSameLogicalNode_buildsCorrectGraph() {
+  void buildFromSpans_withFilterSelfLoopSameLogicalNode_buildsCorrectGraph() {
     List<ZipkinSpanResponse> spans =
         new ArrayList<>(
             List.of(

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -1375,4 +1375,83 @@ public class GraphBuilderTest {
                 edge.sourceNodeId().equals(expectedNodeFId)
                     && edge.targetNodeId().equals(expectedNodeGId));
   }
+
+  @Test
+  void buildFromSpans_selfLoopSameLogicalNode_buildsCorrectGraph() {
+    List<ZipkinSpanResponse> spans =
+        new ArrayList<>(
+            List.of(
+                TestUtils.createSpanWithTags(
+                    "spanA",
+                    "trace1",
+                    null,
+                    Map.of(
+                        "kube.app",
+                        "app1",
+                        "kube.namespace",
+                        "ns1",
+                        "operation_name",
+                        "dropwizard.request",
+                        "resource",
+                        "res1")),
+                TestUtils.createSpanWithTags(
+                    "spanB",
+                    "trace1",
+                    "spanA",
+                    Map.of(
+                        "tag.http.target.host",
+                        "app2.ns2",
+                        "tag.http.target.canonical_path",
+                        "/v1/targetB",
+                        "operation_name",
+                        "http.request")),
+                // spanB and spanC point to the same logical node, but have different operations
+                TestUtils.createSpanWithTags(
+                    "spanC",
+                    "trace1",
+                    "spanB",
+                    Map.of(
+                        "kube.app",
+                        "app2",
+                        "kube.namespace",
+                        "ns2",
+                        "operation_name",
+                        "dropwizard.request",
+                        "resource",
+                        "/v1/targetB"))));
+
+    GraphBuilder.Filter filter =
+        new GraphBuilder.Filter(Map.of("operation_name", List.of("dropwizard.request")));
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
+
+    // Should include A, B (all match filter)
+    assertThat(graph.nodes()).hasSize(2);
+
+    // Expect 1 edge A -> B (dropwizard.request)
+    assertThat(graph.edges()).hasSize(1);
+
+    SortedMap<String, String> nodeAMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "app1.ns1",
+                "resource", "res1"));
+    String expectedNodeAId = Node.generateIdFromMetadata(nodeAMetadata);
+
+    SortedMap<String, String> nodeBMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "app2.ns2",
+                "resource", "/v1/targetB"));
+    String expectedNodeBId = Node.generateIdFromMetadata(nodeBMetadata);
+
+    // A -> B
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeAId)
+                    && edge.targetNodeId().equals(expectedNodeBId));
+
+    Edge edge = graph.edges().get(0);
+    assertThat(edge.metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "dropwizard.request")));
+  }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -379,6 +379,169 @@ public class GraphBuilderTest {
   }
 
   @Test
+  void buildFromSpans_noFilterWithCycles_buildCorrectGraph() {
+    // Topology: A -> spanB1 -> C
+    //           D -> spanB2 -> E
+    //           E -> spanB3 (creates cycle back to node B)
+    // where spanB1, spanB2, spanB3 all represent the same logical node
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            // Root span A
+            TestUtils.createSpanWithTags(
+                "spanA",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "appA",
+                    "kube.namespace", "nsA",
+                    "operation_name", "opA",
+                    "resource", "resA")),
+            // Span B1 - child of A
+            TestUtils.createSpanWithTags(
+                "spanB1",
+                "trace1",
+                "spanA",
+                Map.of(
+                    "kube.app", "appB",
+                    "kube.namespace", "nsB",
+                    "operation_name", "opB",
+                    "resource", "resB")),
+            // Span C - child of B1
+            TestUtils.createSpanWithTags(
+                "spanC",
+                "trace1",
+                "spanB1",
+                Map.of(
+                    "kube.app", "appC",
+                    "kube.namespace", "nsC",
+                    "operation_name", "opC",
+                    "resource", "resC")),
+            // Span D - another root
+            TestUtils.createSpanWithTags(
+                "spanD",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "appD",
+                    "kube.namespace", "nsD",
+                    "operation_name", "opD",
+                    "resource", "resD")),
+            // Span B2 - child of D
+            TestUtils.createSpanWithTags(
+                "spanB2",
+                "trace1",
+                "spanD",
+                Map.of(
+                    "kube.app", "appB",
+                    "kube.namespace", "nsB",
+                    "operation_name", "opB",
+                    "resource", "resB")),
+            // Span E - child of B2
+            TestUtils.createSpanWithTags(
+                "spanE",
+                "trace1",
+                "spanB2",
+                Map.of(
+                    "kube.app", "appE",
+                    "kube.namespace", "nsE",
+                    "operation_name", "opE",
+                    "resource", "resE")),
+            // Span B3 - child of E, creates cycle back to node B
+            TestUtils.createSpanWithTags(
+                "spanB3",
+                "trace1",
+                "spanE",
+                Map.of(
+                    "kube.app", "appB",
+                    "kube.namespace", "nsB",
+                    "operation_name", "opB",
+                    "resource", "resB")));
+
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
+
+    // Should have 5 nodes: A, B, C, D, E
+    assertThat(graph.nodes()).hasSize(5);
+
+    // Should have edges: A->B, B->C, D->B, B->E, E->B (cycle)
+    assertThat(graph.edges()).hasSize(5);
+
+    SortedMap<String, String> nodeAMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "appA.nsA",
+                "resource", "resA"));
+    String expectedNodeAId = Node.generateIdFromMetadata(nodeAMetadata);
+
+    SortedMap<String, String> nodeBMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "appB.nsB",
+                "resource", "resB"));
+    String expectedNodeBId = Node.generateIdFromMetadata(nodeBMetadata);
+
+    SortedMap<String, String> nodeCMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "appC.nsC",
+                "resource", "resC"));
+    String expectedNodeCId = Node.generateIdFromMetadata(nodeCMetadata);
+
+    SortedMap<String, String> nodeDMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "appD.nsD",
+                "resource", "resD"));
+    String expectedNodeDId = Node.generateIdFromMetadata(nodeDMetadata);
+
+    SortedMap<String, String> nodeEMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "appE.nsE",
+                "resource", "resE"));
+    String expectedNodeEId = Node.generateIdFromMetadata(nodeEMetadata);
+
+    // A -> B
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeAId)
+                    && edge.targetNodeId().equals(expectedNodeBId)
+                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opB"))));
+
+    // B -> C
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeBId)
+                    && edge.targetNodeId().equals(expectedNodeCId)
+                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opC"))));
+
+    // D -> B
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeDId)
+                    && edge.targetNodeId().equals(expectedNodeBId)
+                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opB"))));
+
+    // B -> E
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeBId)
+                    && edge.targetNodeId().equals(expectedNodeEId)
+                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opE"))));
+
+    // E -> B
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeEId)
+                    && edge.targetNodeId().equals(expectedNodeBId)
+                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opB"))));
+  }
+
+  @Test
   void buildFromSpans_withFilter_includesOnlyMatchingNodesWithEdges() {
     List<ZipkinSpanResponse> spans =
         List.of(
@@ -955,5 +1118,261 @@ public class GraphBuilderTest {
     // Should include all nodes and edges (same as no filter)
     assertThat(graph.nodes()).hasSize(3);
     assertThat(graph.edges()).hasSize(2);
+  }
+
+  @Test
+  void buildFromSpans_withFilterAndCycles_buildsCorrectGraph() {
+    // Combined test demonstrating both forward and backward transitive dependencies with cycles:
+    //
+    // Topology:
+    // A (http.request) -> B (op2) -> C (http.request) -> D (op2) -> E (http.request), B -> G
+    // Add cycles: E -> B (backward), C -> F (http.request) -> B (backward)
+    //
+    // This demonstrates:
+    // 1. Forward transitive deps: A -> C (through B), A -> G (through B),
+    // C -> E (through D), C -> F (direct)
+    // 2. Backward transitive deps via cycles: E -> C (backward through B),
+    // F -> C (backward through B)
+    // 3. Handles cycles without infinite loops
+    List<ZipkinSpanResponse> spans =
+        new ArrayList<>(
+            List.of(
+                // Root span A - matches filter
+                TestUtils.createSpanWithTags(
+                    "spanA",
+                    "trace1",
+                    null,
+                    Map.of(
+                        "kube.app",
+                        "appA",
+                        "kube.namespace",
+                        "nsA",
+                        "operation_name",
+                        "http.request",
+                        "resource",
+                        "resA",
+                        "tag.http.target.canonical_path",
+                        "/v2/targetA",
+                        "tag.http.target.host",
+                        "targetA.nsA")),
+                // Span B - doesn't match filter, child of A
+                TestUtils.createSpanWithTags(
+                    "spanB",
+                    "trace1",
+                    "spanA",
+                    Map.of(
+                        "kube.app", "appB",
+                        "kube.namespace", "nsB",
+                        "operation_name", "op2",
+                        "resource", "resB")),
+                // Span C - matches filter, child of B
+                TestUtils.createSpanWithTags(
+                    "spanC",
+                    "trace1",
+                    "spanB",
+                    Map.of(
+                        "kube.app",
+                        "appC",
+                        "kube.namespace",
+                        "nsC",
+                        "operation_name",
+                        "http.request",
+                        "resource",
+                        "resC",
+                        "tag.http.target.canonical_path",
+                        "/v2/targetC",
+                        "tag.http.target.host",
+                        "targetC.nsC")),
+                // Span D - doesn't match filter, child of C
+                TestUtils.createSpanWithTags(
+                    "spanD",
+                    "trace1",
+                    "spanC",
+                    Map.of(
+                        "kube.app", "appD",
+                        "kube.namespace", "nsD",
+                        "operation_name", "op2",
+                        "resource", "resD")),
+                // Span E - matches filter, child of D
+                TestUtils.createSpanWithTags(
+                    "spanE",
+                    "trace1",
+                    "spanD",
+                    Map.of(
+                        "kube.app",
+                        "appE",
+                        "kube.namespace",
+                        "nsE",
+                        "operation_name",
+                        "http.request",
+                        "resource",
+                        "resE",
+                        "tag.http.target.canonical_path",
+                        "/v2/targetE",
+                        "tag.http.target.host",
+                        "targetE.nsE")),
+                // Span F - matches filter, child of C (parallel to D)
+                TestUtils.createSpanWithTags(
+                    "spanF",
+                    "trace1",
+                    "spanC",
+                    Map.of(
+                        "kube.app",
+                        "appF",
+                        "kube.namespace",
+                        "nsF",
+                        "operation_name",
+                        "http.request",
+                        "resource",
+                        "resF",
+                        "tag.http.target.canonical_path",
+                        "/v2/targetF",
+                        "tag.http.target.host",
+                        "targetF.nsF")),
+                // Create backward cycle: E -> B
+                TestUtils.createSpanWithTags(
+                    "spanB_from_E",
+                    "trace1",
+                    "spanE",
+                    Map.of(
+                        "kube.app", "appB",
+                        "kube.namespace", "nsB",
+                        "operation_name", "op2",
+                        "resource", "resB")),
+                // Create another backward cycle: F -> B (another path back)
+                TestUtils.createSpanWithTags(
+                    "spanB_from_F",
+                    "trace1",
+                    "spanF",
+                    Map.of(
+                        "kube.app", "appB",
+                        "kube.namespace", "nsB",
+                        "operation_name", "op2",
+                        "resource", "resB")),
+                // Add a child from spanB_from_E to demonstrate that children of sibling spans
+                // are discovered even when visitedNodes skips the sibling span itself
+                TestUtils.createSpanWithTags(
+                    "spanG",
+                    "trace1",
+                    "spanB_from_E",
+                    Map.of(
+                        "kube.app",
+                        "appG",
+                        "kube.namespace",
+                        "nsG",
+                        "operation_name",
+                        "http.request",
+                        "resource",
+                        "resG",
+                        "tag.http.target.canonical_path",
+                        "/v2/targetG",
+                        "tag.http.target.host",
+                        "targetG.nsG"))));
+
+    GraphBuilder.Filter filter =
+        new GraphBuilder.Filter(Map.of("operation_name", List.of("http.request")));
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.of(filter));
+
+    // Should include A, C, E, F, G (all match filter)
+    assertThat(graph.nodes()).hasSize(5);
+
+    // Expect 8 edges (original 5 + A->G + E->G + F->G)
+    // The key insight: when traversing from A through node B, ALL sibling spans of B
+    // (spanB, spanB_from_E, spanB_from_F) are processed together, discovering:
+    //   - C (child of spanB)
+    //   - G (child of spanB_from_E)
+    // So we get: A->C, A->G, C->E, C->F, E->C, F->C, E->G, F->G
+    assertThat(graph.edges()).hasSize(8);
+
+    SortedMap<String, String> nodeAMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "targetA.nsA",
+                "resource", "/v2/targetA"));
+    String expectedNodeAId = Node.generateIdFromMetadata(nodeAMetadata);
+
+    SortedMap<String, String> nodeCMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "targetC.nsC",
+                "resource", "/v2/targetC"));
+    String expectedNodeCId = Node.generateIdFromMetadata(nodeCMetadata);
+
+    SortedMap<String, String> nodeEMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "targetE.nsE",
+                "resource", "/v2/targetE"));
+    String expectedNodeEId = Node.generateIdFromMetadata(nodeEMetadata);
+
+    SortedMap<String, String> nodeFMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "targetF.nsF",
+                "resource", "/v2/targetF"));
+    String expectedNodeFId = Node.generateIdFromMetadata(nodeFMetadata);
+
+    SortedMap<String, String> nodeGMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "targetG.nsG",
+                "resource", "/v2/targetG"));
+    String expectedNodeGId = Node.generateIdFromMetadata(nodeGMetadata);
+
+    // A -> C
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeAId)
+                    && edge.targetNodeId().equals(expectedNodeCId));
+
+    // A -> G
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeAId)
+                    && edge.targetNodeId().equals(expectedNodeGId));
+
+    // C -> E
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeCId)
+                    && edge.targetNodeId().equals(expectedNodeEId));
+
+    // C -> F
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeCId)
+                    && edge.targetNodeId().equals(expectedNodeFId));
+
+    // E -> C
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeEId)
+                    && edge.targetNodeId().equals(expectedNodeCId));
+
+    // F -> C
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeFId)
+                    && edge.targetNodeId().equals(expectedNodeCId));
+
+    // E -> G
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeEId)
+                    && edge.targetNodeId().equals(expectedNodeGId));
+
+    // F -> G
+    assertThat(graph.edges())
+        .anyMatch(
+            edge ->
+                edge.sourceNodeId().equals(expectedNodeFId)
+                    && edge.targetNodeId().equals(expectedNodeGId));
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -403,6 +403,134 @@ public class GraphConfigTest {
   }
 
   @Test
+  public void testResolveWithDelimiterAndPart_validIndex() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                          node_metadata_tag_mapping:
+                            app:
+                              default_key: kube.app
+                              default_value: unknown_app
+                              rules:
+                                - field: operation_name
+                                  value: http.request
+                                  override_key: target_app
+                                  delimiter: .
+                                  part: 0
+                          """);
+    Map<String, String> tags =
+        Map.of(
+            "operation_name", "http.request",
+            "target_app", "my-app.example.com");
+
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    assertThat(result).isEqualTo("my-app");
+  }
+
+  @Test
+  public void testResolveWithDelimiterAndPart_outOfBoundsIndex() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                          node_metadata_tag_mapping:
+                            app:
+                              default_key: kube.app
+                              default_value: unknown_app
+                              rules:
+                                - field: operation_name
+                                  value: http.request
+                                  override_key: target_app
+                                  delimiter: .
+                                  part: 10
+                          """);
+    Map<String, String> tags =
+        Map.of(
+            "operation_name", "http.request",
+            "target_app", "my-app.example.com");
+
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    // Should keep original value when part index is out of bounds
+    assertThat(result).isEqualTo("my-app.example.com");
+  }
+
+  @Test
+  public void testResolveWithDelimiterAndPart_noDelimiterInValue() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                          node_metadata_tag_mapping:
+                            app:
+                              default_key: kube.app
+                              default_value: unknown_app
+                              rules:
+                                - field: operation_name
+                                  value: http.request
+                                  override_key: target_app
+                                  delimiter: .
+                                  part: 1
+                          """);
+    Map<String, String> tags =
+        Map.of(
+            "operation_name", "http.request",
+            "target_app", "localhost");
+
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    // Should keep original value when there's no delimiter
+    assertThat(result).isEqualTo("localhost");
+  }
+
+  @Test
+  public void testResolveWithDelimiterAndPart_multipleDelimiters() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                          node_metadata_tag_mapping:
+                            app:
+                              default_key: kube.app
+                              default_value: unknown_app
+                              rules:
+                                - field: operation_name
+                                  value: http.request
+                                  override_key: target_app
+                                  delimiter: .
+                                  part: 2
+                          """);
+    Map<String, String> tags =
+        Map.of(
+            "operation_name", "http.request",
+            "target_app", "my-app.example.com");
+
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    assertThat(result).isEqualTo("com");
+  }
+
+  @Test
+  public void testResolveWithDelimiterAndPart_noMatchingRule() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                          node_metadata_tag_mapping:
+                            app:
+                              default_key: kube.app
+                              default_value: unknown_app
+                              rules:
+                                - field: operation_name
+                                  value: http.request
+                                  override_key: target_app
+                                  delimiter: .
+                                  part: 0
+                          """);
+    Map<String, String> tags =
+        Map.of(
+            "operation_name", "grpc.request",
+            "kube.app", "my-app");
+
+    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    // Should use default key without delimiter splitting
+    assertThat(result).isEqualTo("my-app");
+  }
+
+  @Test
   public void testCreateNodeMetadataFromSpan_defaultConfig_usesRemoteEndpointServiceName() {
     GraphConfig config = GraphConfig.DEFAULT;
     ZipkinSpanResponse span =

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -19,26 +19,32 @@ public class GraphConfigTest {
         """
               node_metadata_tag_mapping:
                 service:
-                  default_key: service.name
+                  default_key:
+                    - service.name
                   default_value: unknown_service
                   rules:
                     - field: cluster.name
                       value: prod
-                      override_key: prod.service.name
+                      override_key:
+                        - prod.service.name
                     - field: cluster.name
                       value: staging
-                      override_key: test.service.name
+                      override_key:
+                        - test.service.name
                 cluster:
-                  default_key: cluster.name
+                  default_key:
+                    - cluster.name
                   default_value: unknown_cluster
               edge_metadata_tag_mapping:
                 operation:
-                  default_key: operation_name
+                  default_key:
+                    - operation_name
                   default_value: unknown_operation
                   rules:
                     - field: cluster.name
                       value: prod
-                      override_key: operation.prod
+                      override_key:
+                        - operation.prod
               """;
 
     Path configFile = tempDir.resolve("test-config.yaml");
@@ -51,28 +57,28 @@ public class GraphConfigTest {
     assertThat(config.getEdgeMetadataTagMapping()).hasSize(1);
 
     GraphConfig.TagConfig serviceConfig = config.getNodeMetadataTagMapping().get("service");
-    assertThat(serviceConfig.getDefaultKey()).isEqualTo("service.name");
+    assertThat(serviceConfig.getDefaultKey()).containsExactly("service.name");
     assertThat(serviceConfig.getDefaultValue()).isEqualTo("unknown_service");
     assertThat(serviceConfig.getRules()).hasSize(2);
 
     GraphConfig.RuleConfig rule1 = serviceConfig.getRules().getFirst();
-    assertThat(rule1.getOverrideKey()).isEqualTo("prod.service.name");
+    assertThat(rule1.getOverrideKey()).containsExactly("prod.service.name");
     assertThat(rule1.getField()).isEqualTo("cluster.name");
     assertThat(rule1.getValue()).isEqualTo("prod");
 
     GraphConfig.RuleConfig rule2 = serviceConfig.getRules().get(1);
-    assertThat(rule2.getOverrideKey()).isEqualTo("test.service.name");
+    assertThat(rule2.getOverrideKey()).containsExactly("test.service.name");
     assertThat(rule2.getField()).isEqualTo("cluster.name");
     assertThat(rule2.getValue()).isEqualTo("staging");
 
     GraphConfig.TagConfig clusterConfig = config.getNodeMetadataTagMapping().get("cluster");
-    assertThat(clusterConfig.getDefaultKey()).isEqualTo("cluster.name");
+    assertThat(clusterConfig.getDefaultKey()).containsExactly("cluster.name");
     assertThat(clusterConfig.getDefaultValue()).isEqualTo("unknown_cluster");
     assertThat(clusterConfig.getRules()).hasSize(0);
 
     GraphConfig.TagConfig connectionTypeConfig =
         config.getEdgeMetadataTagMapping().get("operation");
-    assertThat(connectionTypeConfig.getDefaultKey()).isEqualTo("operation_name");
+    assertThat(connectionTypeConfig.getDefaultKey()).containsExactly("operation_name");
     assertThat(connectionTypeConfig.getDefaultValue()).isEqualTo("unknown_operation");
     assertThat(connectionTypeConfig.getRules()).hasSize(1);
   }
@@ -111,14 +117,17 @@ public class GraphConfigTest {
             """
              node_metadata_tag_mapping:
                app:
-                 default_key: app.name
+                 default_key:
+                   - app.name
                  default_value: unknown_app
                namespace:
-                 default_key: namespace.name
+                 default_key:
+                   - namespace.name
                  default_value: unknown_namespace
              edge_metadata_tag_mapping:
                operation:
-                 default_key: operation_name
+                 default_key:
+                   - operation_name
                  default_value: unknown_operation
              """);
     Map<String, String> tags = new HashMap<>();
@@ -139,14 +148,17 @@ public class GraphConfigTest {
             """
               node_metadata_tag_mapping:
                 app:
-                  default_key: app.name
+                  default_key:
+                    - app.name
                   default_value: unknown_app
                 namespace:
-                  default_key: namespace.name
+                  default_key:
+                    - namespace.name
                   default_value: unknown_namespace
               edge_metadata_tag_mapping:
                operation:
-                 default_key: operation_name
+                 default_key:
+                   - operation_name
                  default_value: unknown_operation
               """);
     Map<String, String> tags = Map.of("some.tag", "some-value");
@@ -167,26 +179,32 @@ public class GraphConfigTest {
             """
               node_metadata_tag_mapping:
                 app:
-                  default_key: app.name
+                  default_key:
+                    - app.name
                   default_value: unknown_app
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: prod.app.name
+                      override_key:
+                        - prod.app.name
                     - field: cluster.name
                       value: east
-                      override_key: east.app.name
+                      override_key:
+                        - east.app.name
                 namespace:
-                  default_key: namespace.name
+                  default_key:
+                    - namespace.name
                   default_value: unknown_namespace
               edge_metadata_tag_mapping:
                 operation:
-                  default_key: operation_name
+                  default_key:
+                    - operation_name
                   default_value: unknown_operation
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: operation.prod
+                      override_key:
+                        - operation.prod
               """);
     Map<String, String> tags =
         Map.of(
@@ -215,38 +233,44 @@ public class GraphConfigTest {
             """
               node_metadata_tag_mapping:
                 app:
-                  default_key: app.name
+                  default_key:
+                    - app.name
                   default_value: unknown_app
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: prod.app.name
+                      override_key:
+                        - prod.app.name
                     - field: cluster.name
                       value: east
-                      override_key: east.app.name
+                      override_key:
+                        - east.app.name
                 namespace:
-                  default_key: namespace.name
+                  default_key:
+                    - namespace.name
                   default_value: unknown_namespace
               edge_metadata_tag_mapping:
                 operation:
-                  default_key: operation_name
+                  default_key:
+                    - operation_name
                   default_value: unknown_operation
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: operation.prod
+                      override_key:
+                        - operation.prod
               """);
     Map<String, String> tags =
         Map.of(
             "app.name", "my-app", "namespace.name", "prod-ns", "operation_name", "some_operation");
 
-    // Node
+    // Node - rule matches but override key is missing, should return default value
     String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
-    assertThat(result).isEqualTo("my-app");
+    assertThat(result).isEqualTo("unknown_app");
 
-    // Edge
+    // Edge - rule matches but override key is missing, should return default value
     result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
-    assertThat(result).isEqualTo("some_operation");
+    assertThat(result).isEqualTo("unknown_operation");
   }
 
   @Test
@@ -256,26 +280,32 @@ public class GraphConfigTest {
             """
               node_metadata_tag_mapping:
                 app:
-                  default_key: app.name
+                  default_key:
+                    - app.name
                   default_value: unknown_app
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: prod.app.name
+                      override_key:
+                        - prod.app.name
                     - field: cluster.name
                       value: east
-                      override_key: east.app.name
+                      override_key:
+                        - east.app.name
                 namespace:
-                  default_key: namespace.name
+                  default_key:
+                    - namespace.name
                   default_value: unknown_namespace
               edge_metadata_tag_mapping:
                 operation:
-                  default_key: operation_name
+                  default_key:
+                    - operation_name
                   default_value: unknown_operation
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: operation.prod
+                      override_key:
+                        - operation.prod
               """);
     Map<String, String> tags =
         Map.of(
@@ -297,29 +327,36 @@ public class GraphConfigTest {
             """
               node_metadata_tag_mapping:
                 app:
-                  default_key: app.name
+                  default_key:
+                    - app.name
                   default_value: unknown_app
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: prod.app.name
+                      override_key:
+                        - prod.app.name
                     - field: cluster.name
                       value: east
-                      override_key: east.app.name
+                      override_key:
+                        - east.app.name
                 namespace:
-                  default_key: namespace.name
+                  default_key:
+                    - namespace.name
                   default_value: unknown_namespace
               edge_metadata_tag_mapping:
                 operation:
-                  default_key: operation_name
+                  default_key:
+                    - operation_name
                   default_value: unknown_operation
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: operation.prod
+                      override_key:
+                        - operation.prod
                     - field: cluster.name
                       value: east
-                      override_key: operation.east
+                      override_key:
+                        - operation.east
               """);
     Map<String, String> tags =
         Map.of(
@@ -356,29 +393,36 @@ public class GraphConfigTest {
             """
               node_metadata_tag_mapping:
                 app:
-                  default_key: app.name
+                  default_key:
+                    - app.name
                   default_value: unknown_app
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: prod.app.name
+                      override_key:
+                        - prod.app.name
                     - field: cluster.name
                       value: east
-                      override_key: east.app.name
+                      override_key:
+                        - east.app.name
                 namespace:
-                  default_key: namespace.name
+                  default_key:
+                    - namespace.name
                   default_value: unknown_namespace
               edge_metadata_tag_mapping:
                 operation:
-                  default_key: operation_name
+                  default_key:
+                    - operation_name
                   default_value: unknown_operation
                   rules:
                     - field: namespace.name
                       value: prod-ns
-                      override_key: operation.prod
+                      override_key:
+                        - operation.prod
                     - field: cluster.name
                       value: east
-                      override_key: operation_east
+                      override_key:
+                        - operation_east
               """);
     Map<String, String> tags =
         Map.of(
@@ -403,131 +447,130 @@ public class GraphConfigTest {
   }
 
   @Test
-  public void testResolveWithDelimiterAndPart_validIndex() throws IOException {
+  public void testResolveWithMultipleDefaultKeys() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
                           node_metadata_tag_mapping:
-                            app:
-                              default_key: kube.app
-                              default_value: unknown_app
-                              rules:
-                                - field: operation_name
-                                  value: http.request
-                                  override_key: target_app
-                                  delimiter: .
-                                  part: 0
+                            service:
+                              default_key:
+                                - kube.app
+                                - kube.namespace
+                              default_value: unknown_service
+                              key_delimiter: .
                           """);
-    Map<String, String> tags =
-        Map.of(
-            "operation_name", "http.request",
-            "target_app", "my-app.example.com");
+    Map<String, String> tags = Map.of("kube.app", "my-app", "kube.namespace", "prod");
 
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
+    assertThat(result).isEqualTo("my-app.prod");
+  }
+
+  @Test
+  public void testResolveWithMultipleDefaultKeys_missingKey() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                          node_metadata_tag_mapping:
+                            service:
+                              default_key:
+                                - kube.app
+                                - kube.namespace
+                              default_value: unknown_service
+                              key_delimiter: .
+                          """);
+    Map<String, String> tags = Map.of("kube.app", "my-app");
+
+    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
+    // Should return default value when any key is missing
+    assertThat(result).isEqualTo("unknown_service");
+  }
+
+  @Test
+  public void testResolveWithSingleDefaultKey() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                          node_metadata_tag_mapping:
+                            service:
+                              default_key:
+                                - kube.app
+                              default_value: unknown_service
+                          """);
+    Map<String, String> tags = Map.of("kube.app", "my-app");
+
+    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app");
   }
 
   @Test
-  public void testResolveWithDelimiterAndPart_outOfBoundsIndex() throws IOException {
+  public void testResolveWithMultipleOverrideKeys() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
                           node_metadata_tag_mapping:
-                            app:
-                              default_key: kube.app
-                              default_value: unknown_app
+                            service:
+                              default_key:
+                                - kube.app
+                                - kube.namespace
+                              default_value: unknown_service
+                              key_delimiter: .
                               rules:
                                 - field: operation_name
                                   value: http.request
-                                  override_key: target_app
-                                  delimiter: .
-                                  part: 10
+                                  override_key:
+                                    - tag.http.target.host
+                                    - tag.http.method
                           """);
     Map<String, String> tags =
         Map.of(
-            "operation_name", "http.request",
-            "target_app", "my-app.example.com");
+            "kube.app",
+            "my-app",
+            "kube.namespace",
+            "prod",
+            "operation_name",
+            "http.request",
+            "tag.http.target.host",
+            "api.example.com",
+            "tag.http.method",
+            "GET");
 
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
-    // Should keep original value when part index is out of bounds
-    assertThat(result).isEqualTo("my-app.example.com");
+    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
+    assertThat(result).isEqualTo("api.example.com.GET");
   }
 
   @Test
-  public void testResolveWithDelimiterAndPart_noDelimiterInValue() throws IOException {
+  public void testResolveWithMultipleOverrideKeys_missingKey() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
                           node_metadata_tag_mapping:
-                            app:
-                              default_key: kube.app
-                              default_value: unknown_app
+                            service:
+                              default_key:
+                                - kube.app
+                                - kube.namespace
+                              default_value: unknown_service
+                              key_delimiter: .
                               rules:
                                 - field: operation_name
                                   value: http.request
-                                  override_key: target_app
-                                  delimiter: .
-                                  part: 1
+                                  override_key:
+                                    - tag.http.target.host
+                                    - tag.http.method
                           """);
     Map<String, String> tags =
         Map.of(
-            "operation_name", "http.request",
-            "target_app", "localhost");
+            "kube.app",
+            "my-app",
+            "kube.namespace",
+            "prod",
+            "operation_name",
+            "http.request",
+            "tag.http.target.host",
+            "api.example.com");
 
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
-    // Should keep original value when there's no delimiter
-    assertThat(result).isEqualTo("localhost");
-  }
-
-  @Test
-  public void testResolveWithDelimiterAndPart_multipleDelimiters() throws IOException {
-    GraphConfig config =
-        GraphConfig.load(
-            """
-                          node_metadata_tag_mapping:
-                            app:
-                              default_key: kube.app
-                              default_value: unknown_app
-                              rules:
-                                - field: operation_name
-                                  value: http.request
-                                  override_key: target_app
-                                  delimiter: .
-                                  part: 2
-                          """);
-    Map<String, String> tags =
-        Map.of(
-            "operation_name", "http.request",
-            "target_app", "my-app.example.com");
-
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
-    assertThat(result).isEqualTo("com");
-  }
-
-  @Test
-  public void testResolveWithDelimiterAndPart_noMatchingRule() throws IOException {
-    GraphConfig config =
-        GraphConfig.load(
-            """
-                          node_metadata_tag_mapping:
-                            app:
-                              default_key: kube.app
-                              default_value: unknown_app
-                              rules:
-                                - field: operation_name
-                                  value: http.request
-                                  override_key: target_app
-                                  delimiter: .
-                                  part: 0
-                          """);
-    Map<String, String> tags =
-        Map.of(
-            "operation_name", "grpc.request",
-            "kube.app", "my-app");
-
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
-    // Should use default key without delimiter splitting
-    assertThat(result).isEqualTo("my-app");
+    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
+    // Should return default value since override key is missing tag.http.method
+    assertThat(result).isEqualTo("unknown_service");
   }
 
   @Test
@@ -549,13 +592,16 @@ public class GraphConfigTest {
             """
       node_metadata_tag_mapping:
         app:
-          default_key: app.name
+          default_key:
+            - app.name
           default_value: unknown_app
         namespace:
-          default_key: namespace.name
+          default_key:
+            - namespace.name
           default_value: unknown_namespace
         resource:
-          default_key: resource.name
+          default_key:
+            - resource.name
           default_value: unknown_resource
       """);
 
@@ -593,7 +639,8 @@ public class GraphConfigTest {
             """
                   edge_metadata_tag_mapping:
                     operation:
-                      default_key: operation_name
+                      default_key:
+                        - operation_name
                       default_value: unknown_operation
                   """);
 

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -305,7 +305,7 @@ public class GraphServiceTest {
         .thenReturn(List.of());
 
     // Invalid JSON - missing closing brace
-    String invalidFilterJson = "{\"operation\":[\"http.request\"";
+    String invalidFilterJson = "{\"operation_name\":[\"http.request\"";
 
     HttpResponse response =
         graphService.getSubgraph(
@@ -331,7 +331,7 @@ public class GraphServiceTest {
         .thenReturn(List.of());
 
     // Valid JSON but wrong structure - should be Map<String, List<String>> not Map<String, String>
-    String malformedFilterJson = "{\"operation\":\"http.request\"}";
+    String malformedFilterJson = "{\"operation_name\":\"http.request\"}";
 
     HttpResponse response =
         graphService.getSubgraph(
@@ -417,7 +417,7 @@ public class GraphServiceTest {
         .thenReturn(testSpans);
 
     // Filter to only include http.request and grpc.request operations
-    String filterJson = "{\"operation\":[\"http.request\",\"grpc.request\"]}";
+    String filterJson = "{\"operation_name\":[\"http.request\",\"grpc.request\"]}";
 
     HttpResponse response =
         graphService.getSubgraph(

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -98,10 +98,18 @@ public class GraphServiceTest {
                 traceId,
                 null,
                 Map.of(
-                    "kube.app", "api-gateway",
-                    "kube.namespace", "prod",
-                    "operation_name", "http.request",
-                    "resource", "/api/users/profile")),
+                    "kube.app",
+                    "api-gateway",
+                    "kube.namespace",
+                    "prod",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "some_resource",
+                    "tag.http.target.canonical_path",
+                    "/api/users/profile",
+                    "tag.http.target.host",
+                    "app1.ns1")),
 
             // First level children
             TestUtils.createSpanWithTags(
@@ -109,10 +117,18 @@ public class GraphServiceTest {
                 traceId,
                 "root",
                 Map.of(
-                    "kube.app", "auth-service",
-                    "kube.namespace", "prod",
-                    "operation_name", "http.request",
-                    "resource", "/api/auth/validate")),
+                    "kube.app",
+                    "auth-service",
+                    "kube.namespace",
+                    "prod",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "some_resource2",
+                    "tag.http.target.canonical_path",
+                    "/api/auth/validate",
+                    "tag.http.target.host",
+                    "app2.ns2")),
             TestUtils.createSpanWithTags(
                 "child2",
                 traceId,
@@ -205,8 +221,7 @@ public class GraphServiceTest {
       assertTrue(node.has("metadata"));
 
       JsonNode metadata = node.get("metadata");
-      assertTrue(metadata.has("app"));
-      assertTrue(metadata.has("namespace"));
+      assertTrue(metadata.has("service"));
       assertTrue(metadata.has("resource"));
     }
 
@@ -218,5 +233,209 @@ public class GraphServiceTest {
       JsonNode metadata = edge.get("metadata");
       assertTrue(metadata.has("operation"));
     }
+  }
+
+  @Test
+  public void testGetSubgraphByTraceId_withEmptyFilter() throws Exception {
+    String traceId = "test_trace_empty_filter";
+
+    List<com.slack.astra.zipkinApi.ZipkinSpanResponse> testSpans =
+        List.of(
+            TestUtils.createSpanWithTags(
+                "parent1",
+                traceId,
+                null,
+                Map.of(
+                    "kube.app", "app1",
+                    "kube.namespace", "prod",
+                    "operation_name", "http.request",
+                    "resource", "resource1")),
+            TestUtils.createSpanWithTags(
+                "child1",
+                traceId,
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "prod",
+                    "operation_name", "db.query",
+                    "resource", "resource2")));
+
+    when(traceFetcher.getSpansByTraceId(
+            anyString(),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(testSpans);
+
+    // Empty filter JSON - should return all nodes (no filtering applied)
+    String emptyFilterJson = "{}";
+
+    HttpResponse response =
+        graphService.getSubgraph(
+            traceId, Optional.of(emptyFilterJson), Optional.empty(), Optional.empty());
+    AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
+
+    assertEquals(HttpStatus.OK, aggregatedResponse.status());
+
+    String content = aggregatedResponse.contentUtf8();
+    JsonNode jsonNode = objectMapper.readTree(content);
+
+    JsonNode subgraph = jsonNode.get("subgraph");
+    JsonNode nodes = subgraph.get("nodes");
+    JsonNode edges = subgraph.get("edges");
+
+    // Empty filter should return all nodes and edges
+    assertEquals(2, nodes.size(), "Empty filter should return all 2 nodes");
+    assertEquals(1, edges.size(), "Empty filter should return all 1 edge");
+  }
+
+  @Test
+  public void testGetSubgraphByTraceId_withInvalidFilterJson() throws Exception {
+    String traceId = "test_trace_invalid_filter";
+
+    when(traceFetcher.getSpansByTraceId(
+            anyString(),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(List.of());
+
+    // Invalid JSON - missing closing brace
+    String invalidFilterJson = "{\"operation\":[\"http.request\"";
+
+    HttpResponse response =
+        graphService.getSubgraph(
+            traceId, Optional.of(invalidFilterJson), Optional.empty(), Optional.empty());
+    AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
+
+    assertEquals(HttpStatus.BAD_REQUEST, aggregatedResponse.status());
+    String content = aggregatedResponse.contentUtf8();
+    assertTrue(content.contains("Invalid buildFilter JSON"));
+  }
+
+  @Test
+  public void testGetSubgraphByTraceId_withMalformedFilterStructure() throws Exception {
+    String traceId = "test_trace_malformed_filter";
+
+    when(traceFetcher.getSpansByTraceId(
+            anyString(),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(List.of());
+
+    // Valid JSON but wrong structure - should be Map<String, List<String>> not Map<String, String>
+    String malformedFilterJson = "{\"operation\":\"http.request\"}";
+
+    HttpResponse response =
+        graphService.getSubgraph(
+            traceId, Optional.of(malformedFilterJson), Optional.empty(), Optional.empty());
+    AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
+
+    assertEquals(HttpStatus.BAD_REQUEST, aggregatedResponse.status());
+    String content = aggregatedResponse.contentUtf8();
+    assertTrue(content.contains("Invalid buildFilter JSON"));
+  }
+
+  @Test
+  public void testGetSubgraphByTraceId_withValidFilter() throws Exception {
+    String traceId = "test_trace_with_filter";
+
+    // Create spans with different operations
+    List<com.slack.astra.zipkinApi.ZipkinSpanResponse> testSpans =
+        List.of(
+            // Root span with http.request
+            TestUtils.createSpanWithTags(
+                "root",
+                traceId,
+                null,
+                Map.of(
+                    "kube.app",
+                    "api-gateway",
+                    "kube.namespace",
+                    "prod",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "some_resource",
+                    "tag.http.target.canonical_path",
+                    "/api/endpoint",
+                    "tag.http.target.host",
+                    "gateway.prod")),
+            // Child with http.request
+            TestUtils.createSpanWithTags(
+                "child1",
+                traceId,
+                "root",
+                Map.of(
+                    "kube.app",
+                    "service1",
+                    "kube.namespace",
+                    "prod",
+                    "operation_name",
+                    "http.request",
+                    "resource",
+                    "some_resource2",
+                    "tag.http.target.canonical_path",
+                    "/api/service1",
+                    "tag.http.target.host",
+                    "service1.prod")),
+            // Child with grpc.request
+            TestUtils.createSpanWithTags(
+                "child2",
+                traceId,
+                "root",
+                Map.of(
+                    "kube.app", "service2",
+                    "kube.namespace", "prod",
+                    "operation_name", "grpc.request",
+                    "resource", "grpcMethod")),
+            // Child with db.query (should be filtered out)
+            TestUtils.createSpanWithTags(
+                "child3",
+                traceId,
+                "root",
+                Map.of(
+                    "kube.app", "database",
+                    "kube.namespace", "prod",
+                    "operation_name", "db.query",
+                    "resource", "SELECT * FROM users")));
+
+    when(traceFetcher.getSpansByTraceId(
+            anyString(),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(testSpans);
+
+    // Filter to only include http.request and grpc.request operations
+    String filterJson = "{\"operation\":[\"http.request\",\"grpc.request\"]}";
+
+    HttpResponse response =
+        graphService.getSubgraph(
+            traceId, Optional.of(filterJson), Optional.empty(), Optional.empty());
+    AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
+
+    assertEquals(HttpStatus.OK, aggregatedResponse.status());
+
+    String content = aggregatedResponse.contentUtf8();
+    JsonNode jsonNode = objectMapper.readTree(content);
+
+    JsonNode subgraph = jsonNode.get("subgraph");
+    JsonNode nodes = subgraph.get("nodes");
+    JsonNode edges = subgraph.get("edges");
+
+    // Should have 3 nodes (root, child1, child2) - child3 with db.query is filtered out
+    assertEquals(3, nodes.size(), "Should have 3 nodes after filtering");
+    // Should have 2 edges (root->child1, root->child2)
+    assertEquals(2, edges.size(), "Should have 2 edges after filtering");
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -63,6 +63,8 @@ public class GraphServiceTest {
             any(Optional.class),
             any(Optional.class),
             any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
             any(Optional.class)))
         .thenReturn(Collections.emptyList());
 
@@ -196,6 +198,8 @@ public class GraphServiceTest {
             any(Optional.class),
             any(Optional.class),
             any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
             any(Optional.class)))
         .thenReturn(testSpans);
 
@@ -279,6 +283,8 @@ public class GraphServiceTest {
             any(Optional.class),
             any(Optional.class),
             any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
             any(Optional.class)))
         .thenReturn(testSpans);
 
@@ -314,6 +320,8 @@ public class GraphServiceTest {
             any(Optional.class),
             any(Optional.class),
             any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
             any(Optional.class)))
         .thenReturn(List.of());
 
@@ -336,6 +344,8 @@ public class GraphServiceTest {
 
     when(traceFetcher.getSpansByTraceId(
             anyString(),
+            any(Optional.class),
+            any(Optional.class),
             any(Optional.class),
             any(Optional.class),
             any(Optional.class),
@@ -422,6 +432,8 @@ public class GraphServiceTest {
 
     when(traceFetcher.getSpansByTraceId(
             anyString(),
+            any(Optional.class),
+            any(Optional.class),
             any(Optional.class),
             any(Optional.class),
             any(Optional.class),

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -1,34 +1,222 @@
 package com.slack.astra.graphApi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.slack.astra.server.AstraQueryServiceBase;
+import com.slack.astra.zipkinApi.TraceFetcher;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class GraphServiceTest {
-  @Mock private AstraQueryServiceBase searcher;
+  @Mock private TraceFetcher traceFetcher;
   private GraphService graphService;
+  private ObjectMapper objectMapper;
 
   @BeforeEach
   public void setup() throws IOException {
-    graphService = spy(new GraphService(searcher, GraphConfig.DEFAULT));
+    MockitoAnnotations.openMocks(this);
+
+    // Load custom config from YAML file
+    Path configPath =
+        new File(
+                Objects.requireNonNull(
+                        getClass()
+                            .getClassLoader()
+                            .getResource("test-dependency-graph-config.yaml"))
+                    .getFile())
+            .toPath();
+    graphService = spy(new GraphService(traceFetcher, GraphConfig.load(configPath)));
+    objectMapper = new ObjectMapper();
   }
 
   @Test
   public void testGetSubgraphByTraceId_emptyResult() throws Exception {
-    String traceId = "test_trace_1";
+    String traceId = "test_trace_empty";
 
-    HttpResponse response = graphService.getSubgraph(traceId);
+    when(traceFetcher.getSpansByTraceId(
+            anyString(),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(Collections.emptyList());
+
+    HttpResponse response =
+        graphService.getSubgraph(traceId, Optional.empty(), Optional.empty(), Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.OK, aggregatedResponse.status());
-    assertEquals("[]", aggregatedResponse.contentUtf8());
+
+    // Verify it's valid JSON with nodes and edges arrays
+    String content = aggregatedResponse.contentUtf8();
+    JsonNode jsonNode = objectMapper.readTree(content);
+
+    assertTrue(jsonNode.has("subgraph"));
+    assertTrue(jsonNode.has("traceFetchTimeMs"));
+    assertTrue(jsonNode.has("subgraphBuildTimeMs"));
+
+    assertTrue(jsonNode.get("subgraph").isEmpty());
+  }
+
+  @Test
+  public void testGetSubgraphByTraceId_withComplexHierarchy() throws Exception {
+    String traceId = "test_trace_complex";
+
+    // Create a complex span hierarchy:
+    // root (API Gateway)
+    //   ├── child1 (Auth Service)
+    //   ├── child2 (User Service)
+    //   │   ├── grandchild1 (Database)
+    //   │   └── grandchild2 (Cache Service)
+    //   └── child3 (Notification Service)
+    //       └── grandchild3 (Email Service)
+    List<com.slack.astra.zipkinApi.ZipkinSpanResponse> testSpans =
+        List.of(
+            // Root span - API Gateway
+            TestUtils.createSpanWithTags(
+                "root",
+                traceId,
+                null,
+                Map.of(
+                    "kube.app", "api-gateway",
+                    "kube.namespace", "prod",
+                    "operation_name", "http.request",
+                    "resource", "/api/users/profile")),
+
+            // First level children
+            TestUtils.createSpanWithTags(
+                "child1",
+                traceId,
+                "root",
+                Map.of(
+                    "kube.app", "auth-service",
+                    "kube.namespace", "prod",
+                    "operation_name", "http.request",
+                    "resource", "/api/auth/validate")),
+            TestUtils.createSpanWithTags(
+                "child2",
+                traceId,
+                "root",
+                Map.of(
+                    "kube.app", "user-service",
+                    "kube.namespace", "prod",
+                    "operation_name", "user.fetch",
+                    "resource", "getUserProfile")),
+            TestUtils.createSpanWithTags(
+                "child3",
+                traceId,
+                "root",
+                Map.of(
+                    "kube.app", "notification-service",
+                    "kube.namespace", "prod",
+                    "operation_name", "notify.send",
+                    "resource", "sendNotification")),
+
+            // Second level children (grandchildren)
+            TestUtils.createSpanWithTags(
+                "grandchild1",
+                traceId,
+                "child2",
+                Map.of(
+                    "kube.app", "postgres-db",
+                    "kube.namespace", "prod",
+                    "operation_name", "db.query",
+                    "resource", "SELECT * FROM users WHERE id = ?")),
+            TestUtils.createSpanWithTags(
+                "grandchild2",
+                traceId,
+                "child2",
+                Map.of(
+                    "kube.app", "redis-cache",
+                    "kube.namespace", "prod",
+                    "operation_name", "cache.get",
+                    "resource", "user:profile:12345")),
+            TestUtils.createSpanWithTags(
+                "grandchild3",
+                traceId,
+                "child3",
+                Map.of(
+                    "kube.app", "email-service",
+                    "kube.namespace", "prod",
+                    "operation_name", "email.send",
+                    "resource", "sendEmail")));
+
+    when(traceFetcher.getSpansByTraceId(
+            anyString(),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class),
+            any(Optional.class)))
+        .thenReturn(testSpans);
+
+    HttpResponse response =
+        graphService.getSubgraph(traceId, Optional.empty(), Optional.empty(), Optional.empty());
+    AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
+
+    assertEquals(HttpStatus.OK, aggregatedResponse.status());
+
+    // Verify it's valid JSON with proper structure
+    String content = aggregatedResponse.contentUtf8();
+    JsonNode jsonNode = objectMapper.readTree(content);
+
+    // Verify structure
+    assertTrue(jsonNode.has("subgraph"));
+    assertTrue(jsonNode.has("traceFetchTimeMs"));
+    assertTrue(jsonNode.has("subgraphBuildTimeMs"));
+
+    JsonNode subgraph = jsonNode.get("subgraph");
+    assertTrue(subgraph.has("nodes"));
+    assertTrue(subgraph.has("edges"));
+
+    // Verify data content
+    JsonNode nodes = subgraph.get("nodes");
+    JsonNode edges = subgraph.get("edges");
+
+    assertEquals(7, nodes.size(), "Should have 7 nodes (1 root + 3 children + 3 grandchildren)");
+    assertEquals(
+        6,
+        edges.size(),
+        "Should have 6 edges (3 root->child + 2 child2->grandchild + 1 child3->grandchild)");
+
+    // Verify all nodes have required fields
+    for (JsonNode node : nodes) {
+      assertTrue(node.has("id"));
+      assertTrue(node.has("metadata"));
+
+      JsonNode metadata = node.get("metadata");
+      assertTrue(metadata.has("app"));
+      assertTrue(metadata.has("namespace"));
+      assertTrue(metadata.has("resource"));
+    }
+
+    // Verify all edges have required fields
+    for (JsonNode edge : edges) {
+      assertTrue(edge.has("sourceNodeId"));
+      assertTrue(edge.has("targetNodeId"));
+
+      JsonNode metadata = edge.get("metadata");
+      assertTrue(metadata.has("operation"));
+    }
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -12,7 +12,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.slack.astra.testlib.MetricsUtil;
 import com.slack.astra.zipkinApi.TraceFetcher;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -30,6 +33,7 @@ public class GraphServiceTest {
   @Mock private TraceFetcher traceFetcher;
   private GraphService graphService;
   private ObjectMapper objectMapper;
+  private MeterRegistry meterRegistry;
 
   @BeforeEach
   public void setup() throws IOException {
@@ -44,7 +48,8 @@ public class GraphServiceTest {
                             .getResource("test-dependency-graph-config.yaml"))
                     .getFile())
             .toPath();
-    graphService = spy(new GraphService(traceFetcher, GraphConfig.load(configPath)));
+    meterRegistry = new SimpleMeterRegistry();
+    graphService = spy(new GraphService(traceFetcher, GraphConfig.load(configPath), meterRegistry));
     objectMapper = new ObjectMapper();
   }
 
@@ -61,6 +66,10 @@ public class GraphServiceTest {
             any(Optional.class)))
         .thenReturn(Collections.emptyList());
 
+    // Verify timers start at 0
+    assertEquals(0.0, MetricsUtil.getTimerCount("astra_graph_service_trace_fetch", meterRegistry));
+    assertEquals(0.0, MetricsUtil.getTimerCount("astra_graph_service_graph_build", meterRegistry));
+
     HttpResponse response =
         graphService.getSubgraph(traceId, Optional.empty(), Optional.empty(), Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
@@ -76,6 +85,10 @@ public class GraphServiceTest {
     assertTrue(jsonNode.has("subgraphBuildTimeMs"));
 
     assertTrue(jsonNode.get("subgraph").isEmpty());
+
+    // Verify both timers have been recorded once
+    assertEquals(1.0, MetricsUtil.getTimerCount("astra_graph_service_trace_fetch", meterRegistry));
+    assertEquals(1.0, MetricsUtil.getTimerCount("astra_graph_service_graph_build", meterRegistry));
   }
 
   @Test

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -2,18 +2,28 @@ node_metadata_tag_mapping:
   app:
     default_key: kube.app
     default_value: unknown_app
-    rules: []
+    rules:
+      - field: operation_name
+        value: http.request
+        override_key: tag.http.target.host
+        delimiter: .
+        part: 0
   namespace:
     default_key: kube.namespace
     default_value: unknown_namespace
-    rules: []
+    rules:
+      - field: operation_name
+        value: http.request
+        override_key: tag.http.target.host
+        delimiter: .
+        part: 1
   resource:
     default_key: resource
     default_value: unknown_resource
     rules:
       - field: operation_name
         value: http.request
-        override_key: tag.operation.canonical_path
+        override_key: tag.http.target.canonical_path
 edge_metadata_tag_mapping:
   operation:
     default_key: operation_name

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -1,31 +1,27 @@
 node_metadata_tag_mapping:
-  app:
-    default_key: kube.app
-    default_value: unknown_app
+  service:
+    default_key:
+      - kube.app
+      - kube.namespace
+    default_value: unknown_service
+    key_delimiter: .
     rules:
       - field: operation_name
         value: http.request
-        override_key: tag.http.target.host
-        delimiter: .
-        part: 0
-  namespace:
-    default_key: kube.namespace
-    default_value: unknown_namespace
-    rules:
-      - field: operation_name
-        value: http.request
-        override_key: tag.http.target.host
-        delimiter: .
-        part: 1
+        override_key:
+          - tag.http.target.host
   resource:
-    default_key: resource
+    default_key:
+      - resource
     default_value: unknown_resource
     rules:
       - field: operation_name
         value: http.request
-        override_key: tag.http.target.canonical_path
+        override_key:
+          - tag.http.target.canonical_path
 edge_metadata_tag_mapping:
   operation:
-    default_key: operation_name
+    default_key:
+      - operation_name
     default_value: unknown_operation
     rules: []


### PR DESCRIPTION
###  Summary

This PR updates `GraphBuilder` and `GraphConfig` to align with the new span <> metadata configuration and moves certain post-processing logic into Astra for correctness.

`GraphConfig`
- Combines span tags based on a configurable delimiter to populate a metadata field.

`GraphBuilder`
- Generates a full list of nodes and edges when no span filter is provided.
- When a filter is present, performs an iterative DFS to remove intermediate nodes that don’t meet filter conditions.
- Filter logic is OR-based — any span satisfying at least one condition is retained in the final list of dependencies

Post-Processing within Astra
Added a post-processing DFS step during dependency generation for specific span filters. This logic was originally planned to run outside Astra, but that approach lost the span hierarchy required to properly drop intermediate spans and reconnect relevant nodes. 


### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

### Testing

```
▲ ~ curl -G 'http://localhost:8081/api/v1/trace/eZVwBjNwRg6LFefMEg-nRw==/subgraph' \
    --data-urlencode 'buildFilter={"operation_name": ["dropwizard.request"]}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4782  100  4782    0     0   5993      0 --:--:-- --:--:-- --:--:--  5992
{
  "subgraph": {
    "edges": [
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "437a9f05c78b14cedc3ea8f9bafae0838e0875b9dc2f4b76ba0bb36cd4c88f3f"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "cdb6c98c6b46df0b7d0e7964f80bd6b22423f2252c6264e4a89c7355055f1dab"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "7bf016d85a57cad93435953f7d833755b5248bb0dc603cc7382e9134acf628a8"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "4089069a670cc89865fe21e203382df2f13dc4f9e7289a3fbc0b4bf7a16b74d0"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "08c22953c68f7f7bcfd183f864913dffc6999b53d4f3f07471afd94e1c533230"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "2eb3447cb192a9da9cd1dd284cbcad4c4dd6f636584d17957dd7139cde08cd1a"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "f33ff1bde4908a63b85e0734beb74a5ea212cf96ac396daea4474dc004be0a7d"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "356788092a336ce0c8aa235241e877f0e65715ba0ac23084549045f63fe8fb35"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "8b91da8ba8fb5d00480270dc8735123c198f08c496e7223d43309378d2a23b79"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "e9d30c07602571ff1fe8a0b2e10cd2f117ee4256291dd638385e90e11c20a198"
      },
      {
        "metadata": {
          "operation": "dropwizard.request"
        },
        "sourceNodeId": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "targetNodeId": "c7301c3fb1c58566b2aa2bd26eaa03d2d0997232f1d666a94e1835afd9941da3"
      }
    ],
    "nodes": [
      {
        "id": "96a2b9678eb1121c7896d7153a5cb5d4ee0fecd1773173b2cbb6e0c06a2a9297",
        "metadata": {
          "resource": "//{version:(v2|v3)}/viaduct/scope/data-api{operation:(/[a-zA-Z0-9_-]+)?}",
          "service": "viaduct-dispatcher-production.viaduct-dispatcher-production"
        }
      },
      {
        "id": "cdb6c98c6b46df0b7d0e7964f80bd6b22423f2252c6264e4a89c7355055f1dab",
        "metadata": {
          "resource": "viaduct/SillaViaductSuperhostQuery",
          "service": "viaduct-shard-14-production.viaduct-production"
        }
      },
      {
        "id": "8b91da8ba8fb5d00480270dc8735123c198f08c496e7223d43309378d2a23b79",
        "metadata": {
          "resource": "viaduct/DayuMessageThreadQuery",
          "service": "viaduct-shard-180-production.viaduct-production"
        }
      },
      {
        "id": "e9d30c07602571ff1fe8a0b2e10cd2f117ee4256291dd638385e90e11c20a198",
        "metadata": {
          "resource": "viaduct/DayuMessageThreadQuery",
          "service": "viaduct-shard-8-production.viaduct-production"
        }
      },
      {
        "id": "437a9f05c78b14cedc3ea8f9bafae0838e0875b9dc2f4b76ba0bb36cd4c88f3f",
        "metadata": {
          "resource": "viaduct/PocariMediaCollectionQuery",
          "service": "viaduct-shard-15-production.viaduct-production"
        }
      },
      {
        "id": "f33ff1bde4908a63b85e0734beb74a5ea212cf96ac396daea4474dc004be0a7d",
        "metadata": {
          "resource": "viaduct/SillaViaductGuestFavoriteQuery",
          "service": "viaduct-shard-5-production.viaduct-production"
        }
      },
      {
        "id": "c7301c3fb1c58566b2aa2bd26eaa03d2d0997232f1d666a94e1835afd9941da3",
        "metadata": {
          "resource": "viaduct/PocariMediaCollectionQuery",
          "service": "viaduct-shard-13-production.viaduct-production"
        }
      },
      {
        "id": "356788092a336ce0c8aa235241e877f0e65715ba0ac23084549045f63fe8fb35",
        "metadata": {
          "resource": "viaduct/DayuGetThreadsByUserIdQuery",
          "service": "viaduct-shard-4-production.viaduct-production"
        }
      },
      {
        "id": "4089069a670cc89865fe21e203382df2f13dc4f9e7289a3fbc0b4bf7a16b74d0",
        "metadata": {
          "resource": "viaduct/DayuMessageThreadQuery",
          "service": "viaduct-shard-1-production.viaduct-production"
        }
      },
      {
        "id": "08c22953c68f7f7bcfd183f864913dffc6999b53d4f3f07471afd94e1c533230",
        "metadata": {
          "resource": "viaduct/AirlockRiskCheckQuery",
          "service": "viaduct-shard-20-production.viaduct-production"
        }
      },
      {
        "id": "2eb3447cb192a9da9cd1dd284cbcad4c4dd6f636584d17957dd7139cde08cd1a",
        "metadata": {
          "resource": "viaduct/DayuGetThreadsByUserIdQuery",
          "service": "viaduct-shard-10-production.viaduct-production"
        }
      },
      {
        "id": "7bf016d85a57cad93435953f7d833755b5248bb0dc603cc7382e9134acf628a8",
        "metadata": {
          "resource": "viaduct/SillaViaductUserPastTripsQuery",
          "service": "viaduct-shard-2-production.viaduct-production"
        }
      }
    ]
  },
  "subgraphBuildTimeMs": 31,
  "traceFetchTimeMs": 474
}
 ▲ ~ curl -G 'http://localhost:8081/api/v1/trace/eZVwBjNwRg6LFefMEg-nRw==/subgraph' \
    --data-urlencode 'buildFilter={"operation_name": ["http.request"]}' | jq
{
  "subgraph": {
    "edges": [
      {
        "metadata": {
          "operation": "http.request"
        },
        "sourceNodeId": "4089069a670cc89865fe21e203382df2f13dc4f9e7289a3fbc0b4bf7a16b74d0",
        "targetNodeId": "cc71230f648249a1ce3f4c1852a811fb9f76ce2c59f58aba602003e1a66796ec"
      },
      {
        "metadata": {
          "operation": "http.request"
        },
        "sourceNodeId": "e9d30c07602571ff1fe8a0b2e10cd2f117ee4256291dd638385e90e11c20a198",
        "targetNodeId": "af223332f46eb1260a3b5f61ee0fda386685f29505e6f2c2f537536e315f6edc"
      },
      ...
    ],
    "nodes": [
      {
        "id": "bfd1faa3abcbeec2fe2e7871474a4ca283d945fe3eb686f4819e4e14f8c85700",
        "metadata": {
          "resource": "panda/AvailabilityBatchQuery",
          "service": "panda-production.panda-production"
        }
      },
      {
        "id": "f1a283b61ca5ddf47b706990c9b5b79b0a4437e13456cb04fc91863d55ab4691",
        "metadata": {
          "resource": "/Pocari/getRichMessages",
          "service": "pocari-production.pocari-production"
        }
      },
    ...
    ]
  },
  "subgraphBuildTimeMs": 85,
  "traceFetchTimeMs": 419
}
```
