### PR TITLE
Upgrading the aws sdk crt version

### DIFF
--- a/astra/pom.xml
+++ b/astra/pom.xml
@@ -357,7 +357,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.38.5</version>
+            <version>0.39.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
###  Summary
Upgrading aws sdk crt version to fix the lucene directory corruption on download.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
