### PR TITLE
When a trace id is fed to zipkin as a long, search over dd_trace_id instead when header X-DD-TRACE-ID is passed

### DIFF
--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -210,6 +211,13 @@ public class ZipkinService {
     return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
   }
 
+  // DD trace id is a long encoded as a string.
+  private static final Pattern DIGITS = Pattern.compile("^\\d+$");
+
+  private static boolean isDDTraceId(String s) {
+    return s != null && DIGITS.matcher(s).matches();
+  }
+
   @Blocking
   @Get("/api/v2/trace/{traceId}")
   public HttpResponse getTraceByTraceId(
@@ -218,8 +226,15 @@ public class ZipkinService {
       @Param("endTimeEpochMs") Optional<Long> endTimeEpochMs,
       @Param("maxSpans") Optional<Integer> maxSpans,
       @Header("X-User-Request") Optional<Boolean> userRequest,
+      @Header("X-DD-TRACE-ID") Optional<String> ddTraceId,
       @Header("X-Data-Freshness-In-Seconds") Optional<Long> dataFreshnessInSeconds)
       throws IOException {
+
+    String traceFieldName = "trace_id";
+    // if trace id looks like dd_trace_id, then use dd_trace_id field to search
+    if (ddTraceId.isPresent() && isDDTraceId(traceId)) {
+      traceFieldName = "dd_trace_id";
+    }
 
     // Log the custom header userRequest value if present
     if (userRequest.isPresent()) {
@@ -235,7 +250,7 @@ public class ZipkinService {
       }
     }
     JSONObject traceObject = new JSONObject();
-    traceObject.put("trace_id", traceId);
+    traceObject.put(traceFieldName, traceId);
     JSONObject queryJson = new JSONObject();
     queryJson.put("term", traceObject);
     String queryString = queryJson.toString();

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceTest.java
@@ -123,6 +123,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.empty(),
+              Optional.empty(),
               Optional.empty());
       AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
@@ -146,6 +147,70 @@ public class ZipkinServiceTest {
 
       zipkinService.getTraceByTraceId(
           traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty());
+
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"trace_id\":\"" + traceId + "\"")));
+    }
+  }
+
+  @Test
+  public void testGetTraceByTraceId_dd_trace_id() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "4541183944276361430";
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+      String ddTraceIdHeaderVal = "value_does_not_matter";
+
+      zipkinService.getTraceByTraceId(
+          traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(ddTraceIdHeaderVal),
+          Optional.empty());
+
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"dd_trace_id\":\"" + traceId + "\"")));
+    }
+  }
+
+  @Test
+  public void testGetTraceByTraceId_dd_trace_id_Disabled() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "4541183944276361430";
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+
+      zipkinService.getTraceByTraceId(
+          traceId,
+          Optional.empty(),
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
@@ -181,6 +246,7 @@ public class ZipkinServiceTest {
           Optional.empty(),
           Optional.of(maxSpansParam),
           Optional.empty(),
+          Optional.empty(),
           Optional.empty());
 
       verify(searcher)
@@ -215,6 +281,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.empty());
 
       verify(searcher)
@@ -264,6 +331,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.empty());
 
       verify(searcher)
@@ -312,6 +380,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.empty());
 
       verify(mockBlobStore).readFileData(eq(traceFilePath), eq(true));
@@ -359,6 +428,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.of(dataFreshnessInSeconds));
 
       verify(mockBlobStore).readFileData(traceFilePath, true);
@@ -413,6 +483,7 @@ public class ZipkinServiceTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.of(dataFreshnessInSeconds));
 
       verify(mockBlobStore).readFileData(traceFilePath, true);


### PR DESCRIPTION
###  Summary
Cherry-pick https://github.com/airbnb/kaldb/pull/54 into airbnb-main
Describe the goal of this PR. Mention any related Issue numbers.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
