### PR TITLE
When a trace id is fed to zipkin as a long, search over dd_trace_id instead when header X-DD-TRACE-ID is passed

### DIFF
--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,14 +81,29 @@ public class TraceFetcher {
           .serializationInclusion(JsonInclude.Include.NON_EMPTY)
           .build();
 
+  // DD trace id is a long encoded as a string.
+  private static final Pattern DIGITS = Pattern.compile("^\\d+$");
+
+  private static boolean isDDTraceId(String s) {
+    return s != null && DIGITS.matcher(s).matches();
+  }
+
   private Result fetchTraceResult(
       String traceId,
       Optional<Long> startTimeEpochMs,
       Optional<Long> endTimeEpochMs,
       Optional<Integer> maxSpans,
       Optional<Boolean> userRequest,
-      Optional<Long> dataFreshnessInSeconds)
+      Optional<Long> dataFreshnessInSeconds,
+      Optional<Boolean> ddTraceIdEnabled)
       throws IOException {
+
+    String traceFieldName = "trace_id";
+    // if trace id looks like dd_trace_id, then use dd_trace_id field to search
+    if (ddTraceIdEnabled.isPresent() && ddTraceIdEnabled.get() && isDDTraceId(traceId)) {
+      traceFieldName = "dd_trace_id";
+    }
+
     // Log the custom header userRequest value if present
     if (userRequest.isPresent()) {
       LOG.info("Received custom header X-User-Request: {}", userRequest.get());
@@ -102,7 +118,7 @@ public class TraceFetcher {
     }
 
     JSONObject traceObject = new JSONObject();
-    traceObject.put("trace_id", traceId);
+    traceObject.put(traceFieldName, traceId);
     JSONObject queryJson = new JSONObject();
     queryJson.put("term", traceObject);
     String queryString = queryJson.toString();
@@ -163,7 +179,8 @@ public class TraceFetcher {
       Optional<Long> endTimeEpochMs,
       Optional<Integer> maxSpans,
       Optional<Boolean> userRequest,
-      Optional<Long> dataFreshnessInSeconds)
+      Optional<Long> dataFreshnessInSeconds,
+      Optional<Boolean> ddTraceIdEnabled)
       throws IOException {
     Result result =
         fetchTraceResult(
@@ -172,7 +189,8 @@ public class TraceFetcher {
             endTimeEpochMs,
             maxSpans,
             userRequest,
-            dataFreshnessInSeconds);
+            dataFreshnessInSeconds,
+            ddTraceIdEnabled);
 
     if (result.isCached()) {
       return objectMapper.readValue(result.rawJson, new TypeReference<>() {});
@@ -186,7 +204,8 @@ public class TraceFetcher {
       Optional<Long> endTimeEpochMs,
       Optional<Integer> maxSpans,
       Optional<Boolean> userRequest,
-      Optional<Long> dataFreshnessInSeconds)
+      Optional<Long> dataFreshnessInSeconds,
+      Optional<Boolean> ddTraceIdEnabled)
       throws IOException {
     Result result =
         fetchTraceResult(
@@ -195,7 +214,8 @@ public class TraceFetcher {
             endTimeEpochMs,
             maxSpans,
             userRequest,
-            dataFreshnessInSeconds);
+            dataFreshnessInSeconds,
+            ddTraceIdEnabled);
 
     if (result.isCached()) {
       return result.rawJson;

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -70,7 +70,8 @@ public class ZipkinService {
       @Param("endTimeEpochMs") Optional<Long> endTimeEpochMs,
       @Param("maxSpans") Optional<Integer> maxSpans,
       @Header("X-User-Request") Optional<Boolean> userRequest,
-      @Header("X-Data-Freshness-In-Seconds") Optional<Long> dataFreshnessInSeconds)
+      @Header("X-Data-Freshness-In-Seconds") Optional<Long> dataFreshnessInSeconds,
+      @Header("X-DD-TRACE-ID") Optional<Boolean> ddTraceIdEnabled)
       throws IOException {
     String output =
         this.traceFetcher.getByTraceId(
@@ -79,7 +80,8 @@ public class ZipkinService {
             endTimeEpochMs,
             maxSpans,
             userRequest,
-            dataFreshnessInSeconds);
+            dataFreshnessInSeconds,
+            ddTraceIdEnabled);
     return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, output);
   }
 }

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -120,6 +120,7 @@ public class TraceFetcherTest {
               Optional.empty(),
               Optional.empty(),
               Optional.empty(),
+              Optional.empty(),
               Optional.empty());
 
       // Assert
@@ -145,6 +146,7 @@ public class TraceFetcherTest {
 
       traceFetcher.getByTraceId(
           traceId,
+          Optional.empty(),
           Optional.empty(),
           Optional.empty(),
           Optional.empty(),
@@ -180,6 +182,7 @@ public class TraceFetcherTest {
           Optional.empty(),
           Optional.of(maxSpansParam),
           Optional.empty(),
+          Optional.empty(),
           Optional.empty());
 
       verify(searcher)
@@ -214,6 +217,7 @@ public class TraceFetcherTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.empty());
 
       verify(searcher)
@@ -259,6 +263,7 @@ public class TraceFetcherTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.empty());
 
       verify(searcher)
@@ -272,6 +277,70 @@ public class TraceFetcherTest {
 
       assertNotNull(response, "Response should not be null");
       assertTrue(response.contains("[]"), "Response should be empty array for empty search result");
+    }
+  }
+
+  @Test
+  public void testGetTraceByTraceId_dd_trace_id() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "4541183944276361430";
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+      boolean ddTraceIdHeaderVal = true;
+
+      traceFetcher.getByTraceId(
+          traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(ddTraceIdHeaderVal));
+
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"dd_trace_id\":\"" + traceId + "\"")));
+    }
+  }
+
+  @Test
+  public void testGetTraceByTraceId_dd_trace_id_Disabled() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "4541183944276361430";
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+      boolean ddTraceIdHeaderVal = false;
+
+      traceFetcher.getByTraceId(
+          traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(ddTraceIdHeaderVal));
+
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"trace_id\":\"" + traceId + "\"")));
     }
   }
 
@@ -301,6 +370,7 @@ public class TraceFetcherTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
+              Optional.empty(),
               Optional.empty());
 
       verify(mockBlobStore).readFileData(eq(traceFilePath), eq(true));
@@ -343,7 +413,8 @@ public class TraceFetcherTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
-              Optional.of(dataFreshnessInSeconds));
+              Optional.of(dataFreshnessInSeconds),
+              Optional.empty());
 
       verify(mockBlobStore).readFileData(traceFilePath, true);
       verify(mockBlobStore, never()).uploadData(anyString(), anyString(), eq(true));
@@ -393,7 +464,8 @@ public class TraceFetcherTest {
               Optional.empty(),
               Optional.empty(),
               Optional.of(userRequest),
-              Optional.of(dataFreshnessInSeconds));
+              Optional.of(dataFreshnessInSeconds),
+              Optional.empty());
 
       verify(mockBlobStore).readFileData(traceFilePath, true);
       verify(searcher)


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.
Reapply https://github.com/airbnb/kaldb/pull/54 to `airbnb-main` which was on a fork.

### Requirements

* [ ] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
