### PR TITLE
Add @Blocking annotation to GraphService subgraph endpoint

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -8,10 +8,10 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.annotation.Blocking;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
-import com.linecorp.armeria.server.annotation.Path;
 import com.slack.astra.zipkinApi.TraceFetcher;
 import com.slack.astra.zipkinApi.ZipkinSpanResponse;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -56,8 +56,8 @@ public class GraphService {
   private record SubgraphResponse(
       Graph subgraph, long traceFetchTimeMs, long subgraphBuildTimeMs) {}
 
-  @Get
-  @Path("/api/v1/trace/{traceId}/subgraph")
+  @Blocking
+  @Get("/api/v1/trace/{traceId}/subgraph")
   public HttpResponse getSubgraph(
       @Param("traceId") String traceId,
       @Param("buildFilter") Optional<String> buildFilterJson,


### PR DESCRIPTION
###  Summary

We were seeing significant differences in trace fetch time between this endpoint and the `ZipkinService` `getTraceByTraceId` function, the latter performing faster for the same trace id. Noticed that we weren't using this annotation which resulted in hitting the event worker pools, causing pretty significant slow downs.

## Testing

before: 
```
https://airtrace-query-traces-staging.a.musta.ch/api/v1/trace/bGLk7pAxgzjW74Q_JF8CnA==/subgraph?maxSpans=50000
{
...
  "subgraphBuildTimeMs": 11,
  "traceFetchTimeMs": 65067
}
```

after 
```
https://airtrace-query-traces-staging.a.musta.ch/api/v1/trace/bGLk7pAxgzjW74Q_JF8CnA==/subgraph?maxSpans=50000
{
...
  "subgraphBuildTimeMs": 98,
  "traceFetchTimeMs": 900
}
```

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
