### PR TITLE
add start/end epoch param to subgraph endpoint

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphService.java
@@ -60,6 +60,8 @@ public class GraphService {
   @Get("/api/v1/trace/{traceId}/subgraph")
   public HttpResponse getSubgraph(
       @Param("traceId") String traceId,
+      @Param("startTimeEpochMs") Optional<Long> startTimeEpochMs,
+      @Param("endTimeEpochMs") Optional<Long> endTimeEpochMs,
       @Param("buildFilter") Optional<String> buildFilterJson,
       @Param("maxSpans") Optional<Integer> maxSpans,
       @Header("X-User-Request") Optional<Boolean> userRequest)
@@ -86,8 +88,8 @@ public class GraphService {
     List<ZipkinSpanResponse> trace =
         this.traceFetcher.getSpansByTraceId(
             traceId,
-            Optional.empty(),
-            Optional.empty(),
+            startTimeEpochMs,
+            endTimeEpochMs,
             maxSpans,
             userRequest,
             Optional.empty(),

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -73,7 +73,13 @@ public class GraphServiceTest {
     assertEquals(0.0, MetricsUtil.getTimerCount("astra_graph_service_graph_build", meterRegistry));
 
     HttpResponse response =
-        graphService.getSubgraph(traceId, Optional.empty(), Optional.empty(), Optional.empty());
+        graphService.getSubgraph(
+            traceId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.OK, aggregatedResponse.status());
@@ -204,7 +210,13 @@ public class GraphServiceTest {
         .thenReturn(testSpans);
 
     HttpResponse response =
-        graphService.getSubgraph(traceId, Optional.empty(), Optional.empty(), Optional.empty());
+        graphService.getSubgraph(
+            traceId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.OK, aggregatedResponse.status());
@@ -293,7 +305,12 @@ public class GraphServiceTest {
 
     HttpResponse response =
         graphService.getSubgraph(
-            traceId, Optional.of(emptyFilterJson), Optional.empty(), Optional.empty());
+            traceId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(emptyFilterJson),
+            Optional.empty(),
+            Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.OK, aggregatedResponse.status());
@@ -330,7 +347,12 @@ public class GraphServiceTest {
 
     HttpResponse response =
         graphService.getSubgraph(
-            traceId, Optional.of(invalidFilterJson), Optional.empty(), Optional.empty());
+            traceId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(invalidFilterJson),
+            Optional.empty(),
+            Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.BAD_REQUEST, aggregatedResponse.status());
@@ -358,7 +380,12 @@ public class GraphServiceTest {
 
     HttpResponse response =
         graphService.getSubgraph(
-            traceId, Optional.of(malformedFilterJson), Optional.empty(), Optional.empty());
+            traceId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(malformedFilterJson),
+            Optional.empty(),
+            Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.BAD_REQUEST, aggregatedResponse.status());
@@ -446,7 +473,12 @@ public class GraphServiceTest {
 
     HttpResponse response =
         graphService.getSubgraph(
-            traceId, Optional.of(filterJson), Optional.empty(), Optional.empty());
+            traceId,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(filterJson),
+            Optional.empty(),
+            Optional.empty());
     AggregatedHttpResponse aggregatedResponse = response.aggregate().join();
 
     assertEquals(HttpStatus.OK, aggregatedResponse.status());


### PR DESCRIPTION
###  Summary

Add timestamp parameters to the subgraph endpoint. Currently we pass `Optional.empty()` to the trace fetcher, but we need these to fetch the correct snapshot otherwise we search all snapshots for the trace id in the last 7 days by default.

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
