### PR TITLE
multi-rule fallback on empty/missing values

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -211,9 +211,11 @@ public final class GraphConfig {
    *
    * <p>Steps: 1. Look up the TagConfig for this logical field (e.g. "resource"). 2. Check if any
    * rules match: - Iterate through each rule in reverse order. - If a rule's field/value condition
-   * matches, use the overrideKey to look up the value. 3. If no rule matches, use the defaultKey: -
-   * Look up each keyPart from defaultKey list in the tags map. - Combine the values with the
-   * delimiter if multiple parts are present. - If any part is missing, fall back to defaultValue.
+   * matches, try to resolve using the overrideKey. - If the resolved value is non-empty, use it. -
+   * Otherwise, continue to the next matching rule. 3. If no rule produces a non-empty value, use
+   * the defaultKey: - Look up each keyPart from defaultKey list in the tags map. - Combine the
+   * values with the delimiter if multiple parts are present. - If any part is missing or empty,
+   * fall back to defaultValue.
    *
    * <p>Note: This logic does not currently support multiple field matches for a single rule.
    *
@@ -233,39 +235,56 @@ public final class GraphConfig {
       return tags.getOrDefault(logicalField, "unknown_" + logicalField);
     }
 
-    // Later rules override earlier ones, so start from the back of the list and use the first one
-    // that matches.
-    RuleConfig matchingRule =
-        baseCfg.getRules().reversed().stream()
-            .filter(
-                rule ->
-                    rule.getValue()
-                        .equals(tags.getOrDefault(rule.getField(), "unknown_" + rule.getField())))
-            .findFirst()
-            .orElse(null);
+    // Later rules override earlier ones, so start from the back of the list.
+    // Try each matching rule until one produces a non-empty value.
+    for (RuleConfig rule : baseCfg.getRules().reversed()) {
+      if (rule.getValue()
+          .equals(tags.getOrDefault(rule.getField(), "unknown_" + rule.getField()))) {
+        String resolved = resolveKeys(tags, rule.getOverrideKey(), baseCfg.getKeyDelimiter());
+        if (resolved != null && !resolved.isEmpty()) {
+          return resolved;
+        }
+        // Continue to next matching rule if value is empty
+      }
+    }
 
-    // Determine which key to use (override or default)
-    List<String> keyToUse =
-        matchingRule != null ? matchingRule.getOverrideKey() : baseCfg.getDefaultKey();
+    // No rules or rules produced a non-empty value, try the default key
+    String defaultResolved = resolveKeys(tags, baseCfg.getDefaultKey(), baseCfg.getKeyDelimiter());
+    if (defaultResolved != null && !defaultResolved.isEmpty()) {
+      return defaultResolved;
+    }
 
-    if (keyToUse == null || keyToUse.isEmpty()) {
-      return baseCfg.getDefaultValue();
+    // No rules produced a non-empty value, Fall back to default value
+    return baseCfg.getDefaultValue();
+  }
+
+  /**
+   * Helper method to resolve a list of keys from the tags map.
+   *
+   * @param tags Map of tags from the span.
+   * @param keys List of keys to look up.
+   * @param delimiter Delimiter to use when combining multiple key values.
+   * @return The resolved value, or null if any key is missing.
+   */
+  private String resolveKeys(Map<String, String> tags, List<String> keys, String delimiter) {
+    if (keys == null || keys.isEmpty()) {
+      return null;
     }
 
     // Collect values for all parts in a key
     List<String> values = new java.util.ArrayList<>();
-    for (String keyPart : keyToUse) {
+    for (String keyPart : keys) {
       String value = tags.get(keyPart);
       if (value == null) {
-        // If any key is missing, return the default value
-        return baseCfg.getDefaultValue();
+        // If any key is missing, return null
+        return null;
       }
       values.add(value);
     }
 
     // Combine values with delimiter if present and multiple keys exist
-    if (values.size() > 1 && baseCfg.getKeyDelimiter() != null) {
-      return String.join(baseCfg.getKeyDelimiter(), values);
+    if (values.size() > 1 && delimiter != null) {
+      return String.join(delimiter, values);
     }
     return values.get(0);
   }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -264,13 +264,13 @@ public class GraphConfigTest {
         Map.of(
             "app.name", "my-app", "namespace.name", "prod-ns", "operation_name", "some_operation");
 
-    // Node - rule matches but override key is missing, should return default value
+    // Node - rule matches but override key is missing, should return default key's value
     String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
-    assertThat(result).isEqualTo("unknown_app");
+    assertThat(result).isEqualTo("my-app");
 
-    // Edge - rule matches but override key is missing, should return default value
+    // Edge - rule matches but override key is missing, should return default key's value
     result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
-    assertThat(result).isEqualTo("unknown_operation");
+    assertThat(result).isEqualTo("some_operation");
   }
 
   @Test
@@ -569,8 +569,8 @@ public class GraphConfigTest {
             "api.example.com");
 
     String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
-    // Should return default value since override key is missing tag.http.method
-    assertThat(result).isEqualTo("unknown_service");
+    // Should return default key's value since override key is missing tag.http.method
+    assertThat(result).isEqualTo("my-app.prod");
   }
 
   @Test
@@ -619,6 +619,109 @@ public class GraphConfigTest {
     assertThat(metadata.get("app")).isEqualTo("my-app");
     assertThat(metadata.get("namespace")).isEqualTo("my-namespace");
     assertThat(metadata.get("resource")).isEqualTo("my-resource");
+  }
+
+  @Test
+  public void testResolveWithMultipleMatchingRules_emptyValue_fallbackToNextRule()
+      throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                node_metadata_tag_mapping:
+                  resource:
+                    default_key:
+                      - resource
+                    default_value: unknown_resource
+                    rules:
+                      - field: operation_name
+                        value: http.request
+                        override_key:
+                          - http.url
+                      - field: operation_name
+                        value: http.request
+                        override_key:
+                          - tag.http.target.canonical_path
+                """);
+
+    // Case 1: tag.http.target.canonical_path is empty, should fallback to http.url
+    Map<String, String> tags1 =
+        Map.of(
+            "operation_name",
+            "http.request",
+            "tag.http.target.canonical_path",
+            "",
+            "http.url",
+            "/api/v1/users",
+            "resource",
+            "default_resource");
+
+    String result1 = config.resolve(tags1, "resource", GraphConfig.EntityType.NODE);
+    assertThat(result1).isEqualTo("/api/v1/users");
+
+    // Case 2: Both are empty, should fallback to default key
+    Map<String, String> tags2 =
+        Map.of(
+            "operation_name",
+            "http.request",
+            "tag.http.target.canonical_path",
+            "",
+            "http.url",
+            "",
+            "resource",
+            "default_resource");
+
+    String result2 = config.resolve(tags2, "resource", GraphConfig.EntityType.NODE);
+    assertThat(result2).isEqualTo("default_resource");
+
+    // Case 3: All empty including default key, should use default value
+    Map<String, String> tags3 =
+        Map.of(
+            "operation_name",
+            "http.request",
+            "tag.http.target.canonical_path",
+            "",
+            "http.url",
+            "",
+            "resource",
+            "");
+
+    String result3 = config.resolve(tags3, "resource", GraphConfig.EntityType.NODE);
+    assertThat(result3).isEqualTo("unknown_resource");
+
+    // Case 4: tag.http.target.canonical_path has value, should use it
+    Map<String, String> tags4 =
+        Map.of(
+            "operation_name",
+            "http.request",
+            "tag.http.target.canonical_path",
+            "/api/canonical",
+            "http.url",
+            "/api/v1/users",
+            "resource",
+            "default_resource");
+
+    String result4 = config.resolve(tags4, "resource", GraphConfig.EntityType.NODE);
+    assertThat(result4).isEqualTo("/api/canonical");
+
+    // Case 5: tag.http.target.canonical_path is missing, should fallback to http.url
+    Map<String, String> tags5 =
+        Map.of(
+            "operation_name",
+            "http.request",
+            "http.url",
+            "/api/v1/users",
+            "resource",
+            "default_resource");
+
+    String result5 = config.resolve(tags5, "resource", GraphConfig.EntityType.NODE);
+    assertThat(result1).isEqualTo("/api/v1/users");
+
+    // Case 6: Both override keys are missing, should fallback to default key
+    Map<String, String> tags6 =
+        Map.of("operation_name", "http.request", "resource", "default_resource");
+
+    String result6 = config.resolve(tags6, "resource", GraphConfig.EntityType.NODE);
+    assertThat(result2).isEqualTo("default_resource");
   }
 
   @Test

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -18,6 +18,10 @@ node_metadata_tag_mapping:
       - field: operation_name
         value: http.request
         override_key:
+          - http.url
+      - field: operation_name
+        value: http.request
+        override_key:
           - tag.http.target.canonical_path
 edge_metadata_tag_mapping:
   operation:


### PR DESCRIPTION
###  Summary

This PR enhances the resolve method in GraphConfig to properly handle cases where a matching rule's override key resolves to an empty or missing value. Previously, if a rule matched but its override key was missing or empty, the method would immediately return the default value. Now it continues checking subsequent matching rules before falling back to defaults.

- Refactored the resolve method to iterate through all matching rules in reverse order, trying each one until a non-empty value is found
- If a rule matches but produces an empty/null value, the method now continues to the next matching rule instead of returning the default value immediately
- Extracted key resolution logic into a new helper method `resolveKeys()`
- Updated fallback order: matching rules → default key → default value
 
### Testing
- existing and new unit tests pass

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
