### PR TITLE
[graph builder] compute number of times an edge is observed within a trace

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/Edge.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/Edge.java
@@ -2,12 +2,71 @@ package com.slack.astra.graphApi;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Objects;
 import java.util.SortedMap;
 
-// Represents a directed connection between two Nodes.
-public record Edge(String sourceNodeId, String targetNodeId, SortedMap<String, String> metadata) {
-  public Edge {
-    checkNotNull(sourceNodeId, "sourceNodeId cannot be null");
-    checkNotNull(targetNodeId, "targetNodeId cannot be null");
+/**
+ * Represents a directed connection between two Nodes.
+ *
+ * <p>Equality is based on sourceNodeId, targetNodeId, and metadata. The observationCount field is
+ * mutable and excluded from equality, allowing edges to be accumulated in collections while
+ * tracking how many times the same logical edge is observed.
+ */
+public class Edge {
+  private final String sourceNodeId;
+  private final String targetNodeId;
+  private final SortedMap<String, String> metadata;
+  private int observedCount = 0;
+
+  public Edge(String sourceNodeId, String targetNodeId, SortedMap<String, String> metadata) {
+    this.sourceNodeId = checkNotNull(sourceNodeId, "sourceNodeId cannot be null");
+    this.targetNodeId = checkNotNull(targetNodeId, "targetNodeId cannot be null");
+    this.metadata = metadata;
+  }
+
+  static String generateKey(
+      String sourceNodeId, String targetNodeId, SortedMap<String, String> metadata) {
+    return sourceNodeId + targetNodeId + (metadata == null ? 0 : metadata.hashCode());
+  }
+
+  public String getSourceNodeId() {
+    return sourceNodeId;
+  }
+
+  public String getTargetNodeId() {
+    return targetNodeId;
+  }
+
+  public SortedMap<String, String> getMetadata() {
+    return metadata;
+  }
+
+  public int getObservedCount() {
+    return observedCount;
+  }
+
+  public void incrementObservedCount() {
+    observedCount++;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Edge edge)) return false;
+    return Objects.equals(sourceNodeId, edge.sourceNodeId)
+        && Objects.equals(targetNodeId, edge.targetNodeId)
+        && Objects.equals(metadata, edge.metadata);
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= sourceNodeId.hashCode();
+    h *= 1000003;
+    h ^= targetNodeId.hashCode();
+    h *= 1000003;
+    h ^= (metadata == null) ? 0 : metadata.hashCode();
+    return h;
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -72,6 +72,24 @@ public class GraphBuilder {
     }
   }
 
+  private static class EdgeAccumulator {
+    final Edge edge;
+    int observationCount = 0;
+
+    EdgeAccumulator(Edge edge) {
+      this.edge = edge;
+    }
+
+    void increment() {
+      observationCount++;
+    }
+
+    Edge getEdgeWithObservationCount() {
+      this.edge.metadata().put("observationCount", String.valueOf(observationCount));
+      return this.edge;
+    }
+  }
+
   /**
    * Builds an (optionally filtered) dependency graph from a list of Zipkin spans.
    *
@@ -192,7 +210,7 @@ public class GraphBuilder {
       Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds) {
 
     Set<Node> nodes = new HashSet<>();
-    Set<Edge> edges = new HashSet<>();
+    Map<String, EdgeAccumulator> edgeAccumulators = new HashMap<>();
 
     // Process each filtered node as a potential parent
     for (String parentNodeId : nodesToProcess) {
@@ -221,11 +239,19 @@ public class GraphBuilder {
             // Don't traverse past this child - it will be processed in its own iteration.
             nodes.add(nodeIdToNode.get(parentNodeId));
             nodes.add(nodeIdToNode.get(childNodeId));
-            edges.add(
-                new Edge(
-                    parentNodeId,
-                    childNodeId,
-                    config.createMetadataFromSpan(refSpan, GraphConfig.EntityType.EDGE)));
+
+            String edgeKey = parentNodeId + "::" + childNodeId;
+            edgeAccumulators
+                .computeIfAbsent(
+                    edgeKey,
+                    k ->
+                        new EdgeAccumulator(
+                            new Edge(
+                                parentNodeId,
+                                childNodeId,
+                                config.createMetadataFromSpan(
+                                    refSpan, GraphConfig.EntityType.EDGE))))
+                .increment();
           } else {
             // Non-filtered intermediate node - continue traversing through it
             work.push(childNodeId);
@@ -234,6 +260,11 @@ public class GraphBuilder {
       }
     }
 
-    return new Graph(new ArrayList<>(nodes), new ArrayList<>(edges));
+    List<Edge> edges =
+        edgeAccumulators.values().stream()
+            .map(EdgeAccumulator::getEdgeWithObservationCount)
+            .toList();
+
+    return new Graph(new ArrayList<>(nodes), edges);
   }
 }

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -98,7 +98,7 @@ public class GraphBuilder {
      *
      * @return The edge with observation count in metadata
      */
-    Edge getEdgeWithObservationCount() {
+    Edge toEdgeWithObservationCount() {
       this.edge.metadata().put("observationCount", String.valueOf(observationCount));
       return this.edge;
     }
@@ -276,7 +276,7 @@ public class GraphBuilder {
 
     List<Edge> edges =
         edgeAccumulators.values().stream()
-            .map(EdgeAccumulator::getEdgeWithObservationCount)
+            .map(EdgeAccumulator::toEdgeWithObservationCount)
             .toList();
 
     return new Graph(new ArrayList<>(nodes), edges);

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -72,6 +72,13 @@ public class GraphBuilder {
     }
   }
 
+  /**
+   * EdgeAccumulator for tracking edge observations during graph construction.
+   *
+   * <p>Multiple spans may represent the same logical edge (same source and target node). This class
+   * aggregates these observations, counting how many times the edge is seen. The observation count
+   * can be used to compute edge weight or importance in the final graph.
+   */
   private static class EdgeAccumulator {
     final Edge edge;
     int observationCount = 0;
@@ -84,6 +91,13 @@ public class GraphBuilder {
       observationCount++;
     }
 
+    /**
+     * Returns the edge with observation count added to its metadata.
+     *
+     * <p>Note: This method mutates the edge's metadata map by adding the "observationCount" key.
+     *
+     * @return The edge with observation count in metadata
+     */
     Edge getEdgeWithObservationCount() {
       this.edge.metadata().put("observationCount", String.valueOf(observationCount));
       return this.edge;

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,38 +70,6 @@ public class GraphBuilder {
                 String actualValue = span.getTags().get(entry.getKey());
                 return actualValue != null && entry.getValue().contains(actualValue);
               });
-    }
-  }
-
-  /**
-   * EdgeAccumulator for tracking edge observations during graph construction.
-   *
-   * <p>Multiple spans may represent the same logical edge (same source and target node). This class
-   * aggregates these observations, counting how many times the edge is seen. The observation count
-   * can be used to compute edge weight or importance in the final graph.
-   */
-  private static class EdgeAccumulator {
-    final Edge edge;
-    int observationCount = 0;
-
-    EdgeAccumulator(Edge edge) {
-      this.edge = edge;
-    }
-
-    void increment() {
-      observationCount++;
-    }
-
-    /**
-     * Returns the edge with observation count added to its metadata.
-     *
-     * <p>Note: This method mutates the edge's metadata map by adding the "observationCount" key.
-     *
-     * @return The edge with observation count in metadata
-     */
-    Edge toEdgeWithObservationCount() {
-      this.edge.metadata().put("observationCount", String.valueOf(observationCount));
-      return this.edge;
     }
   }
 
@@ -224,7 +193,7 @@ public class GraphBuilder {
       Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds) {
 
     Set<Node> nodes = new HashSet<>();
-    Map<String, EdgeAccumulator> edgeAccumulators = new HashMap<>();
+    Map<String, Edge> edges = new HashMap<>();
 
     // Process each filtered node as a potential parent
     for (String parentNodeId : nodesToProcess) {
@@ -254,18 +223,13 @@ public class GraphBuilder {
             nodes.add(nodeIdToNode.get(parentNodeId));
             nodes.add(nodeIdToNode.get(childNodeId));
 
-            String edgeKey = parentNodeId + "::" + childNodeId;
-            edgeAccumulators
-                .computeIfAbsent(
-                    edgeKey,
-                    k ->
-                        new EdgeAccumulator(
-                            new Edge(
-                                parentNodeId,
-                                childNodeId,
-                                config.createMetadataFromSpan(
-                                    refSpan, GraphConfig.EntityType.EDGE))))
-                .increment();
+            SortedMap<String, String> edgeMetadata =
+                config.createMetadataFromSpan(refSpan, GraphConfig.EntityType.EDGE);
+            String edgeKey = Edge.generateKey(parentNodeId, childNodeId, edgeMetadata);
+
+            edges
+                .computeIfAbsent(edgeKey, k -> new Edge(parentNodeId, childNodeId, edgeMetadata))
+                .incrementObservedCount();
           } else {
             // Non-filtered intermediate node - continue traversing through it
             work.push(childNodeId);
@@ -274,11 +238,6 @@ public class GraphBuilder {
       }
     }
 
-    List<Edge> edges =
-        edgeAccumulators.values().stream()
-            .map(EdgeAccumulator::toEdgeWithObservationCount)
-            .toList();
-
-    return new Graph(new ArrayList<>(nodes), edges);
+    return new Graph(new ArrayList<>(nodes), new ArrayList<>(edges.values()));
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/EdgeTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/EdgeTest.java
@@ -27,16 +27,16 @@ public class EdgeTest {
   void build_withValidSourceAndTarget_succeeds() {
     Edge e = new Edge("source", "target", null);
 
-    assertThat(e.sourceNodeId()).isEqualTo("source");
-    assertThat(e.targetNodeId()).isEqualTo("target");
+    assertThat(e.getSourceNodeId()).isEqualTo("source");
+    assertThat(e.getTargetNodeId()).isEqualTo("target");
   }
 
   @Test
   void build_withValidSourceTargetAndMetadata_succeeds() {
     Edge e = new Edge("source", "target", new TreeMap<>(Map.of("operation", "default")));
 
-    assertThat(e.sourceNodeId()).isEqualTo("source");
-    assertThat(e.targetNodeId()).isEqualTo("target");
-    assertThat(e.metadata()).isNotEmpty();
+    assertThat(e.getSourceNodeId()).isEqualTo("source");
+    assertThat(e.getTargetNodeId()).isEqualTo("target");
+    assertThat(e.getMetadata()).isNotEmpty();
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -97,13 +97,13 @@ public class GraphBuilderTest {
                 "resource", "/v2/res2"));
 
     // uses canonical path as resource
-    SortedMap<String, String> edgeMetadata =
-        new TreeMap<>(Map.of("operation", "http.request", "observationCount", "1"));
+    SortedMap<String, String> edgeMetadata = new TreeMap<>(Map.of("operation", "http.request"));
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
     Edge edge = graph.edges().iterator().next();
-    assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
-    assertThat(edge.targetNodeId()).isEqualTo(expectedChildId);
-    assertThat(edge.metadata()).isEqualTo(edgeMetadata);
+    assertThat(edge.getSourceNodeId()).isEqualTo(expectedParentId);
+    assertThat(edge.getTargetNodeId()).isEqualTo(expectedChildId);
+    assertThat(edge.getMetadata()).isEqualTo(edgeMetadata);
+    assertThat(edge.getObservedCount()).isEqualTo(1);
   }
 
   @Test
@@ -198,17 +198,18 @@ public class GraphBuilderTest {
 
     // verify both edges have the same parent
     List<Edge> edges = graph.edges();
-    assertThat(edges.stream().allMatch(edge -> edge.sourceNodeId().equals(expectedParentId)))
+    assertThat(edges.stream().allMatch(edge -> edge.getSourceNodeId().equals(expectedParentId)))
         .isTrue();
 
     // metadata of the edges
-    assertThat(edges.get(0).metadata())
-        .isEqualTo(new TreeMap<>(Map.of("operation", "op2", "observationCount", "1")));
-    assertThat(edges.get(1).metadata())
-        .isEqualTo(new TreeMap<>(Map.of("operation", "op3", "observationCount", "1")));
+    assertThat(edges.get(0).getMetadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op2")));
+    assertThat(edges.get(0).getObservedCount()).isEqualTo(1);
+    assertThat(edges.get(1).getMetadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op3")));
+    assertThat(edges.get(1).getObservedCount()).isEqualTo(1);
 
     // verify different children
-    List<String> childIds = List.of(edges.stream().map(Edge::targetNodeId).toArray(String[]::new));
+    List<String> childIds =
+        List.of(edges.stream().map(Edge::getTargetNodeId).toArray(String[]::new));
     assertThat(childIds).containsExactlyInAnyOrder(expectedChild1Id, expectedChild2Id);
   }
 
@@ -254,8 +255,9 @@ public class GraphBuilderTest {
 
     // should have only 1 edge despite multiple spans creating the same parent-child relationship
     assertThat(graph.edges()).hasSize(1);
-    assertThat(graph.edges().get(0).metadata())
-        .isEqualTo(new TreeMap<>(Map.of("operation", "op2", "observationCount", "2")));
+    assertThat(graph.edges().get(0).getMetadata())
+        .isEqualTo(new TreeMap<>(Map.of("operation", "op2")));
+    assertThat(graph.edges().get(0).getObservedCount()).isEqualTo(2);
 
     SortedMap<String, String> parentMetadata =
         new TreeMap<>(
@@ -272,8 +274,8 @@ public class GraphBuilderTest {
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
 
     Edge edge = graph.edges().getFirst();
-    assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
-    assertThat(edge.targetNodeId()).isEqualTo(expectedChildId);
+    assertThat(edge.getSourceNodeId()).isEqualTo(expectedParentId);
+    assertThat(edge.getTargetNodeId()).isEqualTo(expectedChildId);
   }
 
   @Test
@@ -362,31 +364,26 @@ public class GraphBuilderTest {
     assertThat(edges)
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedRootId)
-                    && edge.targetNodeId().equals(expectedChild1Id)
-                    && edge.metadata()
-                        .equals(
-                            new TreeMap<>(
-                                Map.of("operation", "child1_op", "observationCount", "1"))));
+                edge.getSourceNodeId().equals(expectedRootId)
+                    && edge.getTargetNodeId().equals(expectedChild1Id)
+                    && edge.getMetadata().equals(new TreeMap<>(Map.of("operation", "child1_op")))
+                    && edge.getObservedCount() == 1);
 
     assertThat(edges)
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedRootId)
-                    && edge.targetNodeId().equals(expectedChild2Id)
-                    && edge.metadata()
-                        .equals(
-                            new TreeMap<>(
-                                Map.of("operation", "child2_op", "observationCount", "1"))));
+                edge.getSourceNodeId().equals(expectedRootId)
+                    && edge.getTargetNodeId().equals(expectedChild2Id)
+                    && edge.getMetadata().equals(new TreeMap<>(Map.of("operation", "child2_op")))
+                    && edge.getObservedCount() == 1);
 
     assertThat(edges)
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedChild1Id)
-                    && edge.targetNodeId().equals(expectedGrandchildId)
-                    && edge.metadata()
-                        .equals(
-                            new TreeMap<>(Map.of("operation", "gc_op", "observationCount", "1"))));
+                edge.getSourceNodeId().equals(expectedChild1Id)
+                    && edge.getTargetNodeId().equals(expectedGrandchildId)
+                    && edge.getMetadata().equals(new TreeMap<>(Map.of("operation", "gc_op")))
+                    && edge.getObservedCount() == 1);
   }
 
   @Test
@@ -515,51 +512,46 @@ public class GraphBuilderTest {
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeAId)
-                    && edge.targetNodeId().equals(expectedNodeBId)
-                    && edge.metadata()
-                        .equals(
-                            new TreeMap<>(Map.of("operation", "opB", "observationCount", "1"))));
+                edge.getSourceNodeId().equals(expectedNodeAId)
+                    && edge.getTargetNodeId().equals(expectedNodeBId)
+                    && edge.getMetadata().equals(new TreeMap<>(Map.of("operation", "opB")))
+                    && edge.getObservedCount() == 1);
 
     // B -> C
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeBId)
-                    && edge.targetNodeId().equals(expectedNodeCId)
-                    && edge.metadata()
-                        .equals(
-                            new TreeMap<>(Map.of("operation", "opC", "observationCount", "1"))));
+                edge.getSourceNodeId().equals(expectedNodeBId)
+                    && edge.getTargetNodeId().equals(expectedNodeCId)
+                    && edge.getMetadata().equals(new TreeMap<>(Map.of("operation", "opC")))
+                    && edge.getObservedCount() == 1);
 
     // D -> B
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeDId)
-                    && edge.targetNodeId().equals(expectedNodeBId)
-                    && edge.metadata()
-                        .equals(
-                            new TreeMap<>(Map.of("operation", "opB", "observationCount", "1"))));
+                edge.getSourceNodeId().equals(expectedNodeDId)
+                    && edge.getTargetNodeId().equals(expectedNodeBId)
+                    && edge.getMetadata().equals(new TreeMap<>(Map.of("operation", "opB")))
+                    && edge.getObservedCount() == 1);
 
     // B -> E
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeBId)
-                    && edge.targetNodeId().equals(expectedNodeEId)
-                    && edge.metadata()
-                        .equals(
-                            new TreeMap<>(Map.of("operation", "opE", "observationCount", "1"))));
+                edge.getSourceNodeId().equals(expectedNodeBId)
+                    && edge.getTargetNodeId().equals(expectedNodeEId)
+                    && edge.getMetadata().equals(new TreeMap<>(Map.of("operation", "opE")))
+                    && edge.getObservedCount() == 1);
 
     // E -> B
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeEId)
-                    && edge.targetNodeId().equals(expectedNodeBId)
-                    && edge.metadata()
-                        .equals(
-                            new TreeMap<>(Map.of("operation", "opB", "observationCount", "1"))));
+                edge.getSourceNodeId().equals(expectedNodeEId)
+                    && edge.getTargetNodeId().equals(expectedNodeBId)
+                    && edge.getMetadata().equals(new TreeMap<>(Map.of("operation", "opB")))
+                    && edge.getObservedCount() == 1);
   }
 
   @Test
@@ -634,10 +626,10 @@ public class GraphBuilderTest {
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
     Edge edge = graph.edges().get(0);
-    assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
-    assertThat(edge.targetNodeId()).isEqualTo(expectedChild1Id);
-    assertThat(edge.metadata())
-        .isEqualTo(new TreeMap<>(Map.of("operation", "http.request", "observationCount", "1")));
+    assertThat(edge.getSourceNodeId()).isEqualTo(expectedParentId);
+    assertThat(edge.getTargetNodeId()).isEqualTo(expectedChild1Id);
+    assertThat(edge.getMetadata()).isEqualTo(new TreeMap<>(Map.of("operation", "http.request")));
+    assertThat(edge.getObservedCount()).isEqualTo(1);
   }
 
   @Test
@@ -716,10 +708,10 @@ public class GraphBuilderTest {
 
     // Should have edge directly from root to grandchild (skipping intermediate)
     Edge edge = graph.edges().get(0);
-    assertThat(edge.sourceNodeId()).isEqualTo(expectedRootId);
-    assertThat(edge.targetNodeId()).isEqualTo(expectedGrandchildId);
-    assertThat(edge.metadata())
-        .isEqualTo(new TreeMap<>(Map.of("operation", "http.request", "observationCount", "1")));
+    assertThat(edge.getSourceNodeId()).isEqualTo(expectedRootId);
+    assertThat(edge.getTargetNodeId()).isEqualTo(expectedGrandchildId);
+    assertThat(edge.getMetadata()).isEqualTo(new TreeMap<>(Map.of("operation", "http.request")));
+    assertThat(edge.getObservedCount()).isEqualTo(1);
   }
 
   @Test
@@ -831,7 +823,8 @@ public class GraphBuilderTest {
     String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
 
     // Both edges should originate from root
-    assertThat(graph.edges().stream().allMatch(edge -> edge.sourceNodeId().equals(expectedRootId)))
+    assertThat(
+            graph.edges().stream().allMatch(edge -> edge.getSourceNodeId().equals(expectedRootId)))
         .isTrue();
   }
 
@@ -1009,15 +1002,15 @@ public class GraphBuilderTest {
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedChild1Id)
-                    && edge.targetNodeId().equals(expectedGrandchild1Id));
+                edge.getSourceNodeId().equals(expectedChild1Id)
+                    && edge.getTargetNodeId().equals(expectedGrandchild1Id));
 
     // This edge should skip multiple non-matching intermediate nodes
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedMatching1Id)
-                    && edge.targetNodeId().equals(expectedMatching2Id));
+                edge.getSourceNodeId().equals(expectedMatching1Id)
+                    && edge.getTargetNodeId().equals(expectedMatching2Id));
   }
 
   @Test
@@ -1097,10 +1090,10 @@ public class GraphBuilderTest {
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
 
     Edge edge = graph.edges().get(0);
-    assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
-    assertThat(edge.targetNodeId()).isEqualTo(expectedChildId);
-    assertThat(edge.metadata())
-        .isEqualTo(new TreeMap<>(Map.of("operation", "grpc.request", "observationCount", "1")));
+    assertThat(edge.getSourceNodeId()).isEqualTo(expectedParentId);
+    assertThat(edge.getTargetNodeId()).isEqualTo(expectedChildId);
+    assertThat(edge.getMetadata()).isEqualTo(new TreeMap<>(Map.of("operation", "grpc.request")));
+    assertThat(edge.getObservedCount()).isEqualTo(1);
   }
 
   @Test
@@ -1347,57 +1340,57 @@ public class GraphBuilderTest {
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeAId)
-                    && edge.targetNodeId().equals(expectedNodeCId));
+                edge.getSourceNodeId().equals(expectedNodeAId)
+                    && edge.getTargetNodeId().equals(expectedNodeCId));
 
     // A -> G
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeAId)
-                    && edge.targetNodeId().equals(expectedNodeGId));
+                edge.getSourceNodeId().equals(expectedNodeAId)
+                    && edge.getTargetNodeId().equals(expectedNodeGId));
 
     // C -> E
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeCId)
-                    && edge.targetNodeId().equals(expectedNodeEId));
+                edge.getSourceNodeId().equals(expectedNodeCId)
+                    && edge.getTargetNodeId().equals(expectedNodeEId));
 
     // C -> F
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeCId)
-                    && edge.targetNodeId().equals(expectedNodeFId));
+                edge.getSourceNodeId().equals(expectedNodeCId)
+                    && edge.getTargetNodeId().equals(expectedNodeFId));
 
     // E -> C
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeEId)
-                    && edge.targetNodeId().equals(expectedNodeCId));
+                edge.getSourceNodeId().equals(expectedNodeEId)
+                    && edge.getTargetNodeId().equals(expectedNodeCId));
 
     // F -> C
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeFId)
-                    && edge.targetNodeId().equals(expectedNodeCId));
+                edge.getSourceNodeId().equals(expectedNodeFId)
+                    && edge.getTargetNodeId().equals(expectedNodeCId));
 
     // E -> G
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeEId)
-                    && edge.targetNodeId().equals(expectedNodeGId));
+                edge.getSourceNodeId().equals(expectedNodeEId)
+                    && edge.getTargetNodeId().equals(expectedNodeGId));
 
     // F -> G
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeFId)
-                    && edge.targetNodeId().equals(expectedNodeGId));
+                edge.getSourceNodeId().equals(expectedNodeFId)
+                    && edge.getTargetNodeId().equals(expectedNodeGId));
   }
 
   @Test
@@ -1472,13 +1465,13 @@ public class GraphBuilderTest {
     assertThat(graph.edges())
         .anyMatch(
             edge ->
-                edge.sourceNodeId().equals(expectedNodeAId)
-                    && edge.targetNodeId().equals(expectedNodeBId));
+                edge.getSourceNodeId().equals(expectedNodeAId)
+                    && edge.getTargetNodeId().equals(expectedNodeBId));
 
     Edge edge = graph.edges().get(0);
-    assertThat(edge.metadata())
-        .isEqualTo(
-            new TreeMap<>(Map.of("operation", "dropwizard.request", "observationCount", "1")));
+    assertThat(edge.getMetadata())
+        .isEqualTo(new TreeMap<>(Map.of("operation", "dropwizard.request")));
+    assertThat(edge.getObservedCount()).isEqualTo(1);
   }
 
   @Test
@@ -1534,7 +1527,7 @@ public class GraphBuilderTest {
     // Should have 1 edge with observation count of 3
     assertThat(graph.edges()).hasSize(1);
     Edge edge = graph.edges().get(0);
-    assertThat(edge.metadata())
-        .isEqualTo(new TreeMap<>(Map.of("operation", "op2", "observationCount", "3")));
+    assertThat(edge.getMetadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op2")));
+    assertThat(edge.getObservedCount()).isEqualTo(3);
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -97,7 +97,8 @@ public class GraphBuilderTest {
                 "resource", "/v2/res2"));
 
     // uses canonical path as resource
-    SortedMap<String, String> edgeMetadata = new TreeMap<>(Map.of("operation", "http.request"));
+    SortedMap<String, String> edgeMetadata =
+        new TreeMap<>(Map.of("operation", "http.request", "observationCount", "1"));
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
     Edge edge = graph.edges().iterator().next();
     assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
@@ -201,8 +202,10 @@ public class GraphBuilderTest {
         .isTrue();
 
     // metadata of the edges
-    assertThat(edges.get(0).metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op2")));
-    assertThat(edges.get(1).metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op3")));
+    assertThat(edges.get(0).metadata())
+        .isEqualTo(new TreeMap<>(Map.of("operation", "op2", "observationCount", "1")));
+    assertThat(edges.get(1).metadata())
+        .isEqualTo(new TreeMap<>(Map.of("operation", "op3", "observationCount", "1")));
 
     // verify different children
     List<String> childIds = List.of(edges.stream().map(Edge::targetNodeId).toArray(String[]::new));
@@ -252,7 +255,7 @@ public class GraphBuilderTest {
     // should have only 1 edge despite multiple spans creating the same parent-child relationship
     assertThat(graph.edges()).hasSize(1);
     assertThat(graph.edges().get(0).metadata())
-        .isEqualTo(new TreeMap<>(Map.of("operation", "op2")));
+        .isEqualTo(new TreeMap<>(Map.of("operation", "op2", "observationCount", "2")));
 
     SortedMap<String, String> parentMetadata =
         new TreeMap<>(
@@ -361,21 +364,29 @@ public class GraphBuilderTest {
             edge ->
                 edge.sourceNodeId().equals(expectedRootId)
                     && edge.targetNodeId().equals(expectedChild1Id)
-                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "child1_op"))));
+                    && edge.metadata()
+                        .equals(
+                            new TreeMap<>(
+                                Map.of("operation", "child1_op", "observationCount", "1"))));
 
     assertThat(edges)
         .anyMatch(
             edge ->
                 edge.sourceNodeId().equals(expectedRootId)
                     && edge.targetNodeId().equals(expectedChild2Id)
-                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "child2_op"))));
+                    && edge.metadata()
+                        .equals(
+                            new TreeMap<>(
+                                Map.of("operation", "child2_op", "observationCount", "1"))));
 
     assertThat(edges)
         .anyMatch(
             edge ->
                 edge.sourceNodeId().equals(expectedChild1Id)
                     && edge.targetNodeId().equals(expectedGrandchildId)
-                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "gc_op"))));
+                    && edge.metadata()
+                        .equals(
+                            new TreeMap<>(Map.of("operation", "gc_op", "observationCount", "1"))));
   }
 
   @Test
@@ -506,7 +517,9 @@ public class GraphBuilderTest {
             edge ->
                 edge.sourceNodeId().equals(expectedNodeAId)
                     && edge.targetNodeId().equals(expectedNodeBId)
-                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opB"))));
+                    && edge.metadata()
+                        .equals(
+                            new TreeMap<>(Map.of("operation", "opB", "observationCount", "1"))));
 
     // B -> C
     assertThat(graph.edges())
@@ -514,7 +527,9 @@ public class GraphBuilderTest {
             edge ->
                 edge.sourceNodeId().equals(expectedNodeBId)
                     && edge.targetNodeId().equals(expectedNodeCId)
-                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opC"))));
+                    && edge.metadata()
+                        .equals(
+                            new TreeMap<>(Map.of("operation", "opC", "observationCount", "1"))));
 
     // D -> B
     assertThat(graph.edges())
@@ -522,7 +537,9 @@ public class GraphBuilderTest {
             edge ->
                 edge.sourceNodeId().equals(expectedNodeDId)
                     && edge.targetNodeId().equals(expectedNodeBId)
-                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opB"))));
+                    && edge.metadata()
+                        .equals(
+                            new TreeMap<>(Map.of("operation", "opB", "observationCount", "1"))));
 
     // B -> E
     assertThat(graph.edges())
@@ -530,7 +547,9 @@ public class GraphBuilderTest {
             edge ->
                 edge.sourceNodeId().equals(expectedNodeBId)
                     && edge.targetNodeId().equals(expectedNodeEId)
-                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opE"))));
+                    && edge.metadata()
+                        .equals(
+                            new TreeMap<>(Map.of("operation", "opE", "observationCount", "1"))));
 
     // E -> B
     assertThat(graph.edges())
@@ -538,7 +557,9 @@ public class GraphBuilderTest {
             edge ->
                 edge.sourceNodeId().equals(expectedNodeEId)
                     && edge.targetNodeId().equals(expectedNodeBId)
-                    && edge.metadata().equals(new TreeMap<>(Map.of("operation", "opB"))));
+                    && edge.metadata()
+                        .equals(
+                            new TreeMap<>(Map.of("operation", "opB", "observationCount", "1"))));
   }
 
   @Test
@@ -615,7 +636,8 @@ public class GraphBuilderTest {
     Edge edge = graph.edges().get(0);
     assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
     assertThat(edge.targetNodeId()).isEqualTo(expectedChild1Id);
-    assertThat(edge.metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "http.request")));
+    assertThat(edge.metadata())
+        .isEqualTo(new TreeMap<>(Map.of("operation", "http.request", "observationCount", "1")));
   }
 
   @Test
@@ -696,7 +718,8 @@ public class GraphBuilderTest {
     Edge edge = graph.edges().get(0);
     assertThat(edge.sourceNodeId()).isEqualTo(expectedRootId);
     assertThat(edge.targetNodeId()).isEqualTo(expectedGrandchildId);
-    assertThat(edge.metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "http.request")));
+    assertThat(edge.metadata())
+        .isEqualTo(new TreeMap<>(Map.of("operation", "http.request", "observationCount", "1")));
   }
 
   @Test
@@ -1076,7 +1099,8 @@ public class GraphBuilderTest {
     Edge edge = graph.edges().get(0);
     assertThat(edge.sourceNodeId()).isEqualTo(expectedParentId);
     assertThat(edge.targetNodeId()).isEqualTo(expectedChildId);
-    assertThat(edge.metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "grpc.request")));
+    assertThat(edge.metadata())
+        .isEqualTo(new TreeMap<>(Map.of("operation", "grpc.request", "observationCount", "1")));
   }
 
   @Test
@@ -1452,6 +1476,65 @@ public class GraphBuilderTest {
                     && edge.targetNodeId().equals(expectedNodeBId));
 
     Edge edge = graph.edges().get(0);
-    assertThat(edge.metadata()).isEqualTo(new TreeMap<>(Map.of("operation", "dropwizard.request")));
+    assertThat(edge.metadata())
+        .isEqualTo(
+            new TreeMap<>(Map.of("operation", "dropwizard.request", "observationCount", "1")));
+  }
+
+  @Test
+  void buildFromSpans_multipleSpansSameEdge_incrementsObservationCount() {
+    // Create 3 spans that all create the same logical edge (same parent node -> same child node)
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            TestUtils.createSpanWithTags(
+                "parent1",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "app1",
+                    "kube.namespace", "ns1",
+                    "operation_name", "op1",
+                    "resource", "res1")),
+            // First child span - creates edge from parent to child node
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "ns2",
+                    "operation_name", "op2",
+                    "resource", "res2")),
+            // Second child span - same node metadata, different span ID
+            TestUtils.createSpanWithTags(
+                "child2",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "ns2",
+                    "operation_name", "op2",
+                    "resource", "res2")),
+            // Third child span - same node metadata, different span ID
+            TestUtils.createSpanWithTags(
+                "child3",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "ns2",
+                    "operation_name", "op2",
+                    "resource", "res2")));
+
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
+
+    // Should have 2 nodes (parent and child - all child spans map to same logical node)
+    assertThat(graph.nodes()).hasSize(2);
+
+    // Should have 1 edge with observation count of 3
+    assertThat(graph.edges()).hasSize(1);
+    Edge edge = graph.edges().get(0);
+    assertThat(edge.metadata())
+        .isEqualTo(new TreeMap<>(Map.of("operation", "op2", "observationCount", "3")));
   }
 }


### PR DESCRIPTION
###  Summary

We'd like to calculate edge weights. To do that we need the number of times an edge was observed when building the subgraph for a trace. 

Add an `observedCount` to the `Edge` that increments every time we see an edge during a traversal. Edge can no longer be a record class since this count is mutable.

### Testing
- unit tests
- staging
```
▲ ~ curl -X GET --get "http://localhost:8081/api/v1/trace/rPmLlEfZ2J5dsDd9VFJiJA==/subgraph" \
--data-urlencode 'buildFilter={"operation_name":["http.request"]}' \
--data-urlencode 'maxSpans=20000' \
-H "Content-Type: application/json" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  103k  100  103k    0     0   147k      0 --:--:-- --:--:-- --:--:--  147k
{
  "subgraph": {
    "edges": [
      {
        "metadata": {
          "operation": "http.request"
        },
        "observedCount": 1,
        "sourceNodeId": "c681bb41490c20b03816371cbef3bbbdcbd1ca52303cbfb2e7865480de7b7677",
        "targetNodeId": "6585c20e434585543a21f07092054fd5df5c5af79501ff3d0e6665eae10d9836"
      },
      {
        "metadata": {
          "operation": "http.request"
        },
        "observedCount": 17,
        "sourceNodeId": "934d0314226c19cfae61d5d8cea9f93350e9265c6a3de1de91223fe85c8cc464",
        "targetNodeId": "0ac80bd108af13887ae74040a60d45b9373d9ae6dc90a682950347b6fd92ec9b"
      },
      {
        "metadata": {
          "operation": "http.request"
        },
        "observedCount": 2,
        "sourceNodeId": "21d033d020f3331dd3d1826be1b91e98c1f2e83792e58542bd74bebd40648d0d",
        "targetNodeId": "e638e7f56db2f014ad8667dbef26e0d48a793b9939bf40a204ca10d322781689"
      },
      {
        "metadata": {
          "operation": "http.request"
        },
        "observedCount": 2,
        "sourceNodeId": "21d033d020f3331dd3d1826be1b91e98c1f2e83792e58542bd74bebd40648d0d",
        "targetNodeId": "96dbb00b5c4a8bb887d09eba1ef081a8ad92b566555322cff8063364ca92b92d"
      },
      {
        "metadata": {
          "operation": "http.request"
        },
        "observedCount": 2,
        "sourceNodeId": "153f5aa49b85746b522a2c3aa55e7e379803bdd645902ef8df86d7d5fc241aa2",
        "targetNodeId": "75cb8670de7564f6514d8e41460edd22861bf10740724d1ad9acc43a39f3cbdf"
      },
      {
        "metadata": {
          "operation": "http.request"
        },
        "observedCount": 1,
        "sourceNodeId": "21d033d020f3331dd3d1826be1b91e98c1f2e83792e58542bd74bebd40648d0d",
        "targetNodeId": "220a0c7f90a57284e76e6c5746ea06fe6dd0f68713aaefda9cf581fbf24ba6f4"
      },
      {
        "metadata": {
          "operation": "http.request"
        },
        "observedCount": 20,
        "sourceNodeId": "4b5e36220a134c109af46b7795cd3b7a5f0429ea4ca7792ddb3ec3f5ff31237b",
        "targetNodeId": "9305fc8e16c13c832c75fba81eff01734c6f5eca6971311b4d53ea7627b8322e"
      },
...
```

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
