### PR TITLE
zipkin-api coerce long as span id to hex

### DIFF
--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -31,9 +31,11 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,9 +104,8 @@ public class TraceFetcher {
     // If input is hex → convert to Base64 URL-safe
     if (traceId.matches("^[0-9a-fA-F]+$") && traceId.length() % 2 == 0) {
       try {
-        byte[] bytes = Hex.decodeHex(traceId.toCharArray());
+        base64Url = base64EncodeHexEncodedId(traceId);
         hex = traceId.toLowerCase();
-        base64Url = Base64.getUrlEncoder().encodeToString(bytes);
         return new TraceIds(hex, base64Url);
       } catch (Exception ignored) {
         return null;
@@ -113,13 +114,22 @@ public class TraceFetcher {
 
     // Otherwise, assume Base64-URL → convert to hex
     try {
-      byte[] bytes = Base64.getUrlDecoder().decode(traceId);
-      hex = Hex.encodeHexString(bytes);
+      hex = hexEncodeBase64EncodedId(traceId);
       base64Url = traceId;
       return new TraceIds(hex, base64Url);
     } catch (Exception ignored) {
       return null;
     }
+  }
+
+  static String base64EncodeHexEncodedId(String traceId) throws DecoderException {
+    byte[] bytes = Hex.decodeHex(traceId.toCharArray());
+    return Base64.getUrlEncoder().encodeToString(bytes);
+  }
+
+  private static @NonNull String hexEncodeBase64EncodedId(String traceId) {
+    byte[] bytes = Base64.getUrlDecoder().decode(traceId);
+    return Hex.encodeHexString(bytes);
   }
 
   private static JSONObject singleTermQuery(String traceFieldName, String traceId) {
@@ -378,7 +388,8 @@ public class TraceFetcher {
       }
 
       final ZipkinSpanResponse span =
-          new ZipkinSpanResponse(maybeMapLongStringToHexString(id), messageTraceId);
+          new ZipkinSpanResponse(
+              maybeMapLongStringToHexString(id), maybeMapBase64ToHexString(messageTraceId));
       span.setParentId(maybeMapLongStringToHexString(parentId));
       span.setName(name);
       if (serviceName != null) {
@@ -393,6 +404,19 @@ public class TraceFetcher {
     }
 
     return traces;
+  }
+
+  private static final Pattern BASE64_PATTERN = Pattern.compile("^[A-Za-z0-9_-]+==$");
+
+  static String maybeMapBase64ToHexString(String messageTraceId) {
+    if (messageTraceId == null) {
+      return null;
+    }
+
+    if (!BASE64_PATTERN.matcher(messageTraceId).matches()) {
+      return messageTraceId;
+    }
+    return hexEncodeBase64EncodedId(messageTraceId);
   }
 
   // returning LogWireMessage instead of LogMessage

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -33,9 +33,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,7 +106,7 @@ public class TraceFetcher {
     // If input is hex → convert to Base64 URL-safe
     if (traceId.matches("^[0-9a-fA-F]+$") && traceId.length() % 2 == 0) {
       try {
-        base64Url = base64EncodeHexEncodedId(traceId);
+        base64Url = base64EncodeHexEncodedId(normalizeHexTraceId(traceId));
         hex = traceId.toLowerCase();
         return new TraceIds(hex, base64Url);
       } catch (Exception ignored) {
@@ -312,22 +314,6 @@ public class TraceFetcher {
     return objectMapper.writeValueAsString(result.spans);
   }
 
-  static String maybeMapLongStringToHexString(String value) {
-    if (value == null) {
-      return null;
-    }
-    // assume if it's 16 or less chars, it'll be fine. [0-9]{16} or less will decode properly
-    if (value.length() <= 16) {
-      return value;
-    }
-    try {
-      long longValue = Long.parseLong(value);
-      return Long.toHexString(longValue);
-    } catch (NumberFormatException e) {
-      return value;
-    }
-  }
-
   protected static List<ZipkinSpanResponse> convertLogWireMessageToZipkinSpan(
       List<LogWireMessage> messages) throws JsonProcessingException {
     List<ZipkinSpanResponse> traces = new ArrayList<>(messages.size());
@@ -389,8 +375,8 @@ public class TraceFetcher {
 
       final ZipkinSpanResponse span =
           new ZipkinSpanResponse(
-              maybeMapLongStringToHexString(id), maybeMapBase64ToHexString(messageTraceId));
-      span.setParentId(maybeMapLongStringToHexString(parentId));
+              maybeMapLongSpanIdToHex(id), maybeMapBase64TraceIdToHex(messageTraceId));
+      span.setParentId(maybeMapLongSpanIdToHex(parentId));
       span.setName(name);
       if (serviceName != null) {
         ZipkinEndpointResponse remoteEndpoint = new ZipkinEndpointResponse();
@@ -406,18 +392,37 @@ public class TraceFetcher {
     return traces;
   }
 
-  private static final Pattern BASE64_PATTERN = Pattern.compile("^[A-Za-z0-9_-]+==$");
-
-  static String maybeMapBase64ToHexString(String messageTraceId) {
+  static @Nullable String maybeMapBase64TraceIdToHex(String messageTraceId) {
     if (messageTraceId == null) {
       return null;
-    }
-
-    if (!BASE64_PATTERN.matcher(messageTraceId).matches()) {
+    } else if (!BASE64_PATTERN.matcher(messageTraceId).matches()) {
       return messageTraceId;
+    } else {
+      return normalizeHexTraceId(hexEncodeBase64EncodedId(messageTraceId));
     }
-    return hexEncodeBase64EncodedId(messageTraceId);
   }
+
+  private static String normalizeHexTraceId(@NonNull String hexTraceId) {
+    return StringUtils.leftPad(hexTraceId, 32, '0');
+  }
+
+  static @Nullable String maybeMapLongSpanIdToHex(String id) {
+    // assume if it's 16 or less chars, it'll be fine. [0-9]{16} or less will decode properly
+    if (id == null) {
+      return null;
+    } else if (id.length() <= 16) {
+      return id;
+    } else {
+      try {
+        long longValue = Long.parseLong(id);
+        return StringUtils.leftPad(Long.toHexString(longValue), 16, '0');
+      } catch (NumberFormatException e) {
+        return id;
+      }
+    }
+  }
+
+  private static final Pattern BASE64_PATTERN = Pattern.compile("^[A-Za-z0-9_-]+==$");
 
   // returning LogWireMessage instead of LogMessage
   // If we return LogMessage the caller then needs to call getSource which is a deep copy of the

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -302,6 +302,22 @@ public class TraceFetcher {
     return objectMapper.writeValueAsString(result.spans);
   }
 
+  static String maybeMapLongStringToHexString(String value) {
+    if (value == null) {
+      return null;
+    }
+    // assume if it's 16 or less chars, it'll be fine. [0-9]{16} or less will decode properly
+    if (value.length() <= 16) {
+      return value;
+    }
+    try {
+      long longValue = Long.parseLong(value);
+      return Long.toHexString(longValue);
+    } catch (NumberFormatException e) {
+      return value;
+    }
+  }
+
   protected static List<ZipkinSpanResponse> convertLogWireMessageToZipkinSpan(
       List<LogWireMessage> messages) throws JsonProcessingException {
     List<ZipkinSpanResponse> traces = new ArrayList<>(messages.size());
@@ -361,8 +377,9 @@ public class TraceFetcher {
         continue;
       }
 
-      final ZipkinSpanResponse span = new ZipkinSpanResponse(id, messageTraceId);
-      span.setParentId(parentId);
+      final ZipkinSpanResponse span =
+          new ZipkinSpanResponse(maybeMapLongStringToHexString(id), messageTraceId);
+      span.setParentId(maybeMapLongStringToHexString(parentId));
       span.setName(name);
       if (serviceName != null) {
         ZipkinEndpointResponse remoteEndpoint = new ZipkinEndpointResponse();

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -97,6 +97,7 @@ public class TraceFetcher {
     // DD trace id is a long encoded as a string.
     private static final Pattern DIGITS = Pattern.compile("^\\d+$");
     private static final Pattern BASE64_PATTERN = Pattern.compile("^[A-Za-z0-9_-]+==$");
+    private static final Pattern HEX_PATTERN = Pattern.compile("^[0-9a-fA-F]+$");
 
     static TraceIds base64AndHex(String traceId) {
       // If input is hex → convert to Base64 URL-safe
@@ -104,11 +105,11 @@ public class TraceFetcher {
     }
 
     private static @NonNull TraceIds base64AndHex(String traceId, boolean onlyOneRepresentation) {
-      // in the case of being unable to convert, we fallback to original traceId
+      // in the case of being unable to convert, we fall back to original traceId
       if (traceId == null || traceId.isEmpty()) return TraceIds.fallback(traceId);
       String hex = null;
       String base64Url = null;
-      if (traceId.matches("^[0-9a-fA-F]+$") && traceId.length() % 2 == 0) {
+      if (HEX_PATTERN.matcher(traceId).matches() && traceId.length() % 2 == 0) {
         try {
           base64Url = base64EncodeHexEncodedId(normalizeHexTraceId(traceId));
           hex = traceId.toLowerCase();

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -95,47 +95,57 @@ public class TraceFetcher {
     return s != null && DIGITS.matcher(s).matches();
   }
 
-  private record TraceIds(String traceIdField, String original, String hex, String base64) {
+  private record TraceIds(
+      String traceIdField,
+      boolean onlyOneRepresentationForQueries,
+      String original,
+      String hex,
+      String base64) {
     static TraceIds base64AndHex(String traceId) {
-      // in the case of being unable to convert, we fallback to original traceId
-      if (traceId == null || traceId.isEmpty()) return TraceIds.original(traceId);
+      // If input is hex → convert to Base64 URL-safe
+      return base64AndHex(traceId, false);
+    }
 
+    private static @NonNull TraceIds base64AndHex(String traceId, boolean onlyOneRepresentation) {
+      // in the case of being unable to convert, we fallback to original traceId
+      if (traceId == null || traceId.isEmpty()) return TraceIds.fallback(traceId);
       String hex = null;
       String base64Url = null;
-
-      // If input is hex → convert to Base64 URL-safe
-      String traceIdField = "trace_id";
       if (traceId.matches("^[0-9a-fA-F]+$") && traceId.length() % 2 == 0) {
         try {
           base64Url = base64EncodeHexEncodedId(normalizeHexTraceId(traceId));
           hex = traceId.toLowerCase();
-          return new TraceIds(traceIdField, traceId, hex, base64Url);
+          return new TraceIds("trace_id", onlyOneRepresentation, traceId, hex, base64Url);
         } catch (Exception ignored) {
-          return TraceIds.original(traceId);
+          return TraceIds.fallback(traceId);
         }
       }
       // Otherwise, assume Base64-URL → convert to hex
       try {
         hex = hexEncodeBase64EncodedId(traceId);
         base64Url = traceId;
-        return new TraceIds(traceIdField, traceId, hex, base64Url);
+        return new TraceIds("trace_id", onlyOneRepresentation, traceId, hex, base64Url);
       } catch (Exception ignored) {
-        return TraceIds.original(traceId);
+        return TraceIds.fallback(traceId);
       }
     }
 
     public static TraceIds ddTraceId(String traceId) {
-      return new TraceIds("dd_trace_id", traceId, null, null);
+      return new TraceIds("dd_trace_id", true, traceId, null, null);
     }
 
     public static TraceIds original(String traceId) {
-      return new TraceIds("trace_id", traceId, null, null);
+      return base64AndHex(traceId, true);
+    }
+
+    private static TraceIds fallback(String traceId) {
+      return new TraceIds("trace_id", true, traceId, null, null);
     }
 
     public JSONObject buildTraceIdQuery() {
       String firstId;
       String secondId;
-      if (hex == null && base64 == null) {
+      if (this.onlyOneRepresentationForQueries()) {
         firstId = original;
         secondId = null;
       } else {
@@ -206,9 +216,9 @@ public class TraceFetcher {
     TraceIds traceIds;
     // if trace id looks like dd_trace_id, then use dd_trace_id field to search. If true, ignores
     // the hex/base64 flag
-    if (ddTraceIdEnabled.isPresent() && ddTraceIdEnabled.get() && isDDTraceId(traceId)) {
+    if (ddTraceIdEnabled.orElse(false) && isDDTraceId(traceId)) {
       traceIds = TraceIds.ddTraceId(traceId);
-    } else if (searchByHexAndBase64.isPresent() && searchByHexAndBase64.get()) {
+    } else if (searchByHexAndBase64.orElse(false)) {
       traceIds = TraceIds.base64AndHex(traceId);
     } else {
       traceIds = TraceIds.original(traceId);
@@ -222,7 +232,7 @@ public class TraceFetcher {
       // cache for data freshness
       String traceData = retrieveDataFromBlobStoreCache(traceIds.cacheKey());
       if (traceData != null) {
-        LOG.info("Trace data retrieved from blob store cache for traceId={}", traceIds.cacheKey());
+        LOG.info("Trace data retrieved from blob store cache for traceId={}", traceIds);
         return new Result(traceData);
       }
     }
@@ -271,8 +281,7 @@ public class TraceFetcher {
 
       if (shouldSaveToBlobStoreCache(latestSpanTimestamp, dataFreshnessInSecondsValue)) {
         LOG.info(
-            "Data freshness check done, can be saved to blob store cache for traceId={}",
-            traceIds.cacheKey());
+            "Data freshness check done, can be saved to blob store cache for traceId={}", traceIds);
         // Save the trace data to blob store cache
         saveDataToBlobStoreCache(traceIds.cacheKey(), objectMapper.writeValueAsString(spans));
       }

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -146,10 +146,8 @@ public class TraceFetcher {
     }
 
     public String cacheKey() {
-      // to ensure we only cache the same trace once, we use the base64 version as the cache key.
-      return base64 != null ? base64 : original;
-      // TODO we will change to the below in the next commit
-      //      return hex != null ? hex : original;
+      // to ensure we only cache the same trace once, we use the hex version as the cache key.
+      return hex != null ? hex : original;
     }
   }
 

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -88,19 +88,16 @@ public class TraceFetcher {
           .serializationInclusion(JsonInclude.Include.NON_EMPTY)
           .build();
 
-  // DD trace id is a long encoded as a string.
-  private static final Pattern DIGITS = Pattern.compile("^\\d+$");
-
-  private static boolean isDDTraceId(String s) {
-    return s != null && DIGITS.matcher(s).matches();
-  }
-
-  private record TraceIds(
+  record TraceIds(
       String traceIdField,
       boolean onlyOneRepresentationForQueries,
       String original,
       String hex,
       String base64) {
+    // DD trace id is a long encoded as a string.
+    private static final Pattern DIGITS = Pattern.compile("^\\d+$");
+    private static final Pattern BASE64_PATTERN = Pattern.compile("^[A-Za-z0-9_-]+==$");
+
     static TraceIds base64AndHex(String traceId) {
       // If input is hex → convert to Base64 URL-safe
       return base64AndHex(traceId, false);
@@ -142,6 +139,81 @@ public class TraceFetcher {
       return new TraceIds("trace_id", true, traceId, null, null);
     }
 
+    private static boolean isDDTraceId(String s) {
+      return s != null && DIGITS.matcher(s).matches();
+    }
+
+    static @Nullable String maybeMapBase64TraceIdToHex(String messageTraceId) {
+      if (messageTraceId == null) {
+        return null;
+      } else if (!BASE64_PATTERN.matcher(messageTraceId).matches()) {
+        return messageTraceId;
+      } else {
+        return normalizeHexTraceId(hexEncodeBase64EncodedId(messageTraceId));
+      }
+    }
+
+    static String base64EncodeHexEncodedId(String traceId) throws DecoderException {
+      byte[] bytes = Hex.decodeHex(traceId.toCharArray());
+      return Base64.getUrlEncoder().encodeToString(bytes);
+    }
+
+    private static @NonNull String hexEncodeBase64EncodedId(String traceId) {
+      byte[] bytes = Base64.getUrlDecoder().decode(traceId);
+      return Hex.encodeHexString(bytes);
+    }
+
+    private static JSONObject singleTermQuery(String traceFieldName, String traceId) {
+      JSONObject traceObject = new JSONObject();
+      traceObject.put(traceFieldName, traceId);
+      JSONObject queryJson = new JSONObject();
+      queryJson.put("term", traceObject);
+      return queryJson;
+    }
+
+    private static JSONObject buildTraceIdQuery(
+        String traceFieldName, String traceId, String convertedId) {
+      // When there is no converted ID, return the original simple term query
+      if (convertedId == null) {
+        return singleTermQuery(traceFieldName, traceId);
+      }
+
+      // When we have a convertedId, do traceId OR convertedId
+      JSONArray shouldArray = new JSONArray();
+      // term for original traceId
+      shouldArray.put(singleTermQuery(traceFieldName, traceId));
+      // term for convertedId
+      shouldArray.put(singleTermQuery(traceFieldName, convertedId));
+      JSONObject boolQuery = new JSONObject();
+      boolQuery.put("should", shouldArray);
+      boolQuery.put("minimum_should_match", 1);
+
+      JSONObject queryJson = new JSONObject();
+      queryJson.put("bool", boolQuery);
+
+      return queryJson;
+    }
+
+    private static String normalizeHexTraceId(@NonNull String hexTraceId) {
+      return StringUtils.leftPad(hexTraceId, 32, '0');
+    }
+
+    static @Nullable String maybeMapLongSpanIdToHex(String id) {
+      // assume if it's 16 or less chars, it'll be fine. [0-9]{16} or less will decode properly
+      if (id == null) {
+        return null;
+      } else if (id.length() <= 16) {
+        return id;
+      } else {
+        try {
+          long longValue = Long.parseLong(id);
+          return StringUtils.leftPad(Long.toHexString(longValue), 16, '0');
+        } catch (NumberFormatException e) {
+          return id;
+        }
+      }
+    }
+
     public JSONObject buildTraceIdQuery() {
       String firstId;
       String secondId;
@@ -152,54 +224,13 @@ public class TraceFetcher {
         firstId = base64;
         secondId = hex;
       }
-      return TraceFetcher.buildTraceIdQuery(traceIdField, firstId, secondId);
+      return buildTraceIdQuery(traceIdField, firstId, secondId);
     }
 
     public String cacheKey() {
       // to ensure we only cache the same trace once, we use the hex version as the cache key.
       return hex != null ? hex : original;
     }
-  }
-
-  static String base64EncodeHexEncodedId(String traceId) throws DecoderException {
-    byte[] bytes = Hex.decodeHex(traceId.toCharArray());
-    return Base64.getUrlEncoder().encodeToString(bytes);
-  }
-
-  private static @NonNull String hexEncodeBase64EncodedId(String traceId) {
-    byte[] bytes = Base64.getUrlDecoder().decode(traceId);
-    return Hex.encodeHexString(bytes);
-  }
-
-  private static JSONObject singleTermQuery(String traceFieldName, String traceId) {
-    JSONObject traceObject = new JSONObject();
-    traceObject.put(traceFieldName, traceId);
-    JSONObject queryJson = new JSONObject();
-    queryJson.put("term", traceObject);
-    return queryJson;
-  }
-
-  private static JSONObject buildTraceIdQuery(
-      String traceFieldName, String traceId, String convertedId) {
-    // When there is no converted ID, return the original simple term query
-    if (convertedId == null) {
-      return singleTermQuery(traceFieldName, traceId);
-    }
-
-    // When we have a convertedId, do traceId OR convertedId
-    JSONArray shouldArray = new JSONArray();
-    // term for original traceId
-    shouldArray.put(singleTermQuery(traceFieldName, traceId));
-    // term for convertedId
-    shouldArray.put(singleTermQuery(traceFieldName, convertedId));
-    JSONObject boolQuery = new JSONObject();
-    boolQuery.put("should", shouldArray);
-    boolQuery.put("minimum_should_match", 1);
-
-    JSONObject queryJson = new JSONObject();
-    queryJson.put("bool", boolQuery);
-
-    return queryJson;
   }
 
   private Result fetchTraceResult(
@@ -216,7 +247,7 @@ public class TraceFetcher {
     TraceIds traceIds;
     // if trace id looks like dd_trace_id, then use dd_trace_id field to search. If true, ignores
     // the hex/base64 flag
-    if (ddTraceIdEnabled.orElse(false) && isDDTraceId(traceId)) {
+    if (ddTraceIdEnabled.orElse(false) && TraceIds.isDDTraceId(traceId)) {
       traceIds = TraceIds.ddTraceId(traceId);
     } else if (searchByHexAndBase64.orElse(false)) {
       traceIds = TraceIds.base64AndHex(traceId);
@@ -405,8 +436,8 @@ public class TraceFetcher {
 
       final ZipkinSpanResponse span =
           new ZipkinSpanResponse(
-              maybeMapLongSpanIdToHex(id), maybeMapBase64TraceIdToHex(messageTraceId));
-      span.setParentId(maybeMapLongSpanIdToHex(parentId));
+              TraceIds.maybeMapLongSpanIdToHex(id), TraceIds.maybeMapBase64TraceIdToHex(messageTraceId));
+      span.setParentId(TraceIds.maybeMapLongSpanIdToHex(parentId));
       span.setName(name);
       if (serviceName != null) {
         ZipkinEndpointResponse remoteEndpoint = new ZipkinEndpointResponse();
@@ -421,38 +452,6 @@ public class TraceFetcher {
 
     return traces;
   }
-
-  static @Nullable String maybeMapBase64TraceIdToHex(String messageTraceId) {
-    if (messageTraceId == null) {
-      return null;
-    } else if (!BASE64_PATTERN.matcher(messageTraceId).matches()) {
-      return messageTraceId;
-    } else {
-      return normalizeHexTraceId(hexEncodeBase64EncodedId(messageTraceId));
-    }
-  }
-
-  private static String normalizeHexTraceId(@NonNull String hexTraceId) {
-    return StringUtils.leftPad(hexTraceId, 32, '0');
-  }
-
-  static @Nullable String maybeMapLongSpanIdToHex(String id) {
-    // assume if it's 16 or less chars, it'll be fine. [0-9]{16} or less will decode properly
-    if (id == null) {
-      return null;
-    } else if (id.length() <= 16) {
-      return id;
-    } else {
-      try {
-        long longValue = Long.parseLong(id);
-        return StringUtils.leftPad(Long.toHexString(longValue), 16, '0');
-      } catch (NumberFormatException e) {
-        return id;
-      }
-    }
-  }
-
-  private static final Pattern BASE64_PATTERN = Pattern.compile("^[A-Za-z0-9_-]+==$");
 
   // returning LogWireMessage instead of LogMessage
   // If we return LogMessage the caller then needs to call getSource which is a deep copy of the

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -171,29 +171,6 @@ public class TraceFetcher {
       return queryJson;
     }
 
-    private static JSONObject buildTraceIdQuery(
-        String traceFieldName, String traceId, String convertedId) {
-      // When there is no converted ID, return the original simple term query
-      if (convertedId == null) {
-        return singleTermQuery(traceFieldName, traceId);
-      }
-
-      // When we have a convertedId, do traceId OR convertedId
-      JSONArray shouldArray = new JSONArray();
-      // term for original traceId
-      shouldArray.put(singleTermQuery(traceFieldName, traceId));
-      // term for convertedId
-      shouldArray.put(singleTermQuery(traceFieldName, convertedId));
-      JSONObject boolQuery = new JSONObject();
-      boolQuery.put("should", shouldArray);
-      boolQuery.put("minimum_should_match", 1);
-
-      JSONObject queryJson = new JSONObject();
-      queryJson.put("bool", boolQuery);
-
-      return queryJson;
-    }
-
     private static String normalizeHexTraceId(@NonNull String hexTraceId) {
       return StringUtils.leftPad(hexTraceId, 32, '0');
     }
@@ -215,16 +192,19 @@ public class TraceFetcher {
     }
 
     public JSONObject buildTraceIdQuery() {
-      String firstId;
-      String secondId;
+      // if we have only one representation for querying, use that one
+      // otherwise generate a query that searches both base64 and hex representations
       if (this.onlyOneRepresentationForQueries()) {
-        firstId = original;
-        secondId = null;
+        return singleTermQuery(traceIdField, original);
       } else {
-        firstId = base64;
-        secondId = hex;
+        return new JSONObject()
+          .put("bool", new JSONObject()
+            .put("should", new JSONArray()
+              .put(singleTermQuery(traceIdField, base64))
+              .put(singleTermQuery(traceIdField, hex))
+            )
+            .put("minimum_should_match", 1));
       }
-      return buildTraceIdQuery(traceIdField, firstId, secondId);
     }
 
     public String cacheKey() {

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -247,7 +247,7 @@ public class TraceFetcher {
       // cache for data freshness
       String traceData = retrieveDataFromBlobStoreCache(traceIds.cacheKey());
       if (traceData != null) {
-        LOG.info("Trace data retrieved from blob store cache for traceId={}", traceIds);
+        LOG.info("Trace data retrieved from blob store cache for traceId={}", traceId);
         return new Result(traceData);
       }
     }
@@ -296,7 +296,7 @@ public class TraceFetcher {
 
       if (shouldSaveToBlobStoreCache(latestSpanTimestamp, dataFreshnessInSecondsValue)) {
         LOG.info(
-            "Data freshness check done, can be saved to blob store cache for traceId={}", traceIds);
+            "Data freshness check done, can be saved to blob store cache for traceId={}", traceId);
         // Save the trace data to blob store cache
         saveDataToBlobStoreCache(traceIds.cacheKey(), objectMapper.writeValueAsString(spans));
       }

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -199,12 +199,15 @@ public class TraceFetcher {
         return singleTermQuery(traceIdField, original);
       } else {
         return new JSONObject()
-          .put("bool", new JSONObject()
-            .put("should", new JSONArray()
-              .put(singleTermQuery(traceIdField, base64))
-              .put(singleTermQuery(traceIdField, hex))
-            )
-            .put("minimum_should_match", 1));
+            .put(
+                "bool",
+                new JSONObject()
+                    .put(
+                        "should",
+                        new JSONArray()
+                            .put(singleTermQuery(traceIdField, base64))
+                            .put(singleTermQuery(traceIdField, hex)))
+                    .put("minimum_should_match", 1));
       }
     }
 
@@ -417,7 +420,8 @@ public class TraceFetcher {
 
       final ZipkinSpanResponse span =
           new ZipkinSpanResponse(
-              TraceIds.maybeMapLongSpanIdToHex(id), TraceIds.maybeMapBase64TraceIdToHex(messageTraceId));
+              TraceIds.maybeMapLongSpanIdToHex(id),
+              TraceIds.maybeMapBase64TraceIdToHex(messageTraceId));
       span.setParentId(TraceIds.maybeMapLongSpanIdToHex(parentId));
       span.setName(name);
       if (serviceName != null) {

--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -95,32 +95,61 @@ public class TraceFetcher {
     return s != null && DIGITS.matcher(s).matches();
   }
 
-  private record TraceIds(String hex, String base64) {}
+  private record TraceIds(String traceIdField, String original, String hex, String base64) {
+    static TraceIds base64AndHex(String traceId) {
+      // in the case of being unable to convert, we fallback to original traceId
+      if (traceId == null || traceId.isEmpty()) return TraceIds.original(traceId);
 
-  private static TraceIds convertTraceId(String traceId) {
-    if (traceId == null || traceId.isEmpty()) return null;
+      String hex = null;
+      String base64Url = null;
 
-    String hex = null;
-    String base64Url = null;
-
-    // If input is hex → convert to Base64 URL-safe
-    if (traceId.matches("^[0-9a-fA-F]+$") && traceId.length() % 2 == 0) {
+      // If input is hex → convert to Base64 URL-safe
+      String traceIdField = "trace_id";
+      if (traceId.matches("^[0-9a-fA-F]+$") && traceId.length() % 2 == 0) {
+        try {
+          base64Url = base64EncodeHexEncodedId(normalizeHexTraceId(traceId));
+          hex = traceId.toLowerCase();
+          return new TraceIds(traceIdField, traceId, hex, base64Url);
+        } catch (Exception ignored) {
+          return TraceIds.original(traceId);
+        }
+      }
+      // Otherwise, assume Base64-URL → convert to hex
       try {
-        base64Url = base64EncodeHexEncodedId(normalizeHexTraceId(traceId));
-        hex = traceId.toLowerCase();
-        return new TraceIds(hex, base64Url);
+        hex = hexEncodeBase64EncodedId(traceId);
+        base64Url = traceId;
+        return new TraceIds(traceIdField, traceId, hex, base64Url);
       } catch (Exception ignored) {
-        return null;
+        return TraceIds.original(traceId);
       }
     }
 
-    // Otherwise, assume Base64-URL → convert to hex
-    try {
-      hex = hexEncodeBase64EncodedId(traceId);
-      base64Url = traceId;
-      return new TraceIds(hex, base64Url);
-    } catch (Exception ignored) {
-      return null;
+    public static TraceIds ddTraceId(String traceId) {
+      return new TraceIds("dd_trace_id", traceId, null, null);
+    }
+
+    public static TraceIds original(String traceId) {
+      return new TraceIds("trace_id", traceId, null, null);
+    }
+
+    public JSONObject buildTraceIdQuery() {
+      String firstId;
+      String secondId;
+      if (hex == null && base64 == null) {
+        firstId = original;
+        secondId = null;
+      } else {
+        firstId = base64;
+        secondId = hex;
+      }
+      return TraceFetcher.buildTraceIdQuery(traceIdField, firstId, secondId);
+    }
+
+    public String cacheKey() {
+      // to ensure we only cache the same trace once, we use the base64 version as the cache key.
+      return base64 != null ? base64 : original;
+      // TODO we will change to the below in the next commit
+      //      return hex != null ? hex : original;
     }
   }
 
@@ -176,21 +205,15 @@ public class TraceFetcher {
       Optional<Boolean> searchByHexAndBase64)
       throws IOException {
 
-    String traceFieldName = "trace_id";
-    String convertedId = null;
+    TraceIds traceIds;
     // if trace id looks like dd_trace_id, then use dd_trace_id field to search. If true, ignores
     // the hex/base64 flag
     if (ddTraceIdEnabled.isPresent() && ddTraceIdEnabled.get() && isDDTraceId(traceId)) {
-      traceFieldName = "dd_trace_id";
+      traceIds = TraceIds.ddTraceId(traceId);
     } else if (searchByHexAndBase64.isPresent() && searchByHexAndBase64.get()) {
-      TraceIds traceIds = convertTraceId(traceId);
-      // to ensure we only cache the same trace once, we use the base64 version as the traceId.
-      // TraceIds are null
-      // in the case of being unable to convert, fallback to original traceId
-      if (traceIds != null) {
-        traceId = traceIds.base64;
-        convertedId = traceIds.hex;
-      }
+      traceIds = TraceIds.base64AndHex(traceId);
+    } else {
+      traceIds = TraceIds.original(traceId);
     }
 
     // Log the custom header userRequest value if present
@@ -199,15 +222,14 @@ public class TraceFetcher {
 
       // try to retrieve trace data from blob store cache; check timestamp before using blob store
       // cache for data freshness
-      String traceData = retrieveDataFromBlobStoreCache(traceId);
+      String traceData = retrieveDataFromBlobStoreCache(traceIds.cacheKey());
       if (traceData != null) {
-        LOG.info("Trace data retrieved from blob store cache for traceId={}", traceId);
+        LOG.info("Trace data retrieved from blob store cache for traceId={}", traceIds.cacheKey());
         return new Result(traceData);
       }
     }
 
-    JSONObject queryJson = buildTraceIdQuery(traceFieldName, traceId, convertedId);
-    String queryString = queryJson.toString();
+    String queryString = traceIds.buildTraceIdQuery().toString();
     LOG.debug("Querying with queryString={}", queryString);
 
     long startTime =
@@ -251,9 +273,10 @@ public class TraceFetcher {
 
       if (shouldSaveToBlobStoreCache(latestSpanTimestamp, dataFreshnessInSecondsValue)) {
         LOG.info(
-            "Data freshness check done, can be saved to blob store cache for traceId={}", traceId);
+            "Data freshness check done, can be saved to blob store cache for traceId={}",
+            traceIds.cacheKey());
         // Save the trace data to blob store cache
-        saveDataToBlobStoreCache(traceId, objectMapper.writeValueAsString(spans));
+        saveDataToBlobStoreCache(traceIds.cacheKey(), objectMapper.writeValueAsString(spans));
       }
     }
 

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -778,7 +778,10 @@ public class TraceFetcherTest {
           {"1234567890123456", "1234567890123456"},
           {"9223372036854775807", "7fffffffffffffff"},
           {"12345678901234567890", "12345678901234567890"},
-          {"18446744073709551615", "18446744073709551615"}, // largest unsigned 64-bit integer - the code we're working around uses abs of signed longs
+          {
+            "18446744073709551615", "18446744073709551615"
+          }, // largest unsigned 64-bit integer - the code we're working around uses abs of signed
+             // longs
           {"not-a-number-but-long", "not-a-number-but-long"},
         };
 

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -767,4 +767,27 @@ public class TraceFetcherTest {
       // Expected - assertion should fail for null data
     }
   }
+
+  @Test
+  public void testMaybeMapLongStringToHexString() {
+    String[][] cases =
+        new String[][] {
+          {null, null},
+          {"", ""},
+          {"1234567890", "1234567890"},
+          {"1234567890123456", "1234567890123456"},
+          {"9223372036854775807", "7fffffffffffffff"},
+          {"12345678901234567890", "12345678901234567890"},
+          {"18446744073709551615", "18446744073709551615"}, // largest unsigned 64-bit integer - the code we're working around uses abs of signed longs
+          {"not-a-number-but-long", "not-a-number-but-long"},
+        };
+
+    for (String[] aCase : cases) {
+      String input = aCase[0];
+      String expected = aCase[1];
+
+      String actual = TraceFetcher.maybeMapLongStringToHexString(input);
+      assertEquals(expected, actual);
+    }
+  }
 }

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -793,4 +793,33 @@ public class TraceFetcherTest {
       assertEquals(expected, actual);
     }
   }
+
+  @Test
+  public void testMybeMapBase64ToHexString() {
+    String[][] cases =
+        new String[][] {
+          {null, null},
+          {"", ""},
+          {"1234567890==", "d76df8e7aefcf7"},
+          {"1234567890", "1234567890"},
+          {"1234567890123456", "1234567890123456"},
+          {"f____________________w==", "7fffffffffffffffffffffffffffffff"},
+          {"12345678901234567890", "12345678901234567890"},
+          {"AAAAAAAAAAAAAAAAAAAAAA==", "00000000000000000000000000000000"},
+          {"not-a-number-but-long", "not-a-number-but-long"},
+          {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+        };
+
+    for (String[] aCase : cases) {
+      String input = aCase[0];
+      String expected = aCase[1];
+      String actual;
+      try {
+        actual = TraceFetcher.maybeMapBase64ToHexString(input);
+      } catch (Exception e) {
+        throw new RuntimeException("Error processing input: " + input, e);
+      }
+      assertEquals(expected, actual, "Failed for input: " + input);
+    }
+  }
 }

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -208,7 +208,9 @@ public class TraceFetcherTest {
       when(mockTracer.currentSpan()).thenReturn(mockSpan);
 
       String traceId = "test_trace_3";
-      String traceFilePath = String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, traceId);
+      String hexTraceId = "b5eb2dfedada71eff7";
+      String traceFilePath =
+          String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, hexTraceId);
       when(searcher.doSearch(any())).thenReturn(mockSearchResult);
 
       boolean userRequest = true;
@@ -282,6 +284,47 @@ public class TraceFetcherTest {
 
       assertNotNull(response, "Response should not be null");
       assertTrue(response.contains("[]"), "Response should be empty array for empty search result");
+    }
+  }
+
+  @Test
+  public void testGetTraceByTraceId_respectUserRequest_base64_id_uses_hex_cache_key()
+      throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "AAAAAAAAAACZmZmZmZmZmQ==";
+      String hexTraceId = "00000000000000009999999999999999";
+      String traceFilePath =
+          String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, hexTraceId);
+
+      Path filePath = Paths.get(Resources.getResource("zipkinApi/traceData.json").toURI());
+
+      when(searcher.doSearch(any())).thenReturn(mockEmptySearchResult);
+      mockBlobStore.uploadData(traceFilePath, Files.readString(filePath), true);
+
+      boolean userRequest = true;
+      String response =
+          traceFetcher.getByTraceId(
+              traceId,
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty(),
+              Optional.of(userRequest),
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty());
+
+      verify(searcher, never()).doSearch(Mockito.any());
+      verify(mockBlobStore).uploadData(traceFilePath, Files.readString(filePath), true);
+      assertNotNull(response, "Response should not be null");
+      assertTrue(
+          response.contains("1234556789"), "Response should contain the trace ID from cached data");
     }
   }
 
@@ -362,7 +405,9 @@ public class TraceFetcherTest {
       when(mockTracer.currentSpan()).thenReturn(mockSpan);
 
       String traceId = "test_trace_5";
-      String traceFilePath = String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, traceId);
+      String hexTraceId = "b5eb2dfedada71eff9";
+      String traceFilePath =
+          String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, hexTraceId);
 
       Path filePath = Paths.get(Resources.getResource("zipkinApi/traceData.json").toURI());
 
@@ -404,7 +449,9 @@ public class TraceFetcherTest {
       when(mockTracer.currentSpan()).thenReturn(mockSpan);
 
       String traceId = "test_trace_6";
-      String traceFilePath = String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, traceId);
+      String hexTraceId = "b5eb2dfedada71effa";
+      String traceFilePath =
+          String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, hexTraceId);
 
       boolean userRequest = true;
       long dataFreshnessInSeconds =
@@ -460,7 +507,9 @@ public class TraceFetcherTest {
       when(mockTracer.currentSpan()).thenReturn(mockSpan);
 
       String traceId = "test_trace_7";
-      String traceFilePath = String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, traceId);
+      String hexTraceId = "b5eb2dfedada71effb";
+      String traceFilePath =
+          String.format("%s/%s/traceData.json.gz", TRACE_CACHE_PREFIX, hexTraceId);
       boolean userRequest = true;
       long dataFreshnessInSeconds = 100;
 

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -570,6 +570,42 @@ public class TraceFetcherTest {
   }
 
   @Test
+  public void testGetTraceByTraceIdHexBase64_hex32bit() throws Exception {
+    try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
+      // Mocking Tracing and Span
+      Tracer mockTracer = mock(Tracer.class);
+      Span mockSpan = mock(Span.class);
+
+      mockedTracing.when(Tracing::currentTracer).thenReturn(mockTracer);
+      when(mockTracer.currentSpan()).thenReturn(mockSpan);
+
+      String traceId = "dfd66f985ddfc26c";
+      String convertedTraceId = "AAAAAAAAAADf1m-YXd_CbA==";
+      when(searcher.doSearch(any())).thenReturn(mockSearchResult);
+
+      traceFetcher.getByTraceId(
+          traceId,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(Boolean.TRUE));
+
+      verify(searcher)
+          .doSearch(
+              Mockito.argThat(
+                  request ->
+                      request.getHowMany() == defaultMaxSpans
+                          && request.getQuery().contains("\"trace_id\":\"" + traceId + "\"")
+                          && request
+                              .getQuery()
+                              .contains("\"trace_id\":\"" + convertedTraceId + "\"")));
+    }
+  }
+
+  @Test
   public void testGetTraceByTraceIdHexBase64_invalid_to_convert() throws Exception {
     try (MockedStatic<Tracing> mockedTracing = mockStatic(Tracing.class)) {
       // Mocking Tracing and Span
@@ -769,7 +805,7 @@ public class TraceFetcherTest {
   }
 
   @Test
-  public void testMaybeMapLongStringToHexString() {
+  public void testMaybeMapLongSpanIdToHex() {
     String[][] cases =
         new String[][] {
           {null, null},
@@ -789,23 +825,25 @@ public class TraceFetcherTest {
       String input = aCase[0];
       String expected = aCase[1];
 
-      String actual = TraceFetcher.maybeMapLongStringToHexString(input);
+      String actual = TraceFetcher.maybeMapLongSpanIdToHex(input);
       assertEquals(expected, actual);
     }
   }
 
   @Test
-  public void testMybeMapBase64ToHexString() {
+  public void testMaybeMapBase64TraceIdToHex() {
     String[][] cases =
         new String[][] {
           {null, null},
           {"", ""},
-          {"1234567890==", "d76df8e7aefcf7"},
+          {"1234567890==", "000000000000000000d76df8e7aefcf7"},
+          {"1234567890==", "000000000000000000d76df8e7aefcf7"},
           {"1234567890", "1234567890"},
           {"1234567890123456", "1234567890123456"},
           {"f____________________w==", "7fffffffffffffffffffffffffffffff"},
           {"12345678901234567890", "12345678901234567890"},
-          {"AAAAAAAAAAAAAAAAAAAAAA==", "00000000000000000000000000000000"},
+          {"AAAAAAAAAACZmZmZmZmZmQ==", "00000000000000009999999999999999"},
+          {"00000000000000000000000000000000", "00000000000000000000000000000000"},
           {"not-a-number-but-long", "not-a-number-but-long"},
           {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
         };
@@ -815,7 +853,7 @@ public class TraceFetcherTest {
       String expected = aCase[1];
       String actual;
       try {
-        actual = TraceFetcher.maybeMapBase64ToHexString(input);
+        actual = TraceFetcher.maybeMapBase64TraceIdToHex(input);
       } catch (Exception e) {
         throw new RuntimeException("Error processing input: " + input, e);
       }

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -781,7 +781,7 @@ public class TraceFetcherTest {
           {
             "18446744073709551615", "18446744073709551615"
           }, // largest unsigned 64-bit integer - the code we're working around uses abs of signed
-             // longs
+          // longs
           {"not-a-number-but-long", "not-a-number-but-long"},
         };
 

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -874,7 +874,7 @@ public class TraceFetcherTest {
       String input = aCase[0];
       String expected = aCase[1];
 
-      String actual = TraceFetcher.maybeMapLongSpanIdToHex(input);
+      String actual = TraceFetcher.TraceIds.maybeMapLongSpanIdToHex(input);
       assertEquals(expected, actual);
     }
   }
@@ -902,7 +902,7 @@ public class TraceFetcherTest {
       String expected = aCase[1];
       String actual;
       try {
-        actual = TraceFetcher.maybeMapBase64TraceIdToHex(input);
+        actual = TraceFetcher.TraceIds.maybeMapBase64TraceIdToHex(input);
       } catch (Exception e) {
         throw new RuntimeException("Error processing input: " + input, e);
       }


### PR DESCRIPTION
###  Summary

For *reasons*, we have some span ids that are encoded as string representations of longs. Grafana's newer zipkin plugin assumes, reasonably, that span ids are 64bit hex encoded strings and some of these strings are too long to be handled successfully by it.

This takes ids that are too long and reencodes them to hex.

### Requirements

* [ ] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
