### PR TITLE
normalize span and trace ids

### DIFF
--- a/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/TraceFetcher.java
@@ -18,6 +18,7 @@ import com.slack.astra.proto.service.AstraSearch;
 import com.slack.astra.server.AstraQueryServiceBase;
 import com.slack.astra.util.JsonUtil;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -33,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.MurmurHash3;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -145,10 +147,13 @@ public class TraceFetcher {
     }
 
     static @Nullable String maybeMapBase64TraceIdToHex(String messageTraceId) {
-      if (messageTraceId == null) {
+      if (messageTraceId == null || messageTraceId.isEmpty() || messageTraceId.equals("-1")) {
         return null;
+      } else if (HEX_PATTERN.matcher(messageTraceId).matches() && messageTraceId.length() <= 32) {
+        return normalizeHexTraceId(messageTraceId.toLowerCase());
       } else if (!BASE64_PATTERN.matcher(messageTraceId).matches()) {
-        return messageTraceId;
+        long[] hash = MurmurHash3.hash128(messageTraceId.getBytes(StandardCharsets.UTF_8));
+        return normalizeHexTraceId(Long.toHexString(hash[0]) + Long.toHexString(hash[1]));
       } else {
         return normalizeHexTraceId(hexEncodeBase64EncodedId(messageTraceId));
       }
@@ -178,17 +183,18 @@ public class TraceFetcher {
 
     static @Nullable String maybeMapLongSpanIdToHex(String id) {
       // assume if it's 16 or less chars, it'll be fine. [0-9]{16} or less will decode properly
-      if (id == null) {
+      if (id == null || id.isEmpty() || id.equals("-1")) {
         return null;
-      } else if (id.length() <= 16) {
-        return id;
+      } else if (id.length() <= 16 && HEX_PATTERN.matcher(id).matches()) {
+        return id.toLowerCase();
       } else {
+        long longValue;
         try {
-          long longValue = Long.parseLong(id);
-          return StringUtils.leftPad(Long.toHexString(longValue), 16, '0');
+          longValue = Long.parseLong(id);
         } catch (NumberFormatException e) {
-          return id;
+          longValue = MurmurHash3.hash128(id.getBytes(StandardCharsets.UTF_8))[0];
         }
+        return StringUtils.leftPad(Long.toHexString(longValue), 16, '0');
       }
     }
 

--- a/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/TraceFetcherTest.java
@@ -858,16 +858,19 @@ public class TraceFetcherTest {
     String[][] cases =
         new String[][] {
           {null, null},
-          {"", ""},
+          {"", null},
+          {"-1", null},
+          {"ABCD", "abcd"},
+          {"not-a-number", "5118cb5950593214"},
           {"1234567890", "1234567890"},
           {"1234567890123456", "1234567890123456"},
           {"9223372036854775807", "7fffffffffffffff"},
-          {"12345678901234567890", "12345678901234567890"},
+          {"12345678901234567890", "24991545f5fe1363"},
           {
-            "18446744073709551615", "18446744073709551615"
+            "18446744073709551615", "1f052584a302c256"
           }, // largest unsigned 64-bit integer - the code we're working around uses abs of signed
           // longs
-          {"not-a-number-but-long", "not-a-number-but-long"},
+          {"not-a-number-but-long", "14be9ff2ed676879"},
         };
 
     for (String[] aCase : cases) {
@@ -875,7 +878,10 @@ public class TraceFetcherTest {
       String expected = aCase[1];
 
       String actual = TraceFetcher.TraceIds.maybeMapLongSpanIdToHex(input);
-      assertEquals(expected, actual);
+      assertEquals(
+          expected,
+          actual,
+          "Failed for input: " + input + " expected: " + expected + " actual: " + actual);
     }
   }
 
@@ -884,16 +890,20 @@ public class TraceFetcherTest {
     String[][] cases =
         new String[][] {
           {null, null},
-          {"", ""},
+          {"", null},
+          {"-1", null},
+          {"0", "00000000000000000000000000000000"},
+          {"00", "00000000000000000000000000000000"},
+          {"ABCD", "0000000000000000000000000000abcd"},
+          {"not-hex", "ac1648674a95e28b9501c2edc9b76cca"},
           {"1234567890==", "000000000000000000d76df8e7aefcf7"},
-          {"1234567890==", "000000000000000000d76df8e7aefcf7"},
-          {"1234567890", "1234567890"},
-          {"1234567890123456", "1234567890123456"},
+          {"1234567890", "00000000000000000000001234567890"},
+          {"1234567890123456", "00000000000000001234567890123456"},
           {"f____________________w==", "7fffffffffffffffffffffffffffffff"},
-          {"12345678901234567890", "12345678901234567890"},
+          {"12345678901234567890", "00000000000012345678901234567890"},
           {"AAAAAAAAAACZmZmZmZmZmQ==", "00000000000000009999999999999999"},
           {"00000000000000000000000000000000", "00000000000000000000000000000000"},
-          {"not-a-number-but-long", "not-a-number-but-long"},
+          {"not-a-number-but-longer-than-thirtytwo-characters", "7816baa92e237febd9634a9bd56f1cce"},
           {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
         };
 

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
@@ -78,7 +78,7 @@ public class ZipkinServiceSpanConversionTest {
     // follows output format from https://zipkin.io/zipkin-api/#/default/get_trace__traceId_
     String expectedOutput =
         String.format(
-            "[{\"duration\":1,\"id\":\"1\",\"name\":\"Trace1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"00000000000000000000000000000001\"},{\"duration\":2,\"id\":\"2\",\"name\":\"Trace2\",\"parentId\":\"1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"1\"}]",
+            "[{\"duration\":1,\"id\":\"1\",\"name\":\"Trace1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"00000000000000000000000000000001\"},{\"duration\":2,\"id\":\"2\",\"name\":\"Trace2\",\"parentId\":\"1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"00000000000000000000000000000001\"}]",
             TraceFetcher.convertToMicroSeconds(time.plusSeconds(1)),
             TraceFetcher.convertToMicroSeconds(time.plusSeconds(2)));
     assertThat(actualOutput).isEqualTo(expectedOutput);
@@ -107,7 +107,7 @@ public class ZipkinServiceSpanConversionTest {
     // follows output format from https://zipkin.io/zipkin-api/#/default/get_trace__traceId_
     String expectedOutput =
         String.format(
-            "[{\"duration\":10,\"id\":\"55c841cc9262c06e\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"},{\"duration\":10,\"id\":\"na\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"}]",
+            "[{\"duration\":10,\"id\":\"55c841cc9262c06e\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"55c841cc9262c06e114200ed4817a18b\"},{\"duration\":10,\"id\":\"55c841cc9262c06e\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"55c841cc9262c06e114200ed4817a18b\"}]",
             TraceFetcher.convertToMicroSeconds(time), TraceFetcher.convertToMicroSeconds(time));
     assertThat(actualOutput).isEqualTo(expectedOutput);
   }

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
@@ -78,7 +78,7 @@ public class ZipkinServiceSpanConversionTest {
     // follows output format from https://zipkin.io/zipkin-api/#/default/get_trace__traceId_
     String expectedOutput =
         String.format(
-            "[{\"duration\":1,\"id\":\"1\",\"name\":\"Trace1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"1\"},{\"duration\":2,\"id\":\"2\",\"name\":\"Trace2\",\"parentId\":\"1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"1\"}]",
+            "[{\"duration\":1,\"id\":\"1\",\"name\":\"Trace1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"00000000000000000000000000000001\"},{\"duration\":2,\"id\":\"2\",\"name\":\"Trace2\",\"parentId\":\"1\",\"remoteEndpoint\":{\"serviceName\":\"service1\"},\"timestamp\":%d,\"traceId\":\"1\"}]",
             TraceFetcher.convertToMicroSeconds(time.plusSeconds(1)),
             TraceFetcher.convertToMicroSeconds(time.plusSeconds(2)));
     assertThat(actualOutput).isEqualTo(expectedOutput);
@@ -107,7 +107,7 @@ public class ZipkinServiceSpanConversionTest {
     // follows output format from https://zipkin.io/zipkin-api/#/default/get_trace__traceId_
     String expectedOutput =
         String.format(
-            "[{\"duration\":10,\"id\":\"na\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"},{\"duration\":10,\"id\":\"na\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"}]",
+            "[{\"duration\":10,\"id\":\"55c841cc9262c06e\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"},{\"duration\":10,\"id\":\"na\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"}]",
             TraceFetcher.convertToMicroSeconds(time), TraceFetcher.convertToMicroSeconds(time));
     assertThat(actualOutput).isEqualTo(expectedOutput);
   }


### PR DESCRIPTION
###  Summary

Ensure that the ids sent out from the zipkin plugin are all parseable by strict parsers.

For trace ids, it means that there are trace ids that you might not be able to round trip if they are stored as a malformed id.

### Requirements

* [ ] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
