### PR TITLE
[GraphService] add project node metadata field/toplevel span field support

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -220,10 +220,10 @@ public final class GraphConfig {
    * rules match: - Iterate through each rule in reverse order. - If a rule's field/value condition
    * matches a span tag, try to resolve using the overrideKey. - If the resolved value is non-empty,
    * use it. - Otherwise, continue to the next matching rule. 3. If no rule produces a non-empty
-   * value, use the defaultKey: - Keys prefixed with "span." are resolved against top-level span
-   * fields (e.g. "span.service" resolves to the remote endpoint service name); all other keys are
-   * looked up in span tags. - Combine the values with the delimiter if multiple keys are present. -
-   * If any key is missing or empty, fall back to defaultValue.
+   * value, use the defaultKey: - Reserved keys (e.g. "service_name", "name") are resolved against
+   * top-level span fields; all other keys are looked up in span tags. - Combine the values with the
+   * delimiter if multiple keys are present. - If any key is missing or empty, fall back to
+   * defaultValue.
    *
    * <p>Note: This logic does not currently support multiple field matches for a single rule.
    *
@@ -277,8 +277,8 @@ public final class GraphConfig {
   }
 
   /**
-   * Helper method to resolve a list of keys from the span. Keys prefixed with "span." are resolved
-   * against top-level span fields; all other keys are resolved against span tags.
+   * Helper method to resolve a list of keys from the span. Reserved keys ("service_name", "name")
+   * are resolved against top-level span fields; all other keys are resolved against span tags.
    *
    * @param span ZipkinSpanResponse containing the span data.
    * @param keys List of keys to look up.
@@ -293,12 +293,14 @@ public final class GraphConfig {
     // Collect values for all parts in a key
     List<String> values = new java.util.ArrayList<>();
     for (String keyPart : keys) {
-      String value;
-      if (keyPart.startsWith("span.")) {
-        value = resolveSpanKey(span, keyPart.substring("span.".length()));
-      } else {
-        value = span.getTags().get(keyPart);
-      }
+      String value =
+          switch (keyPart) {
+            case "service_name" ->
+                span.getRemoteEndpoint() != null ? span.getRemoteEndpoint().getServiceName() : null;
+            case "name" -> span.getName();
+            default -> span.getTags().get(keyPart);
+          };
+
       if (value == null) {
         // If any key is missing, return null
         return null;
@@ -311,21 +313,6 @@ public final class GraphConfig {
       return String.join(delimiter, values);
     }
     return values.get(0);
-  }
-
-  /**
-   * Resolves a top-level span field by name.
-   *
-   * @param span ZipkinSpanResponse containing the span data.
-   * @param fieldName The name of the top-level span field.
-   * @return The field value as a String, or null if not found.
-   */
-  private String resolveSpanKey(ZipkinSpanResponse span, String fieldName) {
-    return switch (fieldName) {
-      case "service" ->
-          span.getRemoteEndpoint() != null ? span.getRemoteEndpoint().getServiceName() : null;
-      default -> null;
-    };
   }
 
   @Override

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -40,18 +40,22 @@ public final class GraphConfig {
     private final String defaultValue;
     private final String keyDelimiter;
     private final List<RuleConfig> rules;
+    private final boolean useDefaultKeyOnEmptyOverride;
 
     @JsonCreator
     public TagConfig(
         @JsonProperty("default_key") List<String> defaultKey,
         @JsonProperty("default_value") String defaultValue,
         @JsonProperty("key_delimiter") String keyDelimiter,
-        @JsonProperty("rules") List<RuleConfig> rules) {
+        @JsonProperty("rules") List<RuleConfig> rules,
+        @JsonProperty("use_default_key_on_empty_override") Boolean useDefaultKeyOnEmptyOverride) {
       this.defaultKey = (defaultKey == null) ? Collections.emptyList() : List.copyOf(defaultKey);
       this.defaultValue = defaultValue;
       // Set default keyDelimiter to "." if null or empty
       this.keyDelimiter = (keyDelimiter == null || keyDelimiter.isEmpty()) ? "." : keyDelimiter;
       this.rules = (rules == null) ? Collections.emptyList() : List.copyOf(rules);
+      this.useDefaultKeyOnEmptyOverride =
+          (useDefaultKeyOnEmptyOverride == null) ? false : useDefaultKeyOnEmptyOverride;
     }
 
     public List<String> getDefaultKey() {
@@ -68,6 +72,10 @@ public final class GraphConfig {
 
     public List<RuleConfig> getRules() {
       return rules;
+    }
+
+    public boolean isUseDefaultKeyOnEmptyOverride() {
+      return useDefaultKeyOnEmptyOverride;
     }
   }
 
@@ -252,13 +260,14 @@ public final class GraphConfig {
       }
     }
 
-    // If a rule matched but none produced a value, return the default value directly.
-    // The default key is only used when no rule matched at all or none exist.
-    if (anyRuleMatched) {
+    // All rules exhausted without a value.
+    // Return the default_value if a rule matched and we don't want to fall back to the default_key.
+    if (anyRuleMatched && !baseCfg.isUseDefaultKeyOnEmptyOverride()) {
       return baseCfg.getDefaultValue();
     }
 
-    // No rules matched or none exist — try the default key
+    // Try the default_key if no rule matched or we want to fall back to the default_key
+    // in case rules produced empty values.
     String defaultResolved = resolveKeys(span, baseCfg.getDefaultKey(), baseCfg.getKeyDelimiter());
     if (defaultResolved != null && !defaultResolved.isEmpty()) {
       return defaultResolved;

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -189,7 +189,6 @@ public final class GraphConfig {
         metadata.put("service", span.getRemoteEndpoint().getServiceName());
       }
     } else {
-      Map<String, String> tags = span.getTags();
 
       // Use configured tag mapping
       Set<String> keys =
@@ -199,7 +198,7 @@ public final class GraphConfig {
           };
 
       for (String key : keys) {
-        metadata.put(key, resolve(tags, key, entityType));
+        metadata.put(key, resolve(span, key, entityType));
       }
     }
 
@@ -207,23 +206,26 @@ public final class GraphConfig {
   }
 
   /**
-   * Resolves the actual tag value for a given logical field, using the provided span tags.
+   * Resolves the value for a given logical field from a span.
    *
    * <p>Steps: 1. Look up the TagConfig for this logical field (e.g. "resource"). 2. Check if any
    * rules match: - Iterate through each rule in reverse order. - If a rule's field/value condition
-   * matches, try to resolve using the overrideKey. - If the resolved value is non-empty, use it. -
-   * Otherwise, continue to the next matching rule. 3. If no rule produces a non-empty value, use
-   * the defaultKey: - Look up each keyPart from defaultKey list in the tags map. - Combine the
-   * values with the delimiter if multiple parts are present. - If any part is missing or empty,
-   * fall back to defaultValue.
+   * matches a span tag, try to resolve using the overrideKey. - If the resolved value is non-empty,
+   * use it. - Otherwise, continue to the next matching rule. 3. If no rule produces a non-empty
+   * value, use the defaultKey: - Keys prefixed with "span." are resolved against top-level span
+   * fields (e.g. "span.service" resolves to the remote endpoint service name); all other keys are
+   * looked up in span tags. - Combine the values with the delimiter if multiple keys are present. -
+   * If any key is missing or empty, fall back to defaultValue.
    *
    * <p>Note: This logic does not currently support multiple field matches for a single rule.
    *
-   * @param tags Map of tags from the span.
+   * @param span ZipkinSpanResponse containing the span data.
    * @param logicalField the node metadata field to resolve.
    * @return String the value of the logical metadata field after applying all GraphConfig rules.
    */
-  public String resolve(Map<String, String> tags, String logicalField, EntityType entityType) {
+  public String resolve(ZipkinSpanResponse span, String logicalField, EntityType entityType) {
+    Map<String, String> tags = span.getTags();
+
     TagConfig baseCfg =
         switch (entityType) {
           case EDGE -> this.edgeMetadataTagMapping.get(logicalField);
@@ -237,10 +239,12 @@ public final class GraphConfig {
 
     // Later rules override earlier ones, so start from the back of the list.
     // Try each matching rule until one produces a non-empty value.
+    boolean anyRuleMatched = false;
     for (RuleConfig rule : baseCfg.getRules().reversed()) {
       if (rule.getValue()
           .equals(tags.getOrDefault(rule.getField(), "unknown_" + rule.getField()))) {
-        String resolved = resolveKeys(tags, rule.getOverrideKey(), baseCfg.getKeyDelimiter());
+        anyRuleMatched = true;
+        String resolved = resolveKeys(span, rule.getOverrideKey(), baseCfg.getKeyDelimiter());
         if (resolved != null && !resolved.isEmpty()) {
           return resolved;
         }
@@ -248,25 +252,31 @@ public final class GraphConfig {
       }
     }
 
-    // No rules or rules produced a non-empty value, try the default key
-    String defaultResolved = resolveKeys(tags, baseCfg.getDefaultKey(), baseCfg.getKeyDelimiter());
+    // If a rule matched but none produced a value, return the default value directly.
+    // The default key is only used when no rule matched at all or none exist.
+    if (anyRuleMatched) {
+      return baseCfg.getDefaultValue();
+    }
+
+    // No rules matched or none exist — try the default key
+    String defaultResolved = resolveKeys(span, baseCfg.getDefaultKey(), baseCfg.getKeyDelimiter());
     if (defaultResolved != null && !defaultResolved.isEmpty()) {
       return defaultResolved;
     }
 
-    // No rules produced a non-empty value, Fall back to default value
     return baseCfg.getDefaultValue();
   }
 
   /**
-   * Helper method to resolve a list of keys from the tags map.
+   * Helper method to resolve a list of keys from the span. Keys prefixed with "span." are resolved
+   * against top-level span fields; all other keys are resolved against span tags.
    *
-   * @param tags Map of tags from the span.
+   * @param span ZipkinSpanResponse containing the span data.
    * @param keys List of keys to look up.
    * @param delimiter Delimiter to use when combining multiple key values.
    * @return The resolved value, or null if any key is missing.
    */
-  private String resolveKeys(Map<String, String> tags, List<String> keys, String delimiter) {
+  private String resolveKeys(ZipkinSpanResponse span, List<String> keys, String delimiter) {
     if (keys == null || keys.isEmpty()) {
       return null;
     }
@@ -274,7 +284,12 @@ public final class GraphConfig {
     // Collect values for all parts in a key
     List<String> values = new java.util.ArrayList<>();
     for (String keyPart : keys) {
-      String value = tags.get(keyPart);
+      String value;
+      if (keyPart.startsWith("span.")) {
+        value = resolveSpanKey(span, keyPart.substring("span.".length()));
+      } else {
+        value = span.getTags().get(keyPart);
+      }
       if (value == null) {
         // If any key is missing, return null
         return null;
@@ -287,6 +302,21 @@ public final class GraphConfig {
       return String.join(delimiter, values);
     }
     return values.get(0);
+  }
+
+  /**
+   * Resolves a top-level span field by name.
+   *
+   * @param span ZipkinSpanResponse containing the span data.
+   * @param fieldName The name of the top-level span field.
+   * @return The field value as a String, or null if not found.
+   */
+  private String resolveSpanKey(ZipkinSpanResponse span, String fieldName) {
+    return switch (fieldName) {
+      case "service" ->
+          span.getRemoteEndpoint() != null ? span.getRemoteEndpoint().getServiceName() : null;
+      default -> null;
+    };
   }
 
   @Override

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -75,7 +75,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/res2",
                     "tag.http.target.host",
-                    "app2.ns2")));
+                    "app2.ns2",
+                    "tag.http.target.service",
+                    "service-a")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 
@@ -87,14 +89,16 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "app1.ns1",
-                "resource", "res1"));
+                "resource", "res1",
+                "project", "default-service"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> childMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "app2.ns2",
-                "resource", "/v2/res2"));
+                "resource", "/v2/res2",
+                "project", "service-a"));
 
     // uses canonical path as resource
     SortedMap<String, String> edgeMetadata = new TreeMap<>(Map.of("operation", "http.request"));
@@ -179,21 +183,24 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "app1.ns1",
-                "resource", "res1"));
+                "resource", "res1",
+                "project", "default-service"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> child1Metadata =
         new TreeMap<>(
             Map.of(
                 "service", "app2.ns2",
-                "resource", "res2"));
+                "resource", "res2",
+                "project", "default-service"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
     SortedMap<String, String> child2Metadata =
         new TreeMap<>(
             Map.of(
                 "service", "app3.ns3",
-                "resource", "res3"));
+                "resource", "res3",
+                "project", "default-service"));
     String expectedChild2Id = Node.generateIdFromMetadata(child2Metadata);
 
     // verify both edges have the same parent
@@ -201,11 +208,17 @@ public class GraphBuilderTest {
     assertThat(edges.stream().allMatch(edge -> edge.getSourceNodeId().equals(expectedParentId)))
         .isTrue();
 
-    // metadata of the edges
-    assertThat(edges.get(0).getMetadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op2")));
-    assertThat(edges.get(0).getObservedCount()).isEqualTo(1);
-    assertThat(edges.get(1).getMetadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op3")));
-    assertThat(edges.get(1).getObservedCount()).isEqualTo(1);
+    // metadata of the edges (order is non-deterministic due to HashMap internals)
+    assertThat(edges)
+        .anyMatch(
+            e ->
+                e.getMetadata().equals(new TreeMap<>(Map.of("operation", "op2")))
+                    && e.getObservedCount() == 1);
+    assertThat(edges)
+        .anyMatch(
+            e ->
+                e.getMetadata().equals(new TreeMap<>(Map.of("operation", "op3")))
+                    && e.getObservedCount() == 1);
 
     // verify different children
     List<String> childIds =
@@ -263,14 +276,16 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "app1.ns1",
-                "resource", "res1"));
+                "resource", "res1",
+                "project", "default-service"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> childMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "app2.ns2",
-                "resource", "res2"));
+                "resource", "res2",
+                "project", "default-service"));
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
 
     Edge edge = graph.edges().getFirst();
@@ -335,28 +350,32 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "root_app.root_ns",
-                "resource", "root_res"));
+                "resource", "root_res",
+                "project", "default-service"));
     String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
 
     SortedMap<String, String> child1Metadata =
         new TreeMap<>(
             Map.of(
                 "service", "child1_app.child1_ns",
-                "resource", "child1_res"));
+                "resource", "child1_res",
+                "project", "default-service"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
     SortedMap<String, String> child2Metadata =
         new TreeMap<>(
             Map.of(
                 "service", "child2_app.child2_ns",
-                "resource", "child2_res"));
+                "resource", "child2_res",
+                "project", "default-service"));
     String expectedChild2Id = Node.generateIdFromMetadata(child2Metadata);
 
     SortedMap<String, String> grandchildMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "gc_app.gc_ns",
-                "resource", "gc_res"));
+                "resource", "gc_res",
+                "project", "default-service"));
     String expectedGrandchildId = Node.generateIdFromMetadata(grandchildMetadata);
 
     List<Edge> edges = graph.edges();
@@ -477,35 +496,40 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "appA.nsA",
-                "resource", "resA"));
+                "resource", "resA",
+                "project", "default-service"));
     String expectedNodeAId = Node.generateIdFromMetadata(nodeAMetadata);
 
     SortedMap<String, String> nodeBMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "appB.nsB",
-                "resource", "resB"));
+                "resource", "resB",
+                "project", "default-service"));
     String expectedNodeBId = Node.generateIdFromMetadata(nodeBMetadata);
 
     SortedMap<String, String> nodeCMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "appC.nsC",
-                "resource", "resC"));
+                "resource", "resC",
+                "project", "default-service"));
     String expectedNodeCId = Node.generateIdFromMetadata(nodeCMetadata);
 
     SortedMap<String, String> nodeDMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "appD.nsD",
-                "resource", "resD"));
+                "resource", "resD",
+                "project", "default-service"));
     String expectedNodeDId = Node.generateIdFromMetadata(nodeDMetadata);
 
     SortedMap<String, String> nodeEMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "appE.nsE",
-                "resource", "resE"));
+                "resource", "resE",
+                "project", "default-service"));
     String expectedNodeEId = Node.generateIdFromMetadata(nodeEMetadata);
 
     // A -> B
@@ -574,7 +598,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target1",
                     "tag.http.target.host",
-                    "target_app1.target_ns1")),
+                    "target_app1.target_ns1",
+                    "tag.http.target.service",
+                    "service-a")),
             TestUtils.createSpanWithTags(
                 "child1",
                 "trace1",
@@ -591,7 +617,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target2",
                     "tag.http.target.host",
-                    "target_app2.target_ns2")),
+                    "target_app2.target_ns2",
+                    "tag.http.target.service",
+                    "service-b")),
             TestUtils.createSpanWithTags(
                 "child2",
                 "trace1",
@@ -615,14 +643,16 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "target_app1.target_ns1",
-                "resource", "/v2/target1"));
+                "resource", "/v2/target1",
+                "project", "service-a"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> child1Metadata =
         new TreeMap<>(
             Map.of(
                 "service", "target_app2.target_ns2",
-                "resource", "/v2/target2"));
+                "resource", "/v2/target2",
+                "project", "service-b"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
     Edge edge = graph.edges().get(0);
@@ -653,7 +683,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target1",
                     "tag.http.target.host",
-                    "target_app1.target_ns1")),
+                    "target_app1.target_ns1",
+                    "tag.http.target.service",
+                    "service-a")),
             // intermediate child - operation: op2 (doesn't match filter)
             TestUtils.createSpanWithTags(
                 "child1",
@@ -681,7 +713,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target2",
                     "tag.http.target.host",
-                    "target_app2.target_ns2")));
+                    "target_app2.target_ns2",
+                    "tag.http.target.service",
+                    "service-b")));
 
     // Filter to only include nodes with operation "http.request"
     GraphBuilder.Filter filter =
@@ -696,14 +730,16 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "target_app1.target_ns1",
-                "resource", "/v2/target1"));
+                "resource", "/v2/target1",
+                "project", "service-a"));
     String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
 
     SortedMap<String, String> grandchildMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "target_app2.target_ns2",
-                "resource", "/v2/target2"));
+                "resource", "/v2/target2",
+                "project", "service-b"));
     String expectedGrandchildId = Node.generateIdFromMetadata(grandchildMetadata);
 
     // Should have edge directly from root to grandchild (skipping intermediate)
@@ -767,7 +803,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target1",
                     "tag.http.target.host",
-                    "target_app1.target_ns1")),
+                    "target_app1.target_ns1",
+                    "tag.http.target.service",
+                    "service-a")),
             // child1 - http.request
             TestUtils.createSpanWithTags(
                 "child1",
@@ -785,7 +823,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target2",
                     "tag.http.target.host",
-                    "target_app2.target_app2")),
+                    "target_app2.target_app2",
+                    "tag.http.target.service",
+                    "service-b")),
             // child2 - http.request
             TestUtils.createSpanWithTags(
                 "child2",
@@ -803,7 +843,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target3",
                     "tag.http.target.host",
-                    "target_app3.target+_ns3")));
+                    "target_app3.target+_ns3",
+                    "tag.http.target.service",
+                    "service-c")));
 
     // Filter to only include nodes with operation "http.request"
     GraphBuilder.Filter filter =
@@ -819,7 +861,8 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "target_app1.target_ns1",
-                "resource", "/v2/target1"));
+                "resource", "/v2/target1",
+                "project", "service-a"));
     String expectedRootId = Node.generateIdFromMetadata(rootMetadata);
 
     // Both edges should originate from root
@@ -858,7 +901,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target1",
                     "tag.http.target.host",
-                    "target_app1.target_ns1")),
+                    "target_app1.target_ns1",
+                    "tag.http.target.service",
+                    "service-a")),
             TestUtils.createSpanWithTags(
                 "grandchild1",
                 "trace1",
@@ -875,7 +920,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target2",
                     "tag.http.target.host",
-                    "target_app2.target_ns2")),
+                    "target_app2.target_ns2",
+                    "tag.http.target.service",
+                    "service-b")),
             // Second subtree: non-matching nodes -> matching -> more non-matching -> matching leaf
             // intermediate2a (parent missing) -> intermediate2b -> intermediate2c -> matching1 ->
             // intermediate2d -> intermediate2e -> matching2
@@ -922,7 +969,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target3",
                     "tag.http.target.host",
-                    "target_app3.target_ns3")),
+                    "target_app3.target_ns3",
+                    "tag.http.target.service",
+                    "service-c")),
             TestUtils.createSpanWithTags(
                 "intermediate2d",
                 "trace1",
@@ -957,7 +1006,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target4",
                     "tag.http.target.host",
-                    "target_app4.target_ns4")));
+                    "target_app4.target_ns4",
+                    "tag.http.target.service",
+                    "service-d")));
 
     // Filter to only include nodes with operation "http.request"
     GraphBuilder.Filter filter =
@@ -974,28 +1025,32 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "target_app1.target_ns1",
-                "resource", "/v2/target1"));
+                "resource", "/v2/target1",
+                "project", "service-a"));
     String expectedChild1Id = Node.generateIdFromMetadata(child1Metadata);
 
     SortedMap<String, String> grandchild1Metadata =
         new TreeMap<>(
             Map.of(
                 "service", "target_app2.target_ns2",
-                "resource", "/v2/target2"));
+                "resource", "/v2/target2",
+                "project", "service-b"));
     String expectedGrandchild1Id = Node.generateIdFromMetadata(grandchild1Metadata);
 
     SortedMap<String, String> matching1Metadata =
         new TreeMap<>(
             Map.of(
                 "service", "target_app3.target_ns3",
-                "resource", "/v2/target3"));
+                "resource", "/v2/target3",
+                "project", "service-c"));
     String expectedMatching1Id = Node.generateIdFromMetadata(matching1Metadata);
 
     SortedMap<String, String> matching2Metadata =
         new TreeMap<>(
             Map.of(
                 "service", "target_app4.target_ns4",
-                "resource", "/v2/target4"));
+                "resource", "/v2/target4",
+                "project", "service-d"));
     String expectedMatching2Id = Node.generateIdFromMetadata(matching2Metadata);
 
     // Verify both disconnected edges exist
@@ -1034,7 +1089,9 @@ public class GraphBuilderTest {
                     "tag.http.target.canonical_path",
                     "/v2/target1",
                     "tag.http.target.host",
-                    "target_app1.target_ns1")),
+                    "target_app1.target_ns1",
+                    "tag.http.target.service",
+                    "service-a")),
             // Child with operation: grpc.request
             TestUtils.createSpanWithTags(
                 "child1",
@@ -1079,14 +1136,16 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "target_app1.target_ns1",
-                "resource", "/v2/target1"));
+                "resource", "/v2/target1",
+                "project", "service-a"));
     String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
 
     SortedMap<String, String> childMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "app2.ns2",
-                "resource", "res2"));
+                "resource", "res2",
+                "project", "default-service"));
     String expectedChildId = Node.generateIdFromMetadata(childMetadata);
 
     Edge edge = graph.edges().get(0);
@@ -1171,7 +1230,9 @@ public class GraphBuilderTest {
                         "tag.http.target.canonical_path",
                         "/v2/targetA",
                         "tag.http.target.host",
-                        "targetA.nsA")),
+                        "targetA.nsA",
+                        "tag.http.target.service",
+                        "service-a")),
                 // Span B - doesn't match filter, child of A
                 TestUtils.createSpanWithTags(
                     "spanB",
@@ -1199,7 +1260,9 @@ public class GraphBuilderTest {
                         "tag.http.target.canonical_path",
                         "/v2/targetC",
                         "tag.http.target.host",
-                        "targetC.nsC")),
+                        "targetC.nsC",
+                        "tag.http.target.service",
+                        "service-c")),
                 // Span D - doesn't match filter, child of C
                 TestUtils.createSpanWithTags(
                     "spanD",
@@ -1227,7 +1290,9 @@ public class GraphBuilderTest {
                         "tag.http.target.canonical_path",
                         "/v2/targetE",
                         "tag.http.target.host",
-                        "targetE.nsE")),
+                        "targetE.nsE",
+                        "tag.http.target.service",
+                        "service-e")),
                 // Span F - matches filter, child of C (parallel to D)
                 TestUtils.createSpanWithTags(
                     "spanF",
@@ -1245,7 +1310,9 @@ public class GraphBuilderTest {
                         "tag.http.target.canonical_path",
                         "/v2/targetF",
                         "tag.http.target.host",
-                        "targetF.nsF")),
+                        "targetF.nsF",
+                        "tag.http.target.service",
+                        "service-f")),
                 // Create backward cycle: E -> B
                 TestUtils.createSpanWithTags(
                     "spanB_from_E",
@@ -1284,7 +1351,9 @@ public class GraphBuilderTest {
                         "tag.http.target.canonical_path",
                         "/v2/targetG",
                         "tag.http.target.host",
-                        "targetG.nsG"))));
+                        "targetG.nsG",
+                        "tag.http.target.service",
+                        "service-g"))));
 
     GraphBuilder.Filter filter =
         new GraphBuilder.Filter(Map.of("operation_name", List.of("http.request")));
@@ -1305,35 +1374,40 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "targetA.nsA",
-                "resource", "/v2/targetA"));
+                "resource", "/v2/targetA",
+                "project", "service-a"));
     String expectedNodeAId = Node.generateIdFromMetadata(nodeAMetadata);
 
     SortedMap<String, String> nodeCMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "targetC.nsC",
-                "resource", "/v2/targetC"));
+                "resource", "/v2/targetC",
+                "project", "service-c"));
     String expectedNodeCId = Node.generateIdFromMetadata(nodeCMetadata);
 
     SortedMap<String, String> nodeEMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "targetE.nsE",
-                "resource", "/v2/targetE"));
+                "resource", "/v2/targetE",
+                "project", "service-e"));
     String expectedNodeEId = Node.generateIdFromMetadata(nodeEMetadata);
 
     SortedMap<String, String> nodeFMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "targetF.nsF",
-                "resource", "/v2/targetF"));
+                "resource", "/v2/targetF",
+                "project", "service-f"));
     String expectedNodeFId = Node.generateIdFromMetadata(nodeFMetadata);
 
     SortedMap<String, String> nodeGMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "targetG.nsG",
-                "resource", "/v2/targetG"));
+                "resource", "/v2/targetG",
+                "project", "service-g"));
     String expectedNodeGId = Node.generateIdFromMetadata(nodeGMetadata);
 
     // A -> C
@@ -1421,7 +1495,9 @@ public class GraphBuilderTest {
                         "tag.http.target.canonical_path",
                         "/v1/targetB",
                         "operation_name",
-                        "http.request")),
+                        "http.request",
+                        "tag.http.target.service",
+                        "service-a")),
                 // spanB and spanC point to the same logical node, but have different operations
                 TestUtils.createSpanWithTags(
                     "spanC",
@@ -1451,14 +1527,16 @@ public class GraphBuilderTest {
         new TreeMap<>(
             Map.of(
                 "service", "app1.ns1",
-                "resource", "res1"));
+                "resource", "res1",
+                "project", "default-service"));
     String expectedNodeAId = Node.generateIdFromMetadata(nodeAMetadata);
 
     SortedMap<String, String> nodeBMetadata =
         new TreeMap<>(
             Map.of(
                 "service", "app2.ns2",
-                "resource", "/v1/targetB"));
+                "resource", "/v1/targetB",
+                "project", "default-service"));
     String expectedNodeBId = Node.generateIdFromMetadata(nodeBMetadata);
 
     // A -> B
@@ -1472,6 +1550,58 @@ public class GraphBuilderTest {
     assertThat(edge.getMetadata())
         .isEqualTo(new TreeMap<>(Map.of("operation", "dropwizard.request")));
     assertThat(edge.getObservedCount()).isEqualTo(1);
+  }
+
+  @Test
+  void buildFromSpans_withProjectOverrideKey_usesTagHttpTargetService() {
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            TestUtils.createSpanWithTags(
+                "parent1",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "app1",
+                    "kube.namespace", "ns1",
+                    "operation_name", "http.request",
+                    "resource", "res1",
+                    "tag.http.target.service", "service-a",
+                    "tag.http.target.canonical_path", "/v2/res1",
+                    "tag.http.target.host", "app1.ns1")),
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "ns2",
+                    "operation_name", "db.query",
+                    "resource", "res2")));
+
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
+
+    assertThat(graph.nodes()).hasSize(2);
+    assertThat(graph.edges()).hasSize(1);
+
+    SortedMap<String, String> parentMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "app1.ns1",
+                "resource", "/v2/res1",
+                "project", "service-a"));
+    String expectedParentId = Node.generateIdFromMetadata(parentMetadata);
+
+    SortedMap<String, String> childMetadata =
+        new TreeMap<>(
+            Map.of(
+                "service", "app2.ns2",
+                "resource", "res2",
+                "project", "default-service"));
+    String expectedChildId = Node.generateIdFromMetadata(childMetadata);
+
+    Edge edge = graph.edges().getFirst();
+    assertThat(edge.getSourceNodeId()).isEqualTo(expectedParentId);
+    assertThat(edge.getTargetNodeId()).isEqualTo(expectedChildId);
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -730,18 +730,19 @@ public class GraphConfigTest {
   public void testResolveProject_withSpanServiceDefaultAndTagOverride() throws IOException {
     GraphConfig config =
         GraphConfig.load(
-            """
+"""
                 node_metadata_tag_mapping:
                   project:
                     default_key:
                       - span.service
                     default_value: unknown_project
+                    use_default_key_on_empty_override: false
                     rules:
                       - field: operation_name
                         value: http.request
                         override_key:
                           - tag.http.target.service
-                """);
+""");
 
     // Case 1: operation_name != "http.request" → falls back to span.service (remote endpoint)
     Map<String, String> tags1 = Map.of("operation_name", "grpc.request");
@@ -762,6 +763,42 @@ public class GraphConfigTest {
     ZipkinSpanResponse span3 = TestUtils.createSpanWithTags("span3", "trace1", null, tags3);
     String result3 = config.resolve(span3, "project", GraphConfig.EntityType.NODE);
     assertThat(result3).isEqualTo("unknown_project");
+  }
+
+  @Test
+  public void testResolveWithUseDefaultKeyOnEmptyOverride_true_fallsBackToDefaultKey()
+      throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                node_metadata_tag_mapping:
+                  service:
+                    default_key:
+                      - kube.app
+                      - kube.namespace
+                    default_value: unknown_service
+                    key_delimiter: .
+                    use_default_key_on_empty_override: true
+                    rules:
+                      - field: operation_name
+                        value: http.request
+                        override_key:
+                          - tag.http.target.host
+                """);
+
+    // Rule matches but override key is missing — falls back to defaultKey
+    Map<String, String> tags1 =
+        Map.of("kube.app", "my-app", "kube.namespace", "prod", "operation_name", "http.request");
+    ZipkinSpanResponse span1 = TestUtils.createSpanWithTags("span1", "trace1", null, tags1);
+    assertThat(config.resolve(span1, "service", GraphConfig.EntityType.NODE))
+        .isEqualTo("my-app.prod");
+
+    // No rule matches — also falls back to defaultKey
+    Map<String, String> tags2 =
+        Map.of("kube.app", "my-app", "kube.namespace", "prod", "operation_name", "grpc.request");
+    ZipkinSpanResponse span2 = TestUtils.createSpanWithTags("span2", "trace1", null, tags2);
+    assertThat(config.resolve(span2, "service", GraphConfig.EntityType.NODE))
+        .isEqualTo("my-app.prod");
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -131,13 +131,14 @@ public class GraphConfigTest {
                  default_value: unknown_operation
              """);
     Map<String, String> tags = new HashMap<>();
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
     // Node
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("unknown_app");
 
     // Edge
-    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    result = config.resolve(span, "operation", GraphConfig.EntityType.EDGE);
     assertThat(result).isEqualTo("unknown_operation");
   }
 
@@ -162,13 +163,14 @@ public class GraphConfigTest {
                  default_value: unknown_operation
               """);
     Map<String, String> tags = Map.of("some.tag", "some-value");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
     // Node
-    String result = config.resolve(tags, "some_field", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "some_field", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("unknown_some_field");
 
     // Edge
-    result = config.resolve(tags, "some_field", GraphConfig.EntityType.EDGE);
+    result = config.resolve(span, "some_field", GraphConfig.EntityType.EDGE);
     assertThat(result).isEqualTo("unknown_some_field");
   }
 
@@ -216,13 +218,14 @@ public class GraphConfigTest {
             "my-app-in-prod",
             "operation.prod",
             "prod_operation");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
     // Node
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app-in-prod");
 
     // Edge
-    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    result = config.resolve(span, "operation", GraphConfig.EntityType.EDGE);
     assertThat(result).isEqualTo("prod_operation");
   }
 
@@ -263,14 +266,15 @@ public class GraphConfigTest {
     Map<String, String> tags =
         Map.of(
             "app.name", "my-app", "namespace.name", "prod-ns", "operation_name", "some_operation");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
-    // Node - rule matches but override key is missing, should return default key's value
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
-    assertThat(result).isEqualTo("my-app");
+    // Node - rule matches but override key is missing, should return default value
+    String result = config.resolve(span, "app", GraphConfig.EntityType.NODE);
+    assertThat(result).isEqualTo("unknown_app");
 
-    // Edge - rule matches but override key is missing, should return default key's value
-    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
-    assertThat(result).isEqualTo("some_operation");
+    // Edge - rule matches but override key is missing, should return default value
+    result = config.resolve(span, "operation", GraphConfig.EntityType.EDGE);
+    assertThat(result).isEqualTo("unknown_operation");
   }
 
   @Test
@@ -310,13 +314,14 @@ public class GraphConfigTest {
     Map<String, String> tags =
         Map.of(
             "app.name", "my-app", "namespace.name", "dev-ns", "operation_name", "some_operation");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
     // Node
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app");
 
     // Edge
-    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    result = config.resolve(span, "operation", GraphConfig.EntityType.EDGE);
     assertThat(result).isEqualTo("some_operation");
   }
 
@@ -376,13 +381,14 @@ public class GraphConfigTest {
             "operation_prod",
             "operation.east",
             "operation_east");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
     // Node
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app-east");
 
     // Edge
-    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    result = config.resolve(span, "operation", GraphConfig.EntityType.EDGE);
     assertThat(result).isEqualTo("operation_east");
   }
 
@@ -436,13 +442,14 @@ public class GraphConfigTest {
             "some_operation",
             "operation.prod",
             "operation_prod");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
     // Node
-    String result = config.resolve(tags, "app", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "app", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app");
 
     // Edge
-    result = config.resolve(tags, "operation", GraphConfig.EntityType.EDGE);
+    result = config.resolve(span, "operation", GraphConfig.EntityType.EDGE);
     assertThat(result).isEqualTo("some_operation");
   }
 
@@ -460,8 +467,9 @@ public class GraphConfigTest {
                               key_delimiter: .
                           """);
     Map<String, String> tags = Map.of("kube.app", "my-app", "kube.namespace", "prod");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
-    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "service", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app.prod");
   }
 
@@ -479,8 +487,9 @@ public class GraphConfigTest {
                               key_delimiter: .
                           """);
     Map<String, String> tags = Map.of("kube.app", "my-app");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
-    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "service", GraphConfig.EntityType.NODE);
     // Should return default value when any key is missing
     assertThat(result).isEqualTo("unknown_service");
   }
@@ -497,8 +506,9 @@ public class GraphConfigTest {
                               default_value: unknown_service
                           """);
     Map<String, String> tags = Map.of("kube.app", "my-app");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
-    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "service", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("my-app");
   }
 
@@ -533,8 +543,9 @@ public class GraphConfigTest {
             "api.example.com",
             "tag.http.method",
             "GET");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
-    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
+    String result = config.resolve(span, "service", GraphConfig.EntityType.NODE);
     assertThat(result).isEqualTo("api.example.com.GET");
   }
 
@@ -567,10 +578,11 @@ public class GraphConfigTest {
             "http.request",
             "tag.http.target.host",
             "api.example.com");
+    ZipkinSpanResponse span = TestUtils.createSpanWithTags("span1", "trace1", null, tags);
 
-    String result = config.resolve(tags, "service", GraphConfig.EntityType.NODE);
-    // Should return default key's value since override key is missing tag.http.method
-    assertThat(result).isEqualTo("my-app.prod");
+    String result = config.resolve(span, "service", GraphConfig.EntityType.NODE);
+    // Should return default value since rule matched but override key is missing tag.http.method
+    assertThat(result).isEqualTo("unknown_service");
   }
 
   @Test
@@ -654,11 +666,12 @@ public class GraphConfigTest {
             "/api/v1/users",
             "resource",
             "default_resource");
+    ZipkinSpanResponse span1 = TestUtils.createSpanWithTags("span1", "trace1", null, tags1);
 
-    String result1 = config.resolve(tags1, "resource", GraphConfig.EntityType.NODE);
+    String result1 = config.resolve(span1, "resource", GraphConfig.EntityType.NODE);
     assertThat(result1).isEqualTo("/api/v1/users");
 
-    // Case 2: Both are empty, should fallback to default key
+    // Case 2: Both are empty, should fallback to default value
     Map<String, String> tags2 =
         Map.of(
             "operation_name",
@@ -669,26 +682,12 @@ public class GraphConfigTest {
             "",
             "resource",
             "default_resource");
+    ZipkinSpanResponse span2 = TestUtils.createSpanWithTags("span2", "trace1", null, tags2);
 
-    String result2 = config.resolve(tags2, "resource", GraphConfig.EntityType.NODE);
-    assertThat(result2).isEqualTo("default_resource");
+    String result2 = config.resolve(span2, "resource", GraphConfig.EntityType.NODE);
+    assertThat(result2).isEqualTo("unknown_resource");
 
-    // Case 3: All empty including default key, should use default value
-    Map<String, String> tags3 =
-        Map.of(
-            "operation_name",
-            "http.request",
-            "tag.http.target.canonical_path",
-            "",
-            "http.url",
-            "",
-            "resource",
-            "");
-
-    String result3 = config.resolve(tags3, "resource", GraphConfig.EntityType.NODE);
-    assertThat(result3).isEqualTo("unknown_resource");
-
-    // Case 4: tag.http.target.canonical_path has value, should use it
+    // Case 3: tag.http.target.canonical_path has value, should use it
     Map<String, String> tags4 =
         Map.of(
             "operation_name",
@@ -699,11 +698,12 @@ public class GraphConfigTest {
             "/api/v1/users",
             "resource",
             "default_resource");
+    ZipkinSpanResponse span4 = TestUtils.createSpanWithTags("span4", "trace1", null, tags4);
 
-    String result4 = config.resolve(tags4, "resource", GraphConfig.EntityType.NODE);
+    String result4 = config.resolve(span4, "resource", GraphConfig.EntityType.NODE);
     assertThat(result4).isEqualTo("/api/canonical");
 
-    // Case 5: tag.http.target.canonical_path is missing, should fallback to http.url
+    // Case 4: tag.http.target.canonical_path is missing, should fallback to http.url
     Map<String, String> tags5 =
         Map.of(
             "operation_name",
@@ -712,16 +712,56 @@ public class GraphConfigTest {
             "/api/v1/users",
             "resource",
             "default_resource");
+    ZipkinSpanResponse span5 = TestUtils.createSpanWithTags("span5", "trace1", null, tags5);
 
-    String result5 = config.resolve(tags5, "resource", GraphConfig.EntityType.NODE);
-    assertThat(result1).isEqualTo("/api/v1/users");
+    String result5 = config.resolve(span5, "resource", GraphConfig.EntityType.NODE);
+    assertThat(result5).isEqualTo("/api/v1/users");
 
-    // Case 6: Both override keys are missing, should fallback to default key
+    // Case 5: Both override keys are missing, should fallback to default value
     Map<String, String> tags6 =
         Map.of("operation_name", "http.request", "resource", "default_resource");
+    ZipkinSpanResponse span6 = TestUtils.createSpanWithTags("span6", "trace1", null, tags6);
 
-    String result6 = config.resolve(tags6, "resource", GraphConfig.EntityType.NODE);
-    assertThat(result2).isEqualTo("default_resource");
+    String result6 = config.resolve(span6, "resource", GraphConfig.EntityType.NODE);
+    assertThat(result6).isEqualTo("unknown_resource");
+  }
+
+  @Test
+  public void testResolveProject_withSpanServiceDefaultAndTagOverride() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+                node_metadata_tag_mapping:
+                  project:
+                    default_key:
+                      - span.service
+                    default_value: unknown_project
+                    rules:
+                      - field: operation_name
+                        value: http.request
+                        override_key:
+                          - tag.http.target.service
+                """);
+
+    // Case 1: operation_name != "http.request" → falls back to span.service (remote endpoint)
+    Map<String, String> tags1 = Map.of("operation_name", "grpc.request");
+    ZipkinSpanResponse span1 = TestUtils.createSpanWithTags("span1", "trace1", null, tags1);
+    String result1 = config.resolve(span1, "project", GraphConfig.EntityType.NODE);
+    assertThat(result1).isEqualTo("default-service");
+
+    // Case 2: operation_name = "http.request" with tag.http.target.service → uses override key
+    Map<String, String> tags2 =
+        Map.of("operation_name", "http.request", "tag.http.target.service", "my-project");
+    ZipkinSpanResponse span2 = TestUtils.createSpanWithTags("span2", "trace1", null, tags2);
+    String result2 = config.resolve(span2, "project", GraphConfig.EntityType.NODE);
+    assertThat(result2).isEqualTo("my-project");
+
+    // Case 3: operation_name = "http.request" but tag.http.target.service missing → returns default
+    // value
+    Map<String, String> tags3 = Map.of("operation_name", "http.request");
+    ZipkinSpanResponse span3 = TestUtils.createSpanWithTags("span3", "trace1", null, tags3);
+    String result3 = config.resolve(span3, "project", GraphConfig.EntityType.NODE);
+    assertThat(result3).isEqualTo("unknown_project");
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -734,7 +734,7 @@ public class GraphConfigTest {
                 node_metadata_tag_mapping:
                   project:
                     default_key:
-                      - span.service
+                      - service_name
                     default_value: unknown_project
                     use_default_key_on_empty_override: false
                     rules:
@@ -744,7 +744,7 @@ public class GraphConfigTest {
                           - tag.http.target.service
 """);
 
-    // Case 1: operation_name != "http.request" → falls back to span.service (remote endpoint)
+    // Case 1: operation_name != "http.request" → falls back to service_name (remote endpoint)
     Map<String, String> tags1 = Map.of("operation_name", "grpc.request");
     ZipkinSpanResponse span1 = TestUtils.createSpanWithTags("span1", "trace1", null, tags1);
     String result1 = config.resolve(span1, "project", GraphConfig.EntityType.NODE);

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphServiceTest.java
@@ -252,6 +252,7 @@ public class GraphServiceTest {
       JsonNode metadata = node.get("metadata");
       assertTrue(metadata.has("service"));
       assertTrue(metadata.has("resource"));
+      assertTrue(metadata.has("project"));
     }
 
     // Verify all edges have required fields

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -3,6 +3,7 @@ node_metadata_tag_mapping:
     default_key:
       - span.service
     default_value: unknown_project
+    use_default_key_on_empty_override: false
     rules:
       - field: operation_name
         value: http.request
@@ -23,6 +24,7 @@ node_metadata_tag_mapping:
     default_key:
       - resource
     default_value: unknown_resource
+    use_default_key_on_empty_override: false
     rules:
       - field: operation_name
         value: http.request

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -1,4 +1,13 @@
 node_metadata_tag_mapping:
+  project:
+    default_key:
+      - span.service
+    default_value: unknown_project
+    rules:
+      - field: operation_name
+        value: http.request
+        override_key:
+          - tag.http.target.service
   service:
     default_key:
       - kube.app

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -1,7 +1,7 @@
 node_metadata_tag_mapping:
   project:
     default_key:
-      - span.service
+      - service_name
     default_value: unknown_project
     use_default_key_on_empty_override: false
     rules:


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.
Add a `project` node metadata field and support for extracting top level span properties, not just tags.

- Updated the `resolve()` method in `GraphConfig` to accept `ZipkinSpanResponse span` instead of a map of tags, enabling resolution against both span tags and top level span fields 
-  Add `use_default_key_on_empty_override` flag to `TagConfig`: when a rule matches but all override keys resolve to null or empty, this flag controls whether to fall back to defaultKey (true) or return defaultValue directly (false, default). Makes the fallback behavior explicit in config rather than implicit in code
- Added project field to `node_metadata_tag_mapping` in `test-dependency-graph-config.yaml` 

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
