### PR TITLE
[graphApi] add non-identity edge annotations with ancestor inheritence

### DIFF
--- a/astra/src/main/java/com/slack/astra/graphApi/Edge.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/Edge.java
@@ -2,7 +2,12 @@ package com.slack.astra.graphApi;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.SortedMap;
 
 /**
@@ -17,6 +22,7 @@ public class Edge {
   private final String targetNodeId;
   private final SortedMap<String, String> metadata;
   private int observedCount = 0;
+  private final Map<String, Set<String>> annotations = new HashMap<>();
 
   public Edge(String sourceNodeId, String targetNodeId, SortedMap<String, String> metadata) {
     this.sourceNodeId = checkNotNull(sourceNodeId, "sourceNodeId cannot be null");
@@ -45,8 +51,13 @@ public class Edge {
     return observedCount;
   }
 
-  public void incrementObservedCount() {
+  public Map<String, Set<String>> getAnnotations() {
+    return Collections.unmodifiableMap(annotations);
+  }
+
+  public void addObservation(Map<String, String> incoming) {
     observedCount++;
+    incoming.forEach((k, v) -> annotations.computeIfAbsent(k, x -> new LinkedHashSet<>()).add(v));
   }
 
   @Override

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -88,7 +88,6 @@ public class GraphBuilder {
    */
   public Graph buildFromSpans(List<ZipkinSpanResponse> spans, Optional<Filter> filter) {
     // Build all lookup structures
-    Map<String, ZipkinSpanResponse> spanIdToSpan = new HashMap<>(); // Lookup a span by span ID
     Map<String, Node> spanIdToNode = new HashMap<>(); // Lookup a span's logical node by span ID
     Map<String, Node> nodeIdToNode = new HashMap<>(); // Lookup a node by node ID
     Set<String> matchingSpanIds = new HashSet<>(); // Spans that match the given filter
@@ -99,8 +98,6 @@ public class GraphBuilder {
         .filter(span -> span.getId() != null && !span.getId().equals("-1"))
         .forEach(
             span -> {
-              spanIdToSpan.put(span.getId(), span);
-
               Node node =
                   new Node(config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE));
               spanIdToNode.put(span.getId(), node);
@@ -123,7 +120,7 @@ public class GraphBuilder {
             .collect(Collectors.toSet());
 
     return traverseAndBuildGraph(
-        matchingSpanIds, nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds, spanIdToSpan);
+        matchingSpanIds, nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds);
   }
 
   /**
@@ -190,10 +187,7 @@ public class GraphBuilder {
       Set<String> matchingSpanIds,
       Set<String> nodesToProcess,
       Map<String, Node> nodeIdToNode,
-      Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds,
-      Map<String, ZipkinSpanResponse> spanIdToSpan) {
-    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
-
+      Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds) {
     Set<Node> nodes = new HashSet<>();
     Map<String, Edge> edges = new HashMap<>();
 
@@ -229,8 +223,7 @@ public class GraphBuilder {
                 config.createMetadataFromSpan(refSpan, GraphConfig.EntityType.EDGE);
             String edgeKey = Edge.generateKey(parentNodeId, childNodeId, edgeMetadata);
 
-            SortedMap<String, String> annotations =
-                config.resolveAnnotationsForSpan(refSpan, spanIdToSpan::get, annotationsBySpanId);
+            SortedMap<String, String> annotations = config.createAnnotationsFromSpan(refSpan);
             edges
                 .computeIfAbsent(edgeKey, k -> new Edge(parentNodeId, childNodeId, edgeMetadata))
                 .addObservation(annotations);

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -88,6 +88,7 @@ public class GraphBuilder {
    */
   public Graph buildFromSpans(List<ZipkinSpanResponse> spans, Optional<Filter> filter) {
     // Build all lookup structures
+    Map<String, ZipkinSpanResponse> spanIdToSpan = new HashMap<>(); // Lookup a span by span ID
     Map<String, Node> spanIdToNode = new HashMap<>(); // Lookup a span's logical node by span ID
     Map<String, Node> nodeIdToNode = new HashMap<>(); // Lookup a node by node ID
     Set<String> matchingSpanIds = new HashSet<>(); // Spans that match the given filter
@@ -98,6 +99,8 @@ public class GraphBuilder {
         .filter(span -> span.getId() != null && !span.getId().equals("-1"))
         .forEach(
             span -> {
+              spanIdToSpan.put(span.getId(), span);
+
               Node node =
                   new Node(config.createMetadataFromSpan(span, GraphConfig.EntityType.NODE));
               spanIdToNode.put(span.getId(), node);
@@ -120,7 +123,7 @@ public class GraphBuilder {
             .collect(Collectors.toSet());
 
     return traverseAndBuildGraph(
-        matchingSpanIds, nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds);
+        matchingSpanIds, nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds, spanIdToSpan);
   }
 
   /**
@@ -187,7 +190,10 @@ public class GraphBuilder {
       Set<String> matchingSpanIds,
       Set<String> nodesToProcess,
       Map<String, Node> nodeIdToNode,
-      Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds) {
+      Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds,
+      Map<String, ZipkinSpanResponse> spanIdToSpan) {
+    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
+
     Set<Node> nodes = new HashSet<>();
     Map<String, Edge> edges = new HashMap<>();
 
@@ -223,7 +229,8 @@ public class GraphBuilder {
                 config.createMetadataFromSpan(refSpan, GraphConfig.EntityType.EDGE);
             String edgeKey = Edge.generateKey(parentNodeId, childNodeId, edgeMetadata);
 
-            SortedMap<String, String> annotations = config.createAnnotationsFromSpan(refSpan);
+            SortedMap<String, String> annotations =
+                config.resolveAnnotationsForSpan(refSpan, spanIdToSpan::get, annotationsBySpanId);
             edges
                 .computeIfAbsent(edgeKey, k -> new Edge(parentNodeId, childNodeId, edgeMetadata))
                 .addObservation(annotations);

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphBuilder.java
@@ -123,7 +123,7 @@ public class GraphBuilder {
             .collect(Collectors.toSet());
 
     return traverseAndBuildGraph(
-        matchingSpanIds, nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds);
+        matchingSpanIds, nodesToProcess, nodeIdToNode, parentNodeIdToChildNodeIds, spanIdToSpan);
   }
 
   /**
@@ -190,7 +190,9 @@ public class GraphBuilder {
       Set<String> matchingSpanIds,
       Set<String> nodesToProcess,
       Map<String, Node> nodeIdToNode,
-      Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds) {
+      Map<String, List<Map.Entry<String, ZipkinSpanResponse>>> parentNodeIdToChildNodeIds,
+      Map<String, ZipkinSpanResponse> spanIdToSpan) {
+    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
 
     Set<Node> nodes = new HashSet<>();
     Map<String, Edge> edges = new HashMap<>();
@@ -227,9 +229,11 @@ public class GraphBuilder {
                 config.createMetadataFromSpan(refSpan, GraphConfig.EntityType.EDGE);
             String edgeKey = Edge.generateKey(parentNodeId, childNodeId, edgeMetadata);
 
+            SortedMap<String, String> annotations =
+                config.resolveAnnotationsForSpan(refSpan, spanIdToSpan::get, annotationsBySpanId);
             edges
                 .computeIfAbsent(edgeKey, k -> new Edge(parentNodeId, childNodeId, edgeMetadata))
-                .incrementObservedCount();
+                .addObservation(annotations);
           } else {
             // Non-filtered intermediate node - continue traversing through it
             work.push(childNodeId);

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -125,6 +125,7 @@ public final class GraphConfig {
   // Holds the entire mapping for logical field names to their configuration of defaults and rules
   // for nodes.
   private final Map<String, TagConfig> edgeMetadataTagMapping;
+  private final List<String> edgeAnnotationKeys;
 
   @JsonCreator
   public GraphConfig(
@@ -138,6 +139,11 @@ public final class GraphConfig {
         (edgeMetadataTagMapping == null)
             ? Collections.emptyMap()
             : Map.copyOf(edgeMetadataTagMapping);
+    this.edgeAnnotationKeys =
+        this.edgeMetadataTagMapping.entrySet().stream()
+            .filter(e -> e.getValue().isAnnotation())
+            .map(Map.Entry::getKey)
+            .toList();
   }
 
   public Map<String, TagConfig> getNodeMetadataTagMapping() {
@@ -359,16 +365,17 @@ public final class GraphConfig {
     annotationsBySpanId.put(span.getId(), result);
 
     // Resolve each annotation field on this span directly (no walk-up here).
-    for (String key : edgeMetadataTagMapping.keySet()) {
-      if (!edgeMetadataTagMapping.get(key).isAnnotation()) continue;
-
+    for (String key : edgeAnnotationKeys) {
       String value = resolve(span, key, EntityType.EDGE);
       if (value != null && !value.isEmpty()) {
         result.put(key, value);
       }
     }
 
-    // All annotation fields currently inherit from the nearest ancestor that carries them.
+    // result is inserted into the cache before recursing to break cycles. putIfAbsent below
+    // mutates it in-place, so the cached entry reflects values for all annotation keys after
+    // inheriting any missing fields from the nearest ancestor that carries them (see
+    // testResolveAnnotationsForSpan_deepChainPartialFields).
     // If a future field should not walk up, add a boolean flag (e.g. inherit_from_ancestor)
     // to TagConfig and gate the putIfAbsent call on it here.
     ZipkinSpanResponse parent =

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -333,10 +333,10 @@ public final class GraphConfig {
    * that carries a non-null value for each annotation field. Results are memoized in the provided
    * cache, keyed by span ID, so each span's chain is walked at most once across all calls.
    *
-   * <p>For each annotation field, resolution on a given span uses the same {@code resolveKeys}
-   * machinery as regular metadata fields. A field is only considered "carried" by a span when all
-   * keys in {@code default_key} resolve to non-null, non-empty values on that span. When a span
-   * doesn't carry a field, the value is inherited from the nearest ancestor that does.
+   * <p>For each annotation field, resolution uses the same {@code resolve} machinery as regular
+   * metadata fields (rules → default_key → default_value). A field is only considered "carried" by
+   * a span when resolution produces a non-empty value. When a span doesn't carry a field, the value
+   * is inherited from the nearest ancestor that does.
    *
    * @param span The span to resolve annotations for.
    * @param parentLookup Function to look up a span by ID; returns null when not found.
@@ -359,12 +359,12 @@ public final class GraphConfig {
     annotationsBySpanId.put(span.getId(), result);
 
     // Resolve each annotation field on this span directly (no walk-up here).
-    for (Map.Entry<String, TagConfig> entry : edgeMetadataTagMapping.entrySet()) {
-      if (!entry.getValue().isAnnotation()) continue;
-      String value =
-          resolveKeys(span, entry.getValue().getDefaultKey(), entry.getValue().getKeyDelimiter());
+    for (String key : edgeMetadataTagMapping.keySet()) {
+      if (!edgeMetadataTagMapping.get(key).isAnnotation()) continue;
+
+      String value = resolve(span, key, EntityType.EDGE);
       if (value != null && !value.isEmpty()) {
-        result.put(entry.getKey(), value);
+        result.put(key, value);
       }
     }
 

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -213,7 +214,7 @@ public final class GraphConfig {
           };
 
       for (String key : keys) {
-        // Annotation fields are resolved separately via createAnnotationsFromSpan and must not
+        // Annotation fields are resolved separately via resolveAnnotationsForSpan and must not
         // influence edge identity.
         if (entityType == EntityType.EDGE && this.edgeMetadataTagMapping.get(key).isAnnotation()) {
           continue;
@@ -328,23 +329,55 @@ public final class GraphConfig {
   }
 
   /**
-   * Creates annotations for an edge from a span's own tags. Annotation fields (those marked {@code
-   * is_annotation: true} in config) are resolved using the same key-lookup machinery as regular
-   * metadata fields but are kept separate from identity-determining metadata.
+   * Resolves annotation fields for a span, walking up the parent chain to find the nearest ancestor
+   * that carries a non-null value for each annotation field. Results are memoized in the provided
+   * cache, keyed by span ID, so each span's chain is walked at most once across all calls.
    *
-   * @param span The span to resolve annotations from.
-   * @return SortedMap of annotation field name to resolved value. Fields not present on this span
-   *     are absent from the map.
+   * <p>For each annotation field, resolution on a given span uses the same {@code resolveKeys}
+   * machinery as regular metadata fields. A field is only considered "carried" by a span when all
+   * keys in {@code default_key} resolve to non-null, non-empty values on that span. When a span
+   * doesn't carry a field, the value is inherited from the nearest ancestor that does.
+   *
+   * @param span The span to resolve annotations for.
+   * @param parentLookup Function to look up a span by ID; returns null when not found.
+   * @param annotationsBySpanId Shared map of spanId to resolved annotations; acts as both a
+   *     memoization store and a visited set to terminate cycles. Populated by this method.
+   * @return SortedMap of annotation field name to resolved value. Fields with no resolvable
+   *     ancestor are absent from the map.
    */
-  public SortedMap<String, String> createAnnotationsFromSpan(ZipkinSpanResponse span) {
+  public SortedMap<String, String> resolveAnnotationsForSpan(
+      ZipkinSpanResponse span,
+      Function<String, ZipkinSpanResponse> parentLookup,
+      Map<String, SortedMap<String, String>> annotationsBySpanId) {
+    if (annotationsBySpanId.containsKey(span.getId())) {
+      return annotationsBySpanId.get(span.getId());
+    }
+
+    // Insert before recursing so cycles in the parent chain terminate at the containsKey check
+    // above.
     SortedMap<String, String> result = new TreeMap<>();
-    for (String key : edgeMetadataTagMapping.keySet()) {
-      if (!edgeMetadataTagMapping.get(key).isAnnotation()) continue;
-      String value = resolve(span, key, EntityType.EDGE);
+    annotationsBySpanId.put(span.getId(), result);
+
+    // Resolve each annotation field on this span directly (no walk-up here).
+    for (Map.Entry<String, TagConfig> entry : edgeMetadataTagMapping.entrySet()) {
+      if (!entry.getValue().isAnnotation()) continue;
+      String value =
+          resolveKeys(span, entry.getValue().getDefaultKey(), entry.getValue().getKeyDelimiter());
       if (value != null && !value.isEmpty()) {
-        result.put(key, value);
+        result.put(entry.getKey(), value);
       }
     }
+
+    // All annotation fields currently inherit from the nearest ancestor that carries them.
+    // If a future field should not walk up, add a boolean flag (e.g. inherit_from_ancestor)
+    // to TagConfig and gate the putIfAbsent call on it here.
+    ZipkinSpanResponse parent =
+        span.getParentId() != null ? parentLookup.apply(span.getParentId()) : null;
+    if (parent != null) {
+      resolveAnnotationsForSpan(parent, parentLookup, annotationsBySpanId)
+          .forEach(result::putIfAbsent);
+    }
+
     return result;
   }
 

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,7 @@ public final class GraphConfig {
     private final String keyDelimiter;
     private final List<RuleConfig> rules;
     private final boolean useDefaultKeyOnEmptyOverride;
+    private final boolean isAnnotation;
 
     @JsonCreator
     public TagConfig(
@@ -48,7 +50,8 @@ public final class GraphConfig {
         @JsonProperty("default_value") String defaultValue,
         @JsonProperty("key_delimiter") String keyDelimiter,
         @JsonProperty("rules") List<RuleConfig> rules,
-        @JsonProperty("use_default_key_on_empty_override") Boolean useDefaultKeyOnEmptyOverride) {
+        @JsonProperty("use_default_key_on_empty_override") Boolean useDefaultKeyOnEmptyOverride,
+        @JsonProperty("is_annotation") Boolean isAnnotation) {
       this.defaultKey = (defaultKey == null) ? Collections.emptyList() : List.copyOf(defaultKey);
       this.defaultValue = defaultValue;
       // Set default keyDelimiter to "." if null or empty
@@ -56,6 +59,7 @@ public final class GraphConfig {
       this.rules = (rules == null) ? Collections.emptyList() : List.copyOf(rules);
       this.useDefaultKeyOnEmptyOverride =
           (useDefaultKeyOnEmptyOverride == null) ? false : useDefaultKeyOnEmptyOverride;
+      this.isAnnotation = (isAnnotation == null) ? false : isAnnotation;
     }
 
     public List<String> getDefaultKey() {
@@ -76,6 +80,10 @@ public final class GraphConfig {
 
     public boolean isUseDefaultKeyOnEmptyOverride() {
       return useDefaultKeyOnEmptyOverride;
+    }
+
+    public boolean isAnnotation() {
+      return isAnnotation;
     }
   }
 
@@ -206,6 +214,11 @@ public final class GraphConfig {
           };
 
       for (String key : keys) {
+        // Annotation fields are resolved separately via resolveAnnotationsForSpan and must not
+        // influence edge identity.
+        if (entityType == EntityType.EDGE && this.edgeMetadataTagMapping.get(key).isAnnotation()) {
+          continue;
+        }
         metadata.put(key, resolve(span, key, entityType));
       }
     }
@@ -313,6 +326,59 @@ public final class GraphConfig {
       return String.join(delimiter, values);
     }
     return values.get(0);
+  }
+
+  /**
+   * Resolves annotation fields for a span, walking up the parent chain to find the nearest ancestor
+   * that carries a non-null value for each annotation field. Results are memoized in the provided
+   * cache, keyed by span ID, so each span's chain is walked at most once across all calls.
+   *
+   * <p>For each annotation field, resolution on a given span uses the same {@code resolveKeys}
+   * machinery as regular metadata fields. A field is only considered "carried" by a span when all
+   * keys in {@code default_key} resolve to non-null, non-empty values on that span. When a span
+   * doesn't carry a field, the value is inherited from the nearest ancestor that does.
+   *
+   * @param span The span to resolve annotations for.
+   * @param parentLookup Function to look up a span by ID; returns null when not found.
+   * @param annotationsBySpanId Shared map of spanId to resolved annotations; acts as both a
+   *     memoization store and a visited set to terminate cycles. Populated by this method.
+   * @return SortedMap of annotation field name to resolved value. Fields with no resolvable
+   *     ancestor are absent from the map.
+   */
+  public SortedMap<String, String> resolveAnnotationsForSpan(
+      ZipkinSpanResponse span,
+      Function<String, ZipkinSpanResponse> parentLookup,
+      Map<String, SortedMap<String, String>> annotationsBySpanId) {
+    if (annotationsBySpanId.containsKey(span.getId())) {
+      return annotationsBySpanId.get(span.getId());
+    }
+
+    // Insert before recursing so cycles in the parent chain terminate at the containsKey check
+    // above.
+    SortedMap<String, String> result = new TreeMap<>();
+    annotationsBySpanId.put(span.getId(), result);
+
+    // Resolve each annotation field on this span directly (no walk-up here).
+    for (Map.Entry<String, TagConfig> entry : edgeMetadataTagMapping.entrySet()) {
+      if (!entry.getValue().isAnnotation()) continue;
+      String value =
+          resolveKeys(span, entry.getValue().getDefaultKey(), entry.getValue().getKeyDelimiter());
+      if (value != null && !value.isEmpty()) {
+        result.put(entry.getKey(), value);
+      }
+    }
+
+    // All annotation fields currently inherit from the nearest ancestor that carries them.
+    // If a future field should not walk up, add a boolean flag (e.g. inherit_from_ancestor)
+    // to TagConfig and gate the putIfAbsent call on it here.
+    ZipkinSpanResponse parent =
+        span.getParentId() != null ? parentLookup.apply(span.getParentId()) : null;
+    if (parent != null) {
+      resolveAnnotationsForSpan(parent, parentLookup, annotationsBySpanId)
+          .forEach(result::putIfAbsent);
+    }
+
+    return result;
   }
 
   @Override

--- a/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
+++ b/astra/src/main/java/com/slack/astra/graphApi/GraphConfig.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -214,7 +213,7 @@ public final class GraphConfig {
           };
 
       for (String key : keys) {
-        // Annotation fields are resolved separately via resolveAnnotationsForSpan and must not
+        // Annotation fields are resolved separately via createAnnotationsFromSpan and must not
         // influence edge identity.
         if (entityType == EntityType.EDGE && this.edgeMetadataTagMapping.get(key).isAnnotation()) {
           continue;
@@ -329,55 +328,23 @@ public final class GraphConfig {
   }
 
   /**
-   * Resolves annotation fields for a span, walking up the parent chain to find the nearest ancestor
-   * that carries a non-null value for each annotation field. Results are memoized in the provided
-   * cache, keyed by span ID, so each span's chain is walked at most once across all calls.
+   * Creates annotations for an edge from a span's own tags. Annotation fields (those marked {@code
+   * is_annotation: true} in config) are resolved using the same key-lookup machinery as regular
+   * metadata fields but are kept separate from identity-determining metadata.
    *
-   * <p>For each annotation field, resolution on a given span uses the same {@code resolveKeys}
-   * machinery as regular metadata fields. A field is only considered "carried" by a span when all
-   * keys in {@code default_key} resolve to non-null, non-empty values on that span. When a span
-   * doesn't carry a field, the value is inherited from the nearest ancestor that does.
-   *
-   * @param span The span to resolve annotations for.
-   * @param parentLookup Function to look up a span by ID; returns null when not found.
-   * @param annotationsBySpanId Shared map of spanId to resolved annotations; acts as both a
-   *     memoization store and a visited set to terminate cycles. Populated by this method.
-   * @return SortedMap of annotation field name to resolved value. Fields with no resolvable
-   *     ancestor are absent from the map.
+   * @param span The span to resolve annotations from.
+   * @return SortedMap of annotation field name to resolved value. Fields not present on this span
+   *     are absent from the map.
    */
-  public SortedMap<String, String> resolveAnnotationsForSpan(
-      ZipkinSpanResponse span,
-      Function<String, ZipkinSpanResponse> parentLookup,
-      Map<String, SortedMap<String, String>> annotationsBySpanId) {
-    if (annotationsBySpanId.containsKey(span.getId())) {
-      return annotationsBySpanId.get(span.getId());
-    }
-
-    // Insert before recursing so cycles in the parent chain terminate at the containsKey check
-    // above.
+  public SortedMap<String, String> createAnnotationsFromSpan(ZipkinSpanResponse span) {
     SortedMap<String, String> result = new TreeMap<>();
-    annotationsBySpanId.put(span.getId(), result);
-
-    // Resolve each annotation field on this span directly (no walk-up here).
-    for (Map.Entry<String, TagConfig> entry : edgeMetadataTagMapping.entrySet()) {
-      if (!entry.getValue().isAnnotation()) continue;
-      String value =
-          resolveKeys(span, entry.getValue().getDefaultKey(), entry.getValue().getKeyDelimiter());
+    for (String key : edgeMetadataTagMapping.keySet()) {
+      if (!edgeMetadataTagMapping.get(key).isAnnotation()) continue;
+      String value = resolve(span, key, EntityType.EDGE);
       if (value != null && !value.isEmpty()) {
-        result.put(entry.getKey(), value);
+        result.put(key, value);
       }
     }
-
-    // All annotation fields currently inherit from the nearest ancestor that carries them.
-    // If a future field should not walk up, add a boolean flag (e.g. inherit_from_ancestor)
-    // to TagConfig and gate the putIfAbsent call on it here.
-    ZipkinSpanResponse parent =
-        span.getParentId() != null ? parentLookup.apply(span.getParentId()) : null;
-    if (parent != null) {
-      resolveAnnotationsForSpan(parent, parentLookup, annotationsBySpanId)
-          .forEach(result::putIfAbsent);
-    }
-
     return result;
   }
 

--- a/astra/src/test/java/com/slack/astra/graphApi/EdgeTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/EdgeTest.java
@@ -39,4 +39,50 @@ public class EdgeTest {
     assertThat(e.getTargetNodeId()).isEqualTo("target");
     assertThat(e.getMetadata()).isNotEmpty();
   }
+
+  @Test
+  void addObservation_emptyAnnotations_incrementsCountAndLeavesAnnotationsEmpty() {
+    Edge e = new Edge("source", "target", null);
+    e.addObservation(Map.of());
+
+    assertThat(e.getObservedCount()).isEqualTo(1);
+    assertThat(e.getAnnotations()).isEmpty();
+  }
+
+  @Test
+  void addObservation_sameFieldAndValueTwice_deduplicates() {
+    Edge e = new Edge("source", "target", null);
+    e.addObservation(Map.of("product_context", "CHECKOUT:CREATE_LISTING:1"));
+    e.addObservation(Map.of("product_context", "CHECKOUT:CREATE_LISTING:1"));
+
+    assertThat(e.getObservedCount()).isEqualTo(2);
+    assertThat(e.getAnnotations().get("product_context")).hasSize(1);
+    assertThat(e.getAnnotations().get("product_context"))
+        .containsExactly("CHECKOUT:CREATE_LISTING:1");
+  }
+
+  @Test
+  void addObservation_differentValuesSameField_accumulatesBoth() {
+    Edge e = new Edge("source", "target", null);
+    e.addObservation(Map.of("product_context", "CHECKOUT:CREATE_LISTING:1"));
+    e.addObservation(Map.of("product_context", "SEARCH:SEARCH_LISTING:2"));
+
+    assertThat(e.getObservedCount()).isEqualTo(2);
+    assertThat(e.getAnnotations().get("product_context")).hasSize(2);
+    assertThat(e.getAnnotations().get("product_context"))
+        .containsExactlyInAnyOrder("CHECKOUT:CREATE_LISTING:1", "SEARCH:SEARCH_LISTING:2");
+  }
+
+  @Test
+  void annotations_doNotAffectEqualsOrGenerateKey() {
+    TreeMap<String, String> metadata = new TreeMap<>(Map.of("operation", "http.request"));
+    Edge e1 = new Edge("source", "target", metadata);
+    Edge e2 = new Edge("source", "target", metadata);
+
+    e1.addObservation(Map.of("product_context", "CHECKOUT:CREATE_LISTING:1"));
+
+    assertThat(e1).isEqualTo(e2);
+    assertThat(Edge.generateKey("source", "target", metadata))
+        .isEqualTo(Edge.generateKey("source", "target", metadata));
+  }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -1739,9 +1739,9 @@ public class GraphBuilderTest {
             .orElseThrow();
 
     assertThat(grandparentToParent.getAnnotations().get("product_context"))
-        .containsExactly("FOO:FOO__BAR__BAZ:1");
+        .containsExactly("FOO|FOO__BAR__BAZ|1");
     assertThat(parentToChild.getAnnotations().get("product_context"))
-        .containsExactly("FOO:FOO__BAR__BAZ:1");
+        .containsExactly("FOO|FOO__BAR__BAZ|1");
   }
 
   @Test
@@ -1828,6 +1828,6 @@ public class GraphBuilderTest {
     assertThat(graph.edges()).hasSize(1);
     assertThat(graph.edges().get(0).getObservedCount()).isEqualTo(2);
     assertThat(graph.edges().get(0).getAnnotations().get("product_context"))
-        .containsExactlyInAnyOrder("FOO:FOO__BAR__BAZ:1", "QUX:QUX__QUUX__CORGE:2");
+        .containsExactlyInAnyOrder("FOO|FOO__BAR__BAZ|1", "QUX|QUX__QUUX__CORGE|2");
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -1660,4 +1660,174 @@ public class GraphBuilderTest {
     assertThat(edge.getMetadata()).isEqualTo(new TreeMap<>(Map.of("operation", "op2")));
     assertThat(edge.getObservedCount()).isEqualTo(3);
   }
+
+  @Test
+  void buildFromSpans_annotationInheritedByDescendants() {
+    // Middle span carries annotation; spans above and below do not.
+    // Edge into annotated span gets the annotation (refSpan IS the annotated span).
+    // Edge out of annotated span also gets the annotation via walk-up from the child.
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            TestUtils.createSpanWithTags(
+                "grandparent",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "appA",
+                    "kube.namespace", "nsA",
+                    "operation_name", "opA",
+                    "resource", "resA")),
+            TestUtils.createSpanWithTags(
+                "parent",
+                "trace1",
+                "grandparent",
+                Map.of(
+                    "kube.app", "appB",
+                    "kube.namespace", "nsB",
+                    "operation_name", "opB",
+                    "resource", "resB",
+                    "tag.product_context_root_function", "FOO",
+                    "tag.product_context", "FOO__BAR__BAZ",
+                    "tag.product_context_criticality", "1")),
+            TestUtils.createSpanWithTags(
+                "child",
+                "trace1",
+                "parent",
+                Map.of(
+                    "kube.app", "appC",
+                    "kube.namespace", "nsC",
+                    "operation_name", "opC",
+                    "resource", "resC")));
+
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
+
+    assertThat(graph.edges()).hasSize(2);
+
+    Edge grandparentToParent =
+        graph.edges().stream()
+            .filter(
+                e ->
+                    e.getTargetNodeId()
+                        .equals(
+                            Node.generateIdFromMetadata(
+                                new TreeMap<>(
+                                    Map.of(
+                                        "service",
+                                        "appB.nsB",
+                                        "resource",
+                                        "resB",
+                                        "project",
+                                        "default-service")))))
+            .findFirst()
+            .orElseThrow();
+    Edge parentToChild =
+        graph.edges().stream()
+            .filter(
+                e ->
+                    e.getTargetNodeId()
+                        .equals(
+                            Node.generateIdFromMetadata(
+                                new TreeMap<>(
+                                    Map.of(
+                                        "service",
+                                        "appC.nsC",
+                                        "resource",
+                                        "resC",
+                                        "project",
+                                        "default-service")))))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(grandparentToParent.getAnnotations().get("product_context"))
+        .containsExactly("FOO:FOO__BAR__BAZ:1");
+    assertThat(parentToChild.getAnnotations().get("product_context"))
+        .containsExactly("FOO:FOO__BAR__BAZ:1");
+  }
+
+  @Test
+  void buildFromSpans_noAnnotationAnywhere_edgesHaveEmptyAnnotations() {
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            TestUtils.createSpanWithTags(
+                "parent1",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "app1",
+                    "kube.namespace", "ns1",
+                    "operation_name", "op1",
+                    "resource", "res1")),
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "parent1",
+                Map.of(
+                    "kube.app", "app2",
+                    "kube.namespace", "ns2",
+                    "operation_name", "op2",
+                    "resource", "res2")));
+
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
+
+    assertThat(graph.edges()).hasSize(1);
+    assertThat(graph.edges().get(0).getAnnotations()).isEmpty();
+  }
+
+  @Test
+  void buildFromSpans_twoSubtreesWithDifferentAnnotations_sameEdgeAccumulatesBoth() {
+    // Two spans map to the same logical edge (same parent/child node metadata) but are descended
+    // from different annotated ancestors. The deduped edge should accumulate both annotation
+    // values.
+    List<ZipkinSpanResponse> spans =
+        List.of(
+            TestUtils.createSpanWithTags(
+                "rootA",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "appA",
+                    "kube.namespace", "nsA",
+                    "operation_name", "opA",
+                    "resource", "resA",
+                    "tag.product_context_root_function", "FOO",
+                    "tag.product_context", "FOO__BAR__BAZ",
+                    "tag.product_context_criticality", "1")),
+            TestUtils.createSpanWithTags(
+                "child1",
+                "trace1",
+                "rootA",
+                Map.of(
+                    "kube.app", "appB",
+                    "kube.namespace", "nsB",
+                    "operation_name", "opB",
+                    "resource", "resB")),
+            TestUtils.createSpanWithTags(
+                "rootB",
+                "trace1",
+                null,
+                Map.of(
+                    "kube.app", "appA",
+                    "kube.namespace", "nsA",
+                    "operation_name", "opA",
+                    "resource", "resA",
+                    "tag.product_context_root_function", "QUX",
+                    "tag.product_context", "QUX__QUUX__CORGE",
+                    "tag.product_context_criticality", "2")),
+            TestUtils.createSpanWithTags(
+                "child2",
+                "trace1",
+                "rootB",
+                Map.of(
+                    "kube.app", "appB",
+                    "kube.namespace", "nsB",
+                    "operation_name", "opB",
+                    "resource", "resB")));
+
+    Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
+
+    assertThat(graph.edges()).hasSize(1);
+    assertThat(graph.edges().get(0).getObservedCount()).isEqualTo(2);
+    assertThat(graph.edges().get(0).getAnnotations().get("product_context"))
+        .containsExactlyInAnyOrder("FOO:FOO__BAR__BAZ:1", "QUX:QUX__QUUX__CORGE:2");
+  }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -1662,35 +1662,85 @@ public class GraphBuilderTest {
   }
 
   @Test
-  void buildFromSpans_spanCarriesAnnotationTags_edgeGetsAnnotation() {
+  void buildFromSpans_annotationInheritedByDescendants() {
+    // Middle span carries annotation; spans above and below do not.
+    // Edge into annotated span gets the annotation (refSpan IS the annotated span).
+    // Edge out of annotated span also gets the annotation via walk-up from the child.
     List<ZipkinSpanResponse> spans =
         List.of(
             TestUtils.createSpanWithTags(
-                "parent",
+                "grandparent",
                 "trace1",
                 null,
                 Map.of(
-                    "kube.app", "app1",
-                    "kube.namespace", "ns1",
-                    "operation_name", "op1",
-                    "resource", "res1")),
+                    "kube.app", "appA",
+                    "kube.namespace", "nsA",
+                    "operation_name", "opA",
+                    "resource", "resA")),
+            TestUtils.createSpanWithTags(
+                "parent",
+                "trace1",
+                "grandparent",
+                Map.of(
+                    "kube.app", "appB",
+                    "kube.namespace", "nsB",
+                    "operation_name", "opB",
+                    "resource", "resB",
+                    "tag.product_context_root_function", "FOO",
+                    "tag.product_context", "FOO__BAR__BAZ",
+                    "tag.product_context_criticality", "1")),
             TestUtils.createSpanWithTags(
                 "child",
                 "trace1",
                 "parent",
                 Map.of(
-                    "kube.app", "app2",
-                    "kube.namespace", "ns2",
-                    "operation_name", "op2",
-                    "resource", "res2",
-                    "tag.product_context_root_function", "FOO",
-                    "tag.product_context", "FOO__BAR__BAZ",
-                    "tag.product_context_criticality", "1")));
+                    "kube.app", "appC",
+                    "kube.namespace", "nsC",
+                    "operation_name", "opC",
+                    "resource", "resC")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 
-    assertThat(graph.edges()).hasSize(1);
-    assertThat(graph.edges().get(0).getAnnotations().get("product_context"))
+    assertThat(graph.edges()).hasSize(2);
+
+    Edge grandparentToParent =
+        graph.edges().stream()
+            .filter(
+                e ->
+                    e.getTargetNodeId()
+                        .equals(
+                            Node.generateIdFromMetadata(
+                                new TreeMap<>(
+                                    Map.of(
+                                        "service",
+                                        "appB.nsB",
+                                        "resource",
+                                        "resB",
+                                        "project",
+                                        "default-service")))))
+            .findFirst()
+            .orElseThrow();
+    Edge parentToChild =
+        graph.edges().stream()
+            .filter(
+                e ->
+                    e.getTargetNodeId()
+                        .equals(
+                            Node.generateIdFromMetadata(
+                                new TreeMap<>(
+                                    Map.of(
+                                        "service",
+                                        "appC.nsC",
+                                        "resource",
+                                        "resC",
+                                        "project",
+                                        "default-service")))))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(grandparentToParent.getAnnotations().get("product_context"))
+        .containsExactly("FOO|FOO__BAR__BAZ|1");
+    assertThat(parentToChild.getAnnotations().get("product_context"))
         .containsExactly("FOO|FOO__BAR__BAZ|1");
   }
 
@@ -1725,8 +1775,9 @@ public class GraphBuilderTest {
 
   @Test
   void buildFromSpans_twoSubtreesWithDifferentAnnotations_sameEdgeAccumulatesBoth() {
-    // Two spans map to the same logical edge (same parent/child node metadata) but each refSpan
-    // carries a different annotation. The deduped edge should accumulate both annotation values.
+    // Two spans map to the same logical edge (same parent/child node metadata) but are descended
+    // from different annotated ancestors. The deduped edge should accumulate both annotation
+    // values.
     List<ZipkinSpanResponse> spans =
         List.of(
             TestUtils.createSpanWithTags(
@@ -1737,7 +1788,10 @@ public class GraphBuilderTest {
                     "kube.app", "appA",
                     "kube.namespace", "nsA",
                     "operation_name", "opA",
-                    "resource", "resA")),
+                    "resource", "resA",
+                    "tag.product_context_root_function", "FOO",
+                    "tag.product_context", "FOO__BAR__BAZ",
+                    "tag.product_context_criticality", "1")),
             TestUtils.createSpanWithTags(
                 "child1",
                 "trace1",
@@ -1746,10 +1800,7 @@ public class GraphBuilderTest {
                     "kube.app", "appB",
                     "kube.namespace", "nsB",
                     "operation_name", "opB",
-                    "resource", "resB",
-                    "tag.product_context_root_function", "FOO",
-                    "tag.product_context", "FOO__BAR__BAZ",
-                    "tag.product_context_criticality", "1")),
+                    "resource", "resB")),
             TestUtils.createSpanWithTags(
                 "rootB",
                 "trace1",
@@ -1758,7 +1809,10 @@ public class GraphBuilderTest {
                     "kube.app", "appA",
                     "kube.namespace", "nsA",
                     "operation_name", "opA",
-                    "resource", "resA")),
+                    "resource", "resA",
+                    "tag.product_context_root_function", "QUX",
+                    "tag.product_context", "QUX__QUUX__CORGE",
+                    "tag.product_context_criticality", "2")),
             TestUtils.createSpanWithTags(
                 "child2",
                 "trace1",
@@ -1767,10 +1821,7 @@ public class GraphBuilderTest {
                     "kube.app", "appB",
                     "kube.namespace", "nsB",
                     "operation_name", "opB",
-                    "resource", "resB",
-                    "tag.product_context_root_function", "QUX",
-                    "tag.product_context", "QUX__QUUX__CORGE",
-                    "tag.product_context_criticality", "2")));
+                    "resource", "resB")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphBuilderTest.java
@@ -1662,85 +1662,35 @@ public class GraphBuilderTest {
   }
 
   @Test
-  void buildFromSpans_annotationInheritedByDescendants() {
-    // Middle span carries annotation; spans above and below do not.
-    // Edge into annotated span gets the annotation (refSpan IS the annotated span).
-    // Edge out of annotated span also gets the annotation via walk-up from the child.
+  void buildFromSpans_spanCarriesAnnotationTags_edgeGetsAnnotation() {
     List<ZipkinSpanResponse> spans =
         List.of(
             TestUtils.createSpanWithTags(
-                "grandparent",
+                "parent",
                 "trace1",
                 null,
                 Map.of(
-                    "kube.app", "appA",
-                    "kube.namespace", "nsA",
-                    "operation_name", "opA",
-                    "resource", "resA")),
-            TestUtils.createSpanWithTags(
-                "parent",
-                "trace1",
-                "grandparent",
-                Map.of(
-                    "kube.app", "appB",
-                    "kube.namespace", "nsB",
-                    "operation_name", "opB",
-                    "resource", "resB",
-                    "tag.product_context_root_function", "FOO",
-                    "tag.product_context", "FOO__BAR__BAZ",
-                    "tag.product_context_criticality", "1")),
+                    "kube.app", "app1",
+                    "kube.namespace", "ns1",
+                    "operation_name", "op1",
+                    "resource", "res1")),
             TestUtils.createSpanWithTags(
                 "child",
                 "trace1",
                 "parent",
                 Map.of(
-                    "kube.app", "appC",
-                    "kube.namespace", "nsC",
-                    "operation_name", "opC",
-                    "resource", "resC")));
+                    "kube.app", "app2",
+                    "kube.namespace", "ns2",
+                    "operation_name", "op2",
+                    "resource", "res2",
+                    "tag.product_context_root_function", "FOO",
+                    "tag.product_context", "FOO__BAR__BAZ",
+                    "tag.product_context_criticality", "1")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 
-    assertThat(graph.edges()).hasSize(2);
-
-    Edge grandparentToParent =
-        graph.edges().stream()
-            .filter(
-                e ->
-                    e.getTargetNodeId()
-                        .equals(
-                            Node.generateIdFromMetadata(
-                                new TreeMap<>(
-                                    Map.of(
-                                        "service",
-                                        "appB.nsB",
-                                        "resource",
-                                        "resB",
-                                        "project",
-                                        "default-service")))))
-            .findFirst()
-            .orElseThrow();
-    Edge parentToChild =
-        graph.edges().stream()
-            .filter(
-                e ->
-                    e.getTargetNodeId()
-                        .equals(
-                            Node.generateIdFromMetadata(
-                                new TreeMap<>(
-                                    Map.of(
-                                        "service",
-                                        "appC.nsC",
-                                        "resource",
-                                        "resC",
-                                        "project",
-                                        "default-service")))))
-            .findFirst()
-            .orElseThrow();
-
-    assertThat(grandparentToParent.getAnnotations().get("product_context"))
-        .containsExactly("FOO|FOO__BAR__BAZ|1");
-    assertThat(parentToChild.getAnnotations().get("product_context"))
+    assertThat(graph.edges()).hasSize(1);
+    assertThat(graph.edges().get(0).getAnnotations().get("product_context"))
         .containsExactly("FOO|FOO__BAR__BAZ|1");
   }
 
@@ -1775,9 +1725,8 @@ public class GraphBuilderTest {
 
   @Test
   void buildFromSpans_twoSubtreesWithDifferentAnnotations_sameEdgeAccumulatesBoth() {
-    // Two spans map to the same logical edge (same parent/child node metadata) but are descended
-    // from different annotated ancestors. The deduped edge should accumulate both annotation
-    // values.
+    // Two spans map to the same logical edge (same parent/child node metadata) but each refSpan
+    // carries a different annotation. The deduped edge should accumulate both annotation values.
     List<ZipkinSpanResponse> spans =
         List.of(
             TestUtils.createSpanWithTags(
@@ -1788,10 +1737,7 @@ public class GraphBuilderTest {
                     "kube.app", "appA",
                     "kube.namespace", "nsA",
                     "operation_name", "opA",
-                    "resource", "resA",
-                    "tag.product_context_root_function", "FOO",
-                    "tag.product_context", "FOO__BAR__BAZ",
-                    "tag.product_context_criticality", "1")),
+                    "resource", "resA")),
             TestUtils.createSpanWithTags(
                 "child1",
                 "trace1",
@@ -1800,7 +1746,10 @@ public class GraphBuilderTest {
                     "kube.app", "appB",
                     "kube.namespace", "nsB",
                     "operation_name", "opB",
-                    "resource", "resB")),
+                    "resource", "resB",
+                    "tag.product_context_root_function", "FOO",
+                    "tag.product_context", "FOO__BAR__BAZ",
+                    "tag.product_context_criticality", "1")),
             TestUtils.createSpanWithTags(
                 "rootB",
                 "trace1",
@@ -1809,10 +1758,7 @@ public class GraphBuilderTest {
                     "kube.app", "appA",
                     "kube.namespace", "nsA",
                     "operation_name", "opA",
-                    "resource", "resA",
-                    "tag.product_context_root_function", "QUX",
-                    "tag.product_context", "QUX__QUUX__CORGE",
-                    "tag.product_context_criticality", "2")),
+                    "resource", "resA")),
             TestUtils.createSpanWithTags(
                 "child2",
                 "trace1",
@@ -1821,7 +1767,10 @@ public class GraphBuilderTest {
                     "kube.app", "appB",
                     "kube.namespace", "nsB",
                     "operation_name", "opB",
-                    "resource", "resB")));
+                    "resource", "resB",
+                    "tag.product_context_root_function", "QUX",
+                    "tag.product_context", "QUX__QUUX__CORGE",
+                    "tag.product_context_criticality", "2")));
 
     Graph graph = configuredGraphBuilder.buildFromSpans(spans, Optional.empty());
 

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -891,7 +891,7 @@ public class GraphConfigTest {
   }
 
   @Test
-  public void testResolveAnnotationsForSpan_allThreeTags_returnsJoinedString() throws IOException {
+  public void testCreateAnnotationsFromSpan_allThreeTags_returnsJoinedString() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
@@ -916,14 +916,13 @@ public class GraphConfigTest {
                 "tag.product_context", "FOO__BAR__BAZ",
                 "tag.product_context_criticality", "1"));
 
-    SortedMap<String, String> annotations =
-        config.resolveAnnotationsForSpan(span, id -> null, new HashMap<>());
+    SortedMap<String, String> annotations = config.createAnnotationsFromSpan(span);
 
     assertThat(annotations).containsEntry("product_context", "FOO|FOO__BAR__BAZ|1");
   }
 
   @Test
-  public void testResolveAnnotationsForSpan_missingOneTag_walksUpToAncestor() throws IOException {
+  public void testCreateAnnotationsFromSpan_missingOneTag_returnsEmptyMap() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
@@ -938,35 +937,23 @@ public class GraphConfigTest {
                 default_value: ""
             """);
 
-    ZipkinSpanResponse parent =
+    // Missing criticality — all-or-nothing, so no annotation resolved.
+    ZipkinSpanResponse span =
         TestUtils.createSpanWithTags(
-            "parent",
+            "s1",
             "t1",
             null,
             Map.of(
                 "tag.product_context_root_function", "FOO",
-                "tag.product_context", "FOO__BAR__BAZ",
-                "tag.product_context_criticality", "1"));
+                "tag.product_context", "FOO__BAR__BAZ"));
 
-    // Missing criticality — treated as not carrying PC, inherits from parent.
-    ZipkinSpanResponse child =
-        TestUtils.createSpanWithTags(
-            "child",
-            "t1",
-            "parent",
-            Map.of(
-                "tag.product_context_root_function", "QUX",
-                "tag.product_context", "QUX__QUUX__CORGE"));
+    SortedMap<String, String> annotations = config.createAnnotationsFromSpan(span);
 
-    Map<String, ZipkinSpanResponse> spanMap = Map.of("parent", parent, "child", child);
-    SortedMap<String, String> annotations =
-        config.resolveAnnotationsForSpan(child, spanMap::get, new HashMap<>());
-
-    assertThat(annotations).containsEntry("product_context", "FOO|FOO__BAR__BAZ|1");
+    assertThat(annotations).isEmpty();
   }
 
   @Test
-  public void testResolveAnnotationsForSpan_noPcAnywhere_returnsEmptyMap() throws IOException {
+  public void testCreateAnnotationsFromSpan_noTagsPresent_returnsEmptyMap() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
@@ -984,119 +971,6 @@ public class GraphConfigTest {
     ZipkinSpanResponse span =
         TestUtils.createSpanWithTags("s1", "t1", null, Map.of("operation_name", "db.query"));
 
-    SortedMap<String, String> annotations =
-        config.resolveAnnotationsForSpan(span, id -> null, new HashMap<>());
-
-    assertThat(annotations).isEmpty();
-  }
-
-  @Test
-  public void testResolveAnnotationsForSpan_stopsAtNearestAncestor() throws IOException {
-    GraphConfig config =
-        GraphConfig.load(
-            """
-            edge_metadata_tag_mapping:
-              category:
-                is_annotation: true
-                default_key: [tag.category]
-                default_value: ""
-            """);
-
-    // grandparent has annotation "cat_gp", parent has annotation "cat_p", child has none.
-    // Child should inherit "cat_p" (nearest), not "cat_gp".
-    ZipkinSpanResponse grandparent =
-        TestUtils.createSpanWithTags("gp", "t1", null, Map.of("tag.category", "cat_gp"));
-    ZipkinSpanResponse parent =
-        TestUtils.createSpanWithTags("p", "t1", "gp", Map.of("tag.category", "cat_p"));
-    ZipkinSpanResponse child = TestUtils.createSpanWithTags("c", "t1", "p", Map.of());
-
-    Map<String, ZipkinSpanResponse> spanMap = Map.of("gp", grandparent, "p", parent, "c", child);
-    SortedMap<String, String> annotations =
-        config.resolveAnnotationsForSpan(child, spanMap::get, new HashMap<>());
-
-    assertThat(annotations).containsEntry("category", "cat_p");
-  }
-
-  @Test
-  public void testResolveAnnotationsForSpan_cycleInParentChain_terminates() throws IOException {
-    GraphConfig config =
-        GraphConfig.load(
-            """
-            edge_metadata_tag_mapping:
-              category:
-                is_annotation: true
-                default_key: [tag.category]
-                default_value: ""
-            """);
-
-    // A's parent is B, B's parent is A — cycle, neither carries the annotation
-    ZipkinSpanResponse spanA = TestUtils.createSpanWithTags("A", "t1", "B", Map.of());
-    ZipkinSpanResponse spanB = TestUtils.createSpanWithTags("B", "t1", "A", Map.of());
-
-    Map<String, ZipkinSpanResponse> spanMap = Map.of("A", spanA, "B", spanB);
-    SortedMap<String, String> annotations =
-        config.resolveAnnotationsForSpan(spanA, spanMap::get, new HashMap<>());
-
-    assertThat(annotations).isEmpty();
-  }
-
-  @Test
-  public void testResolveAnnotationsForSpan_siblingsDifferentAncestorAnnotations_eachInheritsOwn()
-      throws IOException {
-    GraphConfig config =
-        GraphConfig.load(
-            """
-            edge_metadata_tag_mapping:
-              category:
-                is_annotation: true
-                default_key: [tag.category]
-                default_value: ""
-            """);
-
-    ZipkinSpanResponse rootA =
-        TestUtils.createSpanWithTags("rootA", "t1", null, Map.of("tag.category", "cat_a"));
-    ZipkinSpanResponse childA = TestUtils.createSpanWithTags("childA", "t1", "rootA", Map.of());
-
-    ZipkinSpanResponse rootB =
-        TestUtils.createSpanWithTags("rootB", "t1", null, Map.of("tag.category", "cat_b"));
-    ZipkinSpanResponse childB = TestUtils.createSpanWithTags("childB", "t1", "rootB", Map.of());
-
-    Map<String, ZipkinSpanResponse> spanMap =
-        Map.of("rootA", rootA, "childA", childA, "rootB", rootB, "childB", childB);
-    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
-
-    assertThat(config.resolveAnnotationsForSpan(childA, spanMap::get, annotationsBySpanId))
-        .containsEntry("category", "cat_a");
-    assertThat(config.resolveAnnotationsForSpan(childB, spanMap::get, annotationsBySpanId))
-        .containsEntry("category", "cat_b");
-  }
-
-  @Test
-  public void testResolveAnnotationsForSpan_cycleWithAnnotations_eachSpanKeepsOwnValue()
-      throws IOException {
-    GraphConfig config =
-        GraphConfig.load(
-            """
-            edge_metadata_tag_mapping:
-              category:
-                is_annotation: true
-                default_key: [tag.category]
-                default_value: ""
-            """);
-
-    // A's parent is B, B's parent is A — cycle, each carries its own annotation value.
-    // Each should resolve to its own value, not inherit the other's.
-    ZipkinSpanResponse spanA =
-        TestUtils.createSpanWithTags("A", "t1", "B", Map.of("tag.category", "cat_a"));
-    ZipkinSpanResponse spanB =
-        TestUtils.createSpanWithTags("B", "t1", "A", Map.of("tag.category", "cat_b"));
-
-    Map<String, ZipkinSpanResponse> spanMap = Map.of("A", spanA, "B", spanB);
-    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
-
-    assertThat(config.resolveAnnotationsForSpan(spanA, spanMap::get, annotationsBySpanId))
-        .containsEntry("category", "cat_a");
-    assertThat(config.resolveAnnotationsForSpan(spanB, spanMap::get, annotationsBySpanId))
-        .containsEntry("category", "cat_b");
+    assertThat(config.createAnnotationsFromSpan(span)).isEmpty();
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -891,7 +891,7 @@ public class GraphConfigTest {
   }
 
   @Test
-  public void testCreateAnnotationsFromSpan_allThreeTags_returnsJoinedString() throws IOException {
+  public void testResolveAnnotationsForSpan_allThreeTags_returnsJoinedString() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
@@ -916,13 +916,14 @@ public class GraphConfigTest {
                 "tag.product_context", "FOO__BAR__BAZ",
                 "tag.product_context_criticality", "1"));
 
-    SortedMap<String, String> annotations = config.createAnnotationsFromSpan(span);
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(span, id -> null, new HashMap<>());
 
     assertThat(annotations).containsEntry("product_context", "FOO|FOO__BAR__BAZ|1");
   }
 
   @Test
-  public void testCreateAnnotationsFromSpan_missingOneTag_returnsEmptyMap() throws IOException {
+  public void testResolveAnnotationsForSpan_missingOneTag_walksUpToAncestor() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
@@ -937,23 +938,35 @@ public class GraphConfigTest {
                 default_value: ""
             """);
 
-    // Missing criticality — all-or-nothing, so no annotation resolved.
-    ZipkinSpanResponse span =
+    ZipkinSpanResponse parent =
         TestUtils.createSpanWithTags(
-            "s1",
+            "parent",
             "t1",
             null,
             Map.of(
                 "tag.product_context_root_function", "FOO",
-                "tag.product_context", "FOO__BAR__BAZ"));
+                "tag.product_context", "FOO__BAR__BAZ",
+                "tag.product_context_criticality", "1"));
 
-    SortedMap<String, String> annotations = config.createAnnotationsFromSpan(span);
+    // Missing criticality — treated as not carrying PC, inherits from parent.
+    ZipkinSpanResponse child =
+        TestUtils.createSpanWithTags(
+            "child",
+            "t1",
+            "parent",
+            Map.of(
+                "tag.product_context_root_function", "QUX",
+                "tag.product_context", "QUX__QUUX__CORGE"));
 
-    assertThat(annotations).isEmpty();
+    Map<String, ZipkinSpanResponse> spanMap = Map.of("parent", parent, "child", child);
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(child, spanMap::get, new HashMap<>());
+
+    assertThat(annotations).containsEntry("product_context", "FOO|FOO__BAR__BAZ|1");
   }
 
   @Test
-  public void testCreateAnnotationsFromSpan_noTagsPresent_returnsEmptyMap() throws IOException {
+  public void testResolveAnnotationsForSpan_noPcAnywhere_returnsEmptyMap() throws IOException {
     GraphConfig config =
         GraphConfig.load(
             """
@@ -971,6 +984,119 @@ public class GraphConfigTest {
     ZipkinSpanResponse span =
         TestUtils.createSpanWithTags("s1", "t1", null, Map.of("operation_name", "db.query"));
 
-    assertThat(config.createAnnotationsFromSpan(span)).isEmpty();
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(span, id -> null, new HashMap<>());
+
+    assertThat(annotations).isEmpty();
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_stopsAtNearestAncestor() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              category:
+                is_annotation: true
+                default_key: [tag.category]
+                default_value: ""
+            """);
+
+    // grandparent has annotation "cat_gp", parent has annotation "cat_p", child has none.
+    // Child should inherit "cat_p" (nearest), not "cat_gp".
+    ZipkinSpanResponse grandparent =
+        TestUtils.createSpanWithTags("gp", "t1", null, Map.of("tag.category", "cat_gp"));
+    ZipkinSpanResponse parent =
+        TestUtils.createSpanWithTags("p", "t1", "gp", Map.of("tag.category", "cat_p"));
+    ZipkinSpanResponse child = TestUtils.createSpanWithTags("c", "t1", "p", Map.of());
+
+    Map<String, ZipkinSpanResponse> spanMap = Map.of("gp", grandparent, "p", parent, "c", child);
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(child, spanMap::get, new HashMap<>());
+
+    assertThat(annotations).containsEntry("category", "cat_p");
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_cycleInParentChain_terminates() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              category:
+                is_annotation: true
+                default_key: [tag.category]
+                default_value: ""
+            """);
+
+    // A's parent is B, B's parent is A — cycle, neither carries the annotation
+    ZipkinSpanResponse spanA = TestUtils.createSpanWithTags("A", "t1", "B", Map.of());
+    ZipkinSpanResponse spanB = TestUtils.createSpanWithTags("B", "t1", "A", Map.of());
+
+    Map<String, ZipkinSpanResponse> spanMap = Map.of("A", spanA, "B", spanB);
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(spanA, spanMap::get, new HashMap<>());
+
+    assertThat(annotations).isEmpty();
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_siblingsDifferentAncestorAnnotations_eachInheritsOwn()
+      throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              category:
+                is_annotation: true
+                default_key: [tag.category]
+                default_value: ""
+            """);
+
+    ZipkinSpanResponse rootA =
+        TestUtils.createSpanWithTags("rootA", "t1", null, Map.of("tag.category", "cat_a"));
+    ZipkinSpanResponse childA = TestUtils.createSpanWithTags("childA", "t1", "rootA", Map.of());
+
+    ZipkinSpanResponse rootB =
+        TestUtils.createSpanWithTags("rootB", "t1", null, Map.of("tag.category", "cat_b"));
+    ZipkinSpanResponse childB = TestUtils.createSpanWithTags("childB", "t1", "rootB", Map.of());
+
+    Map<String, ZipkinSpanResponse> spanMap =
+        Map.of("rootA", rootA, "childA", childA, "rootB", rootB, "childB", childB);
+    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
+
+    assertThat(config.resolveAnnotationsForSpan(childA, spanMap::get, annotationsBySpanId))
+        .containsEntry("category", "cat_a");
+    assertThat(config.resolveAnnotationsForSpan(childB, spanMap::get, annotationsBySpanId))
+        .containsEntry("category", "cat_b");
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_cycleWithAnnotations_eachSpanKeepsOwnValue()
+      throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              category:
+                is_annotation: true
+                default_key: [tag.category]
+                default_value: ""
+            """);
+
+    // A's parent is B, B's parent is A — cycle, each carries its own annotation value.
+    // Each should resolve to its own value, not inherit the other's.
+    ZipkinSpanResponse spanA =
+        TestUtils.createSpanWithTags("A", "t1", "B", Map.of("tag.category", "cat_a"));
+    ZipkinSpanResponse spanB =
+        TestUtils.createSpanWithTags("B", "t1", "A", Map.of("tag.category", "cat_b"));
+
+    Map<String, ZipkinSpanResponse> spanMap = Map.of("A", spanA, "B", spanB);
+    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
+
+    assertThat(config.resolveAnnotationsForSpan(spanA, spanMap::get, annotationsBySpanId))
+        .containsEntry("category", "cat_a");
+    assertThat(config.resolveAnnotationsForSpan(spanB, spanMap::get, annotationsBySpanId))
+        .containsEntry("category", "cat_b");
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -51,7 +51,7 @@ public class GraphConfigTest {
                     - tag.product_context_root_function
                     - tag.product_context
                     - tag.product_context_criticality
-                  key_delimiter: ":"
+                  key_delimiter: "|"
                   default_value: ""
               """;
 
@@ -99,7 +99,7 @@ public class GraphConfigTest {
             "tag.product_context_root_function",
             "tag.product_context",
             "tag.product_context_criticality");
-    assertThat(productContextConfig.getKeyDelimiter()).isEqualTo(":");
+    assertThat(productContextConfig.getKeyDelimiter()).isEqualTo("|");
   }
 
   @Test
@@ -868,7 +868,7 @@ public class GraphConfigTest {
                   - tag.product_context_root_function
                   - tag.product_context
                   - tag.product_context_criticality
-                key_delimiter: ":"
+                key_delimiter: "|"
                 default_value: ""
             """);
 
@@ -902,7 +902,7 @@ public class GraphConfigTest {
                   - tag.product_context_root_function
                   - tag.product_context
                   - tag.product_context_criticality
-                key_delimiter: ":"
+                key_delimiter: "|"
                 default_value: ""
             """);
 
@@ -919,7 +919,7 @@ public class GraphConfigTest {
     SortedMap<String, String> annotations =
         config.resolveAnnotationsForSpan(span, id -> null, new HashMap<>());
 
-    assertThat(annotations).containsEntry("product_context", "FOO:FOO__BAR__BAZ:1");
+    assertThat(annotations).containsEntry("product_context", "FOO|FOO__BAR__BAZ|1");
   }
 
   @Test
@@ -934,7 +934,7 @@ public class GraphConfigTest {
                   - tag.product_context_root_function
                   - tag.product_context
                   - tag.product_context_criticality
-                key_delimiter: ":"
+                key_delimiter: "|"
                 default_value: ""
             """);
 
@@ -962,7 +962,7 @@ public class GraphConfigTest {
     SortedMap<String, String> annotations =
         config.resolveAnnotationsForSpan(child, spanMap::get, new HashMap<>());
 
-    assertThat(annotations).containsEntry("product_context", "FOO:FOO__BAR__BAZ:1");
+    assertThat(annotations).containsEntry("product_context", "FOO|FOO__BAR__BAZ|1");
   }
 
   @Test
@@ -977,7 +977,7 @@ public class GraphConfigTest {
                   - tag.product_context_root_function
                   - tag.product_context
                   - tag.product_context_criticality
-                key_delimiter: ":"
+                key_delimiter: "|"
                 default_value: ""
             """);
 

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -45,6 +45,14 @@ public class GraphConfigTest {
                       value: prod
                       override_key:
                         - operation.prod
+                product_context:
+                  is_annotation: true
+                  default_key:
+                    - tag.product_context_root_function
+                    - tag.product_context
+                    - tag.product_context_criticality
+                  key_delimiter: ":"
+                  default_value: ""
               """;
 
     Path configFile = tempDir.resolve("test-config.yaml");
@@ -54,7 +62,7 @@ public class GraphConfigTest {
 
     assertThat(config).isNotNull();
     assertThat(config.getNodeMetadataTagMapping()).hasSize(2);
-    assertThat(config.getEdgeMetadataTagMapping()).hasSize(1);
+    assertThat(config.getEdgeMetadataTagMapping()).hasSize(2);
 
     GraphConfig.TagConfig serviceConfig = config.getNodeMetadataTagMapping().get("service");
     assertThat(serviceConfig.getDefaultKey()).containsExactly("service.name");
@@ -81,6 +89,17 @@ public class GraphConfigTest {
     assertThat(connectionTypeConfig.getDefaultKey()).containsExactly("operation_name");
     assertThat(connectionTypeConfig.getDefaultValue()).isEqualTo("unknown_operation");
     assertThat(connectionTypeConfig.getRules()).hasSize(1);
+    assertThat(connectionTypeConfig.isAnnotation()).isFalse();
+
+    GraphConfig.TagConfig productContextConfig =
+        config.getEdgeMetadataTagMapping().get("product_context");
+    assertThat(productContextConfig.isAnnotation()).isTrue();
+    assertThat(productContextConfig.getDefaultKey())
+        .containsExactly(
+            "tag.product_context_root_function",
+            "tag.product_context",
+            "tag.product_context_criticality");
+    assertThat(productContextConfig.getKeyDelimiter()).isEqualTo(":");
   }
 
   @Test
@@ -832,5 +851,252 @@ public class GraphConfigTest {
 
     assertThat(metadata).hasSize(1);
     assertThat(metadata.get("operation")).isEqualTo("some_operation");
+  }
+
+  @Test
+  public void testCreateMetadataFromSpan_edgeExcludesAnnotationFields() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              operation:
+                default_key: [operation_name]
+                default_value: unknown_operation
+              product_context:
+                is_annotation: true
+                default_key:
+                  - tag.product_context_root_function
+                  - tag.product_context
+                  - tag.product_context_criticality
+                key_delimiter: ":"
+                default_value: ""
+            """);
+
+    ZipkinSpanResponse span =
+        TestUtils.createSpanWithTags(
+            "s1",
+            "t1",
+            null,
+            Map.of(
+                "operation_name", "http.request",
+                "tag.product_context_root_function", "FOO",
+                "tag.product_context", "FOO__BAR__BAZ",
+                "tag.product_context_criticality", "1"));
+
+    SortedMap<String, String> metadata =
+        config.createMetadataFromSpan(span, GraphConfig.EntityType.EDGE);
+
+    assertThat(metadata).containsOnlyKeys("operation");
+    assertThat(metadata.get("operation")).isEqualTo("http.request");
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_allThreeTags_returnsJoinedString() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              product_context:
+                is_annotation: true
+                default_key:
+                  - tag.product_context_root_function
+                  - tag.product_context
+                  - tag.product_context_criticality
+                key_delimiter: ":"
+                default_value: ""
+            """);
+
+    ZipkinSpanResponse span =
+        TestUtils.createSpanWithTags(
+            "s1",
+            "t1",
+            null,
+            Map.of(
+                "tag.product_context_root_function", "FOO",
+                "tag.product_context", "FOO__BAR__BAZ",
+                "tag.product_context_criticality", "1"));
+
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(span, id -> null, new HashMap<>());
+
+    assertThat(annotations).containsEntry("product_context", "FOO:FOO__BAR__BAZ:1");
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_missingOneTag_walksUpToAncestor() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              product_context:
+                is_annotation: true
+                default_key:
+                  - tag.product_context_root_function
+                  - tag.product_context
+                  - tag.product_context_criticality
+                key_delimiter: ":"
+                default_value: ""
+            """);
+
+    ZipkinSpanResponse parent =
+        TestUtils.createSpanWithTags(
+            "parent",
+            "t1",
+            null,
+            Map.of(
+                "tag.product_context_root_function", "FOO",
+                "tag.product_context", "FOO__BAR__BAZ",
+                "tag.product_context_criticality", "1"));
+
+    // Missing criticality — treated as not carrying PC, inherits from parent.
+    ZipkinSpanResponse child =
+        TestUtils.createSpanWithTags(
+            "child",
+            "t1",
+            "parent",
+            Map.of(
+                "tag.product_context_root_function", "QUX",
+                "tag.product_context", "QUX__QUUX__CORGE"));
+
+    Map<String, ZipkinSpanResponse> spanMap = Map.of("parent", parent, "child", child);
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(child, spanMap::get, new HashMap<>());
+
+    assertThat(annotations).containsEntry("product_context", "FOO:FOO__BAR__BAZ:1");
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_noPcAnywhere_returnsEmptyMap() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              product_context:
+                is_annotation: true
+                default_key:
+                  - tag.product_context_root_function
+                  - tag.product_context
+                  - tag.product_context_criticality
+                key_delimiter: ":"
+                default_value: ""
+            """);
+
+    ZipkinSpanResponse span =
+        TestUtils.createSpanWithTags("s1", "t1", null, Map.of("operation_name", "db.query"));
+
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(span, id -> null, new HashMap<>());
+
+    assertThat(annotations).isEmpty();
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_stopsAtNearestAncestor() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              category:
+                is_annotation: true
+                default_key: [tag.category]
+                default_value: ""
+            """);
+
+    // grandparent has annotation "cat_gp", parent has annotation "cat_p", child has none.
+    // Child should inherit "cat_p" (nearest), not "cat_gp".
+    ZipkinSpanResponse grandparent =
+        TestUtils.createSpanWithTags("gp", "t1", null, Map.of("tag.category", "cat_gp"));
+    ZipkinSpanResponse parent =
+        TestUtils.createSpanWithTags("p", "t1", "gp", Map.of("tag.category", "cat_p"));
+    ZipkinSpanResponse child = TestUtils.createSpanWithTags("c", "t1", "p", Map.of());
+
+    Map<String, ZipkinSpanResponse> spanMap = Map.of("gp", grandparent, "p", parent, "c", child);
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(child, spanMap::get, new HashMap<>());
+
+    assertThat(annotations).containsEntry("category", "cat_p");
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_cycleInParentChain_terminates() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              category:
+                is_annotation: true
+                default_key: [tag.category]
+                default_value: ""
+            """);
+
+    // A's parent is B, B's parent is A — cycle, neither carries the annotation
+    ZipkinSpanResponse spanA = TestUtils.createSpanWithTags("A", "t1", "B", Map.of());
+    ZipkinSpanResponse spanB = TestUtils.createSpanWithTags("B", "t1", "A", Map.of());
+
+    Map<String, ZipkinSpanResponse> spanMap = Map.of("A", spanA, "B", spanB);
+    SortedMap<String, String> annotations =
+        config.resolveAnnotationsForSpan(spanA, spanMap::get, new HashMap<>());
+
+    assertThat(annotations).isEmpty();
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_siblingsDifferentAncestorAnnotations_eachInheritsOwn()
+      throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              category:
+                is_annotation: true
+                default_key: [tag.category]
+                default_value: ""
+            """);
+
+    ZipkinSpanResponse rootA =
+        TestUtils.createSpanWithTags("rootA", "t1", null, Map.of("tag.category", "cat_a"));
+    ZipkinSpanResponse childA = TestUtils.createSpanWithTags("childA", "t1", "rootA", Map.of());
+
+    ZipkinSpanResponse rootB =
+        TestUtils.createSpanWithTags("rootB", "t1", null, Map.of("tag.category", "cat_b"));
+    ZipkinSpanResponse childB = TestUtils.createSpanWithTags("childB", "t1", "rootB", Map.of());
+
+    Map<String, ZipkinSpanResponse> spanMap =
+        Map.of("rootA", rootA, "childA", childA, "rootB", rootB, "childB", childB);
+    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
+
+    assertThat(config.resolveAnnotationsForSpan(childA, spanMap::get, annotationsBySpanId))
+        .containsEntry("category", "cat_a");
+    assertThat(config.resolveAnnotationsForSpan(childB, spanMap::get, annotationsBySpanId))
+        .containsEntry("category", "cat_b");
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_cycleWithAnnotations_eachSpanKeepsOwnValue()
+      throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              category:
+                is_annotation: true
+                default_key: [tag.category]
+                default_value: ""
+            """);
+
+    // A's parent is B, B's parent is A — cycle, each carries its own annotation value.
+    // Each should resolve to its own value, not inherit the other's.
+    ZipkinSpanResponse spanA =
+        TestUtils.createSpanWithTags("A", "t1", "B", Map.of("tag.category", "cat_a"));
+    ZipkinSpanResponse spanB =
+        TestUtils.createSpanWithTags("B", "t1", "A", Map.of("tag.category", "cat_b"));
+
+    Map<String, ZipkinSpanResponse> spanMap = Map.of("A", spanA, "B", spanB);
+    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
+
+    assertThat(config.resolveAnnotationsForSpan(spanA, spanMap::get, annotationsBySpanId))
+        .containsEntry("category", "cat_a");
+    assertThat(config.resolveAnnotationsForSpan(spanB, spanMap::get, annotationsBySpanId))
+        .containsEntry("category", "cat_b");
   }
 }

--- a/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/graphApi/GraphConfigTest.java
@@ -1099,4 +1099,92 @@ public class GraphConfigTest {
     assertThat(config.resolveAnnotationsForSpan(spanB, spanMap::get, annotationsBySpanId))
         .containsEntry("category", "cat_b");
   }
+
+  @Test
+  public void testResolveAnnotationsForSpan_deepChainPartialFields() throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              a:
+                is_annotation: true
+                default_key: [tag.a]
+                default_value: ""
+              b:
+                is_annotation: true
+                default_key: [tag.b]
+                default_value: ""
+              c:
+                is_annotation: true
+                default_key: [tag.c]
+                default_value: ""
+            """);
+
+    // Chain: A(a=1,c=10) -> B(b=2) -> C(a=3) -> D()
+    // D should get: a=3 (nearest, from C), b=2 (from B), c=10 (from A)
+    // C should get: a=3 (own), b=2 (from B), c=10 (from A)
+    // B should get: b=2 (own), a=1 (from A), c=10 (from A)
+    // A should get: a=1 (own), c=10 (own)
+    ZipkinSpanResponse spanA =
+        TestUtils.createSpanWithTags("A", "t1", null, Map.of("tag.a", "1", "tag.c", "10"));
+    ZipkinSpanResponse spanB = TestUtils.createSpanWithTags("B", "t1", "A", Map.of("tag.b", "2"));
+    ZipkinSpanResponse spanC = TestUtils.createSpanWithTags("C", "t1", "B", Map.of("tag.a", "3"));
+    ZipkinSpanResponse spanD = TestUtils.createSpanWithTags("D", "t1", "C", Map.of());
+
+    Map<String, ZipkinSpanResponse> spanMap =
+        Map.of("A", spanA, "B", spanB, "C", spanC, "D", spanD);
+    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
+
+    // Process D first
+    assertThat(config.resolveAnnotationsForSpan(spanD, spanMap::get, annotationsBySpanId))
+        .containsExactlyInAnyOrderEntriesOf(Map.of("a", "3", "b", "2", "c", "10"));
+
+    // All intermediate spans should now be cached with correct values
+    assertThat(annotationsBySpanId.get("C"))
+        .containsExactlyInAnyOrderEntriesOf(Map.of("a", "3", "b", "2", "c", "10"));
+    assertThat(annotationsBySpanId.get("B"))
+        .containsExactlyInAnyOrderEntriesOf(Map.of("a", "1", "b", "2", "c", "10"));
+    assertThat(annotationsBySpanId.get("A"))
+        .containsExactlyInAnyOrderEntriesOf(Map.of("a", "1", "c", "10"));
+  }
+
+  @Test
+  public void testResolveAnnotationsForSpan_sharedAncestor_bothChainsInheritCorrectly()
+      throws IOException {
+    GraphConfig config =
+        GraphConfig.load(
+            """
+            edge_metadata_tag_mapping:
+              a:
+                is_annotation: true
+                default_key: [tag.a]
+                default_value: ""
+              b:
+                is_annotation: true
+                default_key: [tag.b]
+                default_value: ""
+            """);
+
+    // A(a=1,b=2) -> B(b=3) -> C()
+    //                      -> D(a=5)
+    // C should get: a=1 (from A via B), b=3 (from B)
+    // D should get: a=5 (own), b=3 (from B)
+    ZipkinSpanResponse spanA =
+        TestUtils.createSpanWithTags("A", "t1", null, Map.of("tag.a", "1", "tag.b", "2"));
+    ZipkinSpanResponse spanB = TestUtils.createSpanWithTags("B", "t1", "A", Map.of("tag.b", "3"));
+    ZipkinSpanResponse spanC = TestUtils.createSpanWithTags("C", "t1", "B", Map.of());
+    ZipkinSpanResponse spanD = TestUtils.createSpanWithTags("D", "t1", "B", Map.of("tag.a", "5"));
+
+    Map<String, ZipkinSpanResponse> spanMap =
+        Map.of("A", spanA, "B", spanB, "C", spanC, "D", spanD);
+    Map<String, SortedMap<String, String>> annotationsBySpanId = new HashMap<>();
+
+    // Process C first — warms cache for B and A as side effects
+    assertThat(config.resolveAnnotationsForSpan(spanC, spanMap::get, annotationsBySpanId))
+        .containsExactlyInAnyOrderEntriesOf(Map.of("a", "1", "b", "3"));
+
+    // D shares B and A in its chain — both already cached
+    assertThat(config.resolveAnnotationsForSpan(spanD, spanMap::get, annotationsBySpanId))
+        .containsExactlyInAnyOrderEntriesOf(Map.of("a", "5", "b", "3"));
+  }
 }

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -46,5 +46,5 @@ edge_metadata_tag_mapping:
       - tag.product_context_root_function
       - tag.product_context
       - tag.product_context_criticality
-    key_delimiter: ":"
+    key_delimiter: "|"
     default_value: ""

--- a/astra/src/test/resources/test-dependency-graph-config.yaml
+++ b/astra/src/test/resources/test-dependency-graph-config.yaml
@@ -40,3 +40,11 @@ edge_metadata_tag_mapping:
       - operation_name
     default_value: unknown_operation
     rules: []
+  product_context:
+    is_annotation: true
+    default_key:
+      - tag.product_context_root_function
+      - tag.product_context
+      - tag.product_context_criticality
+    key_delimiter: ":"
+    default_value: ""


### PR DESCRIPTION
###  Summary

- Adds `is_annotation: true` boolean to `edge_metadata_tag_mapping` fields in `GraphConfig`. Annotation fields are excluded from edge identity (not part of metadata or `generateKey`) so they never split otherwise identical edges.
- Introduces `Edge.annotations` (`Map<String, Set<String>>`), accumulating distinct values across observations of the same logical edge. `addObservation(Map<String,String>)` replaces `incrementObservedCount()` as
the single call site, combining count increment and annotation merge.
- Adds `GraphConfig.resolveAnnotationsForSpan`, which walks the parent chain to find the nearest ancestor where all configured keys fully resolve. Results are memoized so each span's chain is walked at most once. All annotation fields currently inherit from ancestors by default. A future `inherit_from_ancestor` flag or equivalent on `TagConfig` could gate this per field.
- Wires annotation resolution into `GraphBuilder.traverseAndBuildGraph` — only spans that produce edges are walked, keeping it lazy.

### Requirements

* [X] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
